### PR TITLE
docs: add language preference note to issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+> **Language:** English is preferred so that discussions are accessible to the broader community. Chinese (中文) is also welcome. If English is not your first language, feel free to use translation tools — we appreciate the effort!
+
 *We recommend you to use the latest version of ir-sim when reporting bugs.*
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -7,4 +7,4 @@ assignees: ''
 
 ---
 
-
+> **Language:** English is preferred so that discussions are accessible to the broader community. Chinese (中文) is also welcome. If English is not your first language, feel free to use translation tools — we appreciate the effort!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+> **Language:** English is preferred so that discussions are accessible to the broader community. Chinese (中文) is also welcome. If English is not your first language, feel free to use translation tools — we appreciate the effort!
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+> **Language:** English is preferred so that discussions are accessible to the broader community. Chinese (中文) is also welcome. If English is not your first language, feel free to use translation tools — we appreciate the effort!
+
+## Summary
+
+<!-- Briefly describe what this PR does and why. -->
+
+## Changes
+
+<!-- List the key changes (bullet points). -->
+
+-
+
+## Test Plan
+
+<!-- How did you verify the changes? -->
+
+- [ ] Ran `ruff check` with no errors
+- [ ] Ran `pytest` with no failures
+- [ ] Updated documentation (if applicable)


### PR DESCRIPTION
## Summary
- Add a language preference note to all issue templates (bug report, feature request, question) recommending English while welcoming Chinese
- Create a new pull request template with the same language guidance and a structured summary/changes/test plan format

## Changes
- Updated `.github/ISSUE_TEMPLATE/bug_report.md`
- Updated `.github/ISSUE_TEMPLATE/feature_request.md`
- Updated `.github/ISSUE_TEMPLATE/custom.md`
- Created `.github/PULL_REQUEST_TEMPLATE.md`

## Test plan
- [x] Verified all four templates render correctly