### PR TITLE
Set init goal

### DIFF
--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -675,12 +675,13 @@ class ObjectBase:
         """
         self._init_geometry = geometry
 
-    def set_goal(self, goal: list=[10, 10, 0]):
+    def set_goal(self, goal: list = [10, 10, 0], init: bool = False):
         """
         Set the goal of the object.
 
         Args:
             goal: The goal of the object [x, y, theta].
+            init (bool): Whether to set the initial goal (default False).
         """
         if isinstance(goal, list):
             if len(goal) > self.state_dim:
@@ -701,6 +702,9 @@ class ObjectBase:
                 temp_goal = goal
 
         assert self._goal.shape == temp_goal.shape
+
+        if init:
+            self._init_goal = temp_goal.copy()
 
         self._goal = temp_goal.copy()
 


### PR DESCRIPTION
Hi,

I noticed that most ObjectBase parameters have an init value that can be set in its setter function (state, velocity etc.). Goal does not have it but looks to me that the extension is simple and can be done the same way as for the other setters.

Here is a quick draft of that. Works quite fine and allows to set a new goal before calling the `env.reset()` call.