### PR TITLE
Add feature obj_linestyle and fix bug of ubobstructed obstacles

### DIFF
--- a/doc/source/yaml_config/configuration.md
+++ b/doc/source/yaml_config/configuration.md
@@ -498,6 +498,7 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
     - `text_size` (int): Font size of the text. Default is `10`.
     - `text_position` (list): Position of the text. Default is `[-radius-0.1, radius+0.1]`.
   - `goal_color` (str): Color of the goal marker. Default is the object's color.
+  - `obj_linestyle` (str): Line style of the object edge. Default is `'-'`. You can set the line style as `'-'`, `'--'`, `':'`, `'-.'`, `'None'`.
 
   **Example:**
   ```yaml
@@ -525,6 +526,7 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
     trail_freq: 2
     show_sensor: True
     goal_color: 'red'
+    obj_linestyle: '--'
   ```
   
 ##### **`state_dim`** and **`vel_dim`**:

--- a/irsim/usage/05lidar_world/lidar_world.yaml
+++ b/irsim/usage/05lidar_world/lidar_world.yaml
@@ -30,10 +30,17 @@ robot:
       
 obstacle:
   - shape: {name: 'circle', radius: 1.0}  # radius
-    state: [5, 5, 0]  
+    state: [5, 5, 0]
   
   - shape: {name: 'rectangle', length: 1.5, width: 1.2}  # length, width
     state: [6, 5, 1] 
   
-  - shape: {name: 'linestring',vertices: [[10, 5], [4, 0], [6, 7]]}  # vertices
+  - shape: {name: 'linestring',vertices: [[10, 5], [4, 0]]}  # vertices
     state: [0, 0, 0] 
+
+  - shape: {name: 'linestring',vertices: [[4, 0], [6, 7]]}  # vertices
+    state: [0, 0, 0] 
+    unobstructed: True
+    plot:
+      obj_linestyle: '--'
+

--- a/irsim/usage/05lidar_world/lidar_world.yaml
+++ b/irsim/usage/05lidar_world/lidar_world.yaml
@@ -31,6 +31,7 @@ robot:
 obstacle:
   - shape: {name: 'circle', radius: 1.0}  # radius
     state: [5, 5, 0]
+    unobstructed: True
   
   - shape: {name: 'rectangle', length: 1.5, width: 1.2}  # length, width
     state: [6, 5, 1] 

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -761,11 +761,12 @@ class ObjectBase:
                 - traj_style (str): Style of the trajectory.
                 - traj_width (float): Width of the trajectory.
                 - traj_alpha (float): Transparency of the trajectory.
-                - edgecolor (str): Edge color of the trail.
-                - linewidth (float): Width of the trail.
+                - trail_edgecolor (str): Edge color of the trail.
+                - trail_linewidth (float): Width of the trail.
                 - trail_alpha (float): Transparency of the trail.
                 - trail_fill (bool): Whether fill the trail.
                 - trail_color (str): Color of the trail.
+                - obj_linestyle (str): Style of the object edge line.
 
         """
         self.state_re = self.state
@@ -785,7 +786,8 @@ class ObjectBase:
         trail_freq = self.plot_kwargs.get("trail_freq", 2)
         goal_color = self.plot_kwargs.get("goal_color", self.color)
 
-        self.plot_object(ax, **kwargs)
+
+        self.plot_object(ax, **self.plot_kwargs)
 
         if show_goal:
             self.plot_goal(ax, goal_color)
@@ -819,13 +821,16 @@ class ObjectBase:
             ax: Matplotlib axis.
             **kwargs: Additional plotting options.
         """
+        
+        obj_linestyle = kwargs.get("obj_linestyle", "-")
+
         if self.description is None or isinstance(ax, Axes3D):
             x = self.state_re[0, 0]
             y = self.state_re[1, 0]
 
             if self.shape == "circle":
                 object_patch = mpl.patches.Circle(
-                    xy=(x, y), radius=self.radius, color=self.color
+                    xy=(x, y), radius=self.radius, color=self.color, linestyle=obj_linestyle
                 )
                 object_patch.set_zorder(3)
 
@@ -835,7 +840,7 @@ class ObjectBase:
                 ax.add_patch(object_patch)
 
             elif self.shape == "polygon" or self.shape == "rectangle":
-                object_patch = mpl.patches.Polygon(xy=self.vertices.T, color=self.color)
+                object_patch = mpl.patches.Polygon(xy=self.vertices.T, color=self.color, linestyle=obj_linestyle)
                 object_patch.set_zorder(3)
 
                 if isinstance(ax, Axes3D):
@@ -854,7 +859,7 @@ class ObjectBase:
                     )
                 else:
                     object_patch = mpl.lines.Line2D(
-                        self.vertices[0, :], self.vertices[1, :], color=self.color
+                        self.vertices[0, :], self.vertices[1, :], color=self.color, linestyle=obj_linestyle
                     )
                 object_patch.set_zorder(3)
                 ax.add_line(object_patch)
@@ -1022,8 +1027,8 @@ class ObjectBase:
             **kwargs: Additional plotting options.
         """
         trail_type = kwargs.get("trail_type", self.shape)
-        trail_edgecolor = kwargs.get("edgecolor", self.color)
-        trail_linewidth = kwargs.get("linewidth", 0.8)
+        trail_edgecolor = kwargs.get("trail_edgecolor", self.color)
+        trail_linewidth = kwargs.get("trail_linewidth", 0.8)
         trail_alpha = kwargs.get("trail_alpha", 0.7)
         trail_fill = kwargs.get("trail_fill", False)
         trail_color = kwargs.get("trail_color", self.color)

--- a/irsim/world/sensors/lidar2d.py
+++ b/irsim/world/sensors/lidar2d.py
@@ -178,7 +178,7 @@ class Lidar2D:
         filtered_objects = [
             obj
             for obj in env_param.objects
-            if obj._id != self.obj_id and is_valid(obj._geometry)
+            if obj._id != self.obj_id and is_valid(obj._geometry) and not obj.unobstructed
         ]
 
         geometries = [obj._geometry for obj in filtered_objects]

--- a/tests/test_all_objects.yaml
+++ b/tests/test_all_objects.yaml
@@ -53,7 +53,9 @@ obstacle:
   - kinematics: {name: 'omni'}
     behavior: {name: 'dash'}
     shape: {name: 'circle', radius: 1.0}  # radius
-    state: [5, 5, 0]  
+    state: [5, 5, 0] 
+    plot:
+      obj_linestyle: '--'
   
   - shape: {name: 'rectangle', length: 1.5, width: 1.2}  # radius
     state: [6, 5, 1] 
@@ -62,6 +64,8 @@ obstacle:
   - shape: {name: 'linestring', vertices: [[5, 5], [4, 0], [1, 6]] }  # vertices
     state: [0, 0, 0] 
     unobstructed: True
+    plot:
+      obj_linestyle: '-.'
   
   - number: 5
     distribution: {name: 'random', range_low: [0, 0, -3.14], range_high: [10, 10, 3.14]}

--- a/todo_list.md
+++ b/todo_list.md
@@ -76,3 +76,4 @@
 - [ ] Add binary occupancy grid map for indoor navigation
 - [ ] traffic scenarios
 - [ ] improve coverage of the code
+- [ ] modular yaml import so that ir-sim can read the yaml file separately


### PR DESCRIPTION
- obj_linestyle can be used to plot different type of linestring obstacles, e.g. lane markings.
- lidar2d will not consider the collision with ubobstructed obstacles.