### PR TITLE
docs: fix formatting issues

### DIFF
--- a/docs/source/usage/configure_keyboard_Mouse_control.md
+++ b/docs/source/usage/configure_keyboard_Mouse_control.md
@@ -57,8 +57,8 @@ robot:
       show_trajectory: True
       show_goal: False
 
-    sensors: 
-      - type: 'lidar2d'
+    sensors:
+      - name: 'lidar2d'
         range_min: 0
         range_max: 20
         angle_range: 3.14
@@ -200,14 +200,14 @@ robot:
       traj_color: 'g'
       show_goals: True
 
-    sensors: 
-      - type: 'lidar2d'
+    sensors:
+      - name: 'lidar2d'
         range_min: 0
         range_max: 20
         angle_range: 3.14
         number: 100
         noise: False
-        std: 1   
+        std: 1
         angle_std: 0.2
         offset: [0, 0, 0]
         alpha: 0.4

--- a/docs/source/usage/configure_robots_obstacles.md
+++ b/docs/source/usage/configure_robots_obstacles.md
@@ -1,5 +1,5 @@
 Configure robots and obstacles
-================
+==============================
 
 To effectively simulate robots within your environment, you need to define and configure various robot parameters.
 

--- a/docs/source/usage/configure_sensor.md
+++ b/docs/source/usage/configure_sensor.md
@@ -74,8 +74,6 @@ obstacle:
 :::
 ::::
 
-:::::
-
 ```{tip}
 Update order
 


### PR DESCRIPTION
## Summary
- Fix sensor config key from `type` to `name` in keyboard/mouse control doc
- Fix title underline length in robots/obstacles configuration doc
- Remove orphan closing tag in sensor configuration doc

## Test plan
- [x] Documentation builds without errors
- [x] Links remain functional