### PR TITLE
Correct vertical stacking in circle geometry constraints

### DIFF
--- a/irsim/lib/handler/geometry_handler.py
+++ b/irsim/lib/handler/geometry_handler.py
@@ -152,7 +152,7 @@ class geometry_handler(ABC):
         assert self.name == "circle"
 
         G = np.array([[1, 0], [0, 1], [0, 0]])
-        h = np.row_stack((center, -radius * np.ones((1, 1))))
+        h = np.vstack((center, -radius * np.ones((1, 1))))
         cone_type = "norm2"
         convex_flag = True
 


### PR DESCRIPTION
# PR Summary
This PR modernizes NumPy array stacking by replacing deprecated aliases. It solves the following warnings which you can find in the CI logs: 
```python
/home/runner/work/ir-sim/ir-sim/irsim/lib/handler/geometry_handler.py:155: DeprecationWarning: `row_stack` alias is deprecated. Use `np.vstack` directly.
```