### PR TITLE
Extract item from ndarray in linewidth_from_data_units

### DIFF
--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -493,10 +493,10 @@ def linewidth_from_data_units(linewidth, axis, reference="y"):
     fig = axis.get_figure()
     if reference == "x":
         length = fig.bbox_inches.width * axis.get_position().width
-        value_range = np.diff(axis.get_xlim())
+        value_range = np.diff(axis.get_xlim()).item()
     elif reference == "y":
         length = fig.bbox_inches.height * axis.get_position().height
-        value_range = np.diff(axis.get_ylim())
+        value_range = np.diff(axis.get_ylim()).item()
     # Convert length to points
     length *= 72
     # Scale linewidth to value range


### PR DESCRIPTION
Hi,

This is a minor issue but the way the that `linewidth_from_data_units` function returns its value causes a warning in matplotlib lines function. Mainly, having `value_range` obtained from `np.diff(axis.get_ylim())` makes it an ndarray and the function returns the final width `linewidth_data` as an ndarray because of it. Calling it in `line.set_linewidth(linewidth_data)` causes a warning:

> DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    w = float(w)

the passed in `w` is this ndarray, and we should have a float or int here.
AFAIK the `value_range` would always be a single number so we can just avoid this but extracting the item from the ndarray and using that. Let me know if there are other ways to avoid this.
