### PR TITLE
refactor: replace circle buffer with box union for obstacle map

### DIFF
--- a/irsim/env/env_base3d.py
+++ b/irsim/env/env_base3d.py
@@ -40,9 +40,8 @@ class EnvBase3D(EnvBase):
         )
         self._map_collection = object_factory.create_from_map(
             self._world.obstacle_positions,
-            self._world.buffer_reso,
+            self._world.reso,
             grid_map=self._world.grid_map,
-            grid_reso=self._world.reso,
             world_offset=self._world.offset[:2],
         )
 

--- a/irsim/env/env_config.py
+++ b/irsim/env/env_config.py
@@ -120,9 +120,8 @@ class EnvConfig:
         )
         map_collection = self.object_factory.create_from_map(
             world.obstacle_positions,
-            world.buffer_reso,
+            world.reso,
             grid_map=world.grid_map,
-            grid_reso=world.reso,
             world_offset=world.offset,
         )
 
@@ -181,9 +180,8 @@ class EnvConfig:
         )
         map_collection = self.object_factory.create_from_map(
             world.obstacle_positions,
-            world.buffer_reso,
+            world.reso,
             grid_map=world.grid_map,
-            grid_reso=world.reso,
             world_offset=world.offset,
         )
 

--- a/irsim/lib/handler/geometry_handler.py
+++ b/irsim/lib/handler/geometry_handler.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 
 import numpy as np
+import shapely as shp
 from shapely import (
     LineString,
-    MultiPoint,
     Point,
     Polygon,
     bounds,
@@ -12,7 +12,7 @@ from shapely import (
     make_valid,
     minimum_bounding_radius,
 )
-from shapely.ops import transform
+from shapely.ops import transform, unary_union
 
 from irsim.lib import random_generate_polygon
 from irsim.util.random import rng
@@ -356,14 +356,26 @@ class PointsGeometry(geometry_handler):
     def __init__(self, name: str = "map", **kwargs):
         super().__init__(name, **kwargs)
 
-    def construct_original_geometry(self, points: np.ndarray, reso: float = 0.1):
+    def construct_original_geometry(
+        self,
+        points: np.ndarray,
+        reso: np.ndarray | float = 0.1,
+        **kwargs,
+    ):
         """
         Args:
             points: (2, N) array of points
-            reso: resolution for the buffer
+            reso: resolution — either a (2, 1) array [x_reso, y_reso]
+                or a scalar applied to both axes
         """
-
-        return MultiPoint(points.T).buffer(reso / 2).boundary
+        reso = np.atleast_2d(reso)
+        half_x = float(reso[0, 0]) / 2
+        half_y = float(reso[-1, -1]) / 2
+        boxes = shp.box(
+            points[0] - half_x, points[1] - half_y,
+            points[0] + half_x, points[1] + half_y,
+        )
+        return unary_union(boxes).boundary
 
 
 ########################################3D Geometry Handler #############################################################

--- a/irsim/lib/handler/geometry_handler.py
+++ b/irsim/lib/handler/geometry_handler.py
@@ -4,6 +4,7 @@ import numpy as np
 import shapely as shp
 from shapely import (
     LineString,
+    MultiLineString,
     Point,
     Polygon,
     bounds,
@@ -375,7 +376,10 @@ class PointsGeometry(geometry_handler):
             points[0] - half_x, points[1] - half_y,
             points[0] + half_x, points[1] + half_y,
         )
-        return unary_union(boxes).boundary
+        boundary = unary_union(boxes).boundary
+        if hasattr(boundary, "geoms"):
+            return boundary
+        return MultiLineString([LineString(boundary.coords)])
 
 
 ########################################3D Geometry Handler #############################################################

--- a/irsim/world/object_factory.py
+++ b/irsim/world/object_factory.py
@@ -63,22 +63,18 @@ class ObjectFactory:
     def create_from_map(
         self,
         points: np.ndarray,
-        reso: float = 0.1,
+        reso: np.ndarray | None = None,
         grid_map: np.ndarray | None = None,
-        grid_reso: np.ndarray | None = None,
         world_offset: list[float] | None = None,
     ) -> list[Any]:
         """
         Create map objects from points.
 
         Args:
-            points (np.ndarray): Array of points defining the map.
-            reso (float): Resolution of the map.
-            grid_map (np.ndarray, optional): Grid map array for fast collision detection.
-                If None, no precomputed grid is used.
-            grid_reso (np.ndarray, optional): Resolution [x_reso, y_reso] of the grid.
-                If None, the resolution is not specified and grid-based collision is
-                either inferred elsewhere or not used.
+            points (np.ndarray): (2, N) array of obstacle cell positions.
+            reso (np.ndarray): (2, 1) array of [x_reso, y_reso] cell sizes.
+            grid_map (np.ndarray, optional): Grid map array for fast collision
+                detection. If None, no precomputed grid is used.
             world_offset (list[float], optional): World offset [x, y].
                 If None, no additional world offset is applied.
 
@@ -92,7 +88,7 @@ class ObjectFactory:
                 shape={"name": "map", "points": points, "reso": reso},
                 color="k",
                 grid_map=grid_map,
-                grid_reso=grid_reso,
+                grid_reso=reso,
                 world_offset=world_offset,
             )
         ]

--- a/irsim/world/object_factory.py
+++ b/irsim/world/object_factory.py
@@ -81,7 +81,7 @@ class ObjectFactory:
         Returns:
             list: List of ObstacleMap objects.
         """
-        if points is None:
+        if points is None or points.size == 0:
             return []
         return [
             ObstacleMap(

--- a/irsim/world/world.py
+++ b/irsim/world/world.py
@@ -172,7 +172,10 @@ class World:
             y_reso = self.height / grid_map.shape[1]
             self.reso = np.array([[x_reso], [y_reso]])
             obstacle_index = np.array(np.where(grid_map > 50))
-            obstacle_positions = obstacle_index * self.reso
+            obstacle_positions = (
+                np.array([[self.offset[0]], [self.offset[1]]])
+                + (obstacle_index + 0.5) * self.reso
+            )
         else:
             obstacle_index = None
             obstacle_positions = None
@@ -253,16 +256,6 @@ class World:
             float: Current time based on steps and step_time.
         """
         return round(self.count * self.step_time, 2)
-
-    @property
-    def buffer_reso(self) -> float:
-        """
-        Get the maximum resolution of the world.
-
-        Returns:
-            float: Maximum resolution.
-        """
-        return np.max(self.reso)
 
     @property
     def _env_param(self):

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -331,3 +331,44 @@ class TestGeometryHandlerCoverage:
         assert h is None
         assert cone is None
         assert convex is None
+
+
+class TestPointsGeometry:
+    """Tests for PointsGeometry (box-union map geometry)."""
+
+    def test_single_contiguous_region(self):
+        """Adjacent boxes merge into a single polygon with MultiLineString boundary."""
+        from shapely import MultiLineString
+
+        from irsim.lib.handler.geometry_handler import PointsGeometry
+
+        # Adjacent points → boxes merge into one polygon → single boundary
+        points = np.array([[0.0, 0.1], [0.0, 0.0]])
+        pg = PointsGeometry(points=points, reso=0.1)
+        assert isinstance(pg.geometry, MultiLineString)
+
+    def test_disjoint_regions(self):
+        """Disjoint boxes produce a multi-component boundary."""
+        from irsim.lib.handler.geometry_handler import PointsGeometry
+
+        # Far-apart points → disjoint polygons → multiple boundary components
+        points = np.array([[0.0, 10.0], [0.0, 10.0]])
+        pg = PointsGeometry(points=points, reso=0.1)
+        assert hasattr(pg.geometry, "geoms")
+        assert len(pg.geometry.geoms) > 1
+
+    def test_scalar_reso(self):
+        """Scalar resolution is handled correctly."""
+        from irsim.lib.handler.geometry_handler import PointsGeometry
+
+        points = np.array([[0.0], [0.0]])
+        pg = PointsGeometry(points=points, reso=0.5)
+        assert pg.geometry is not None
+
+    def test_array_reso(self):
+        """Array resolution with different x/y sizes."""
+        from irsim.lib.handler.geometry_handler import PointsGeometry
+
+        points = np.array([[0.0], [0.0]])
+        pg = PointsGeometry(points=points, reso=np.array([[0.2], [0.3]]))
+        assert pg.geometry is not None

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -126,6 +126,11 @@ class TestObjectFactory:
         result = factory.create_from_map(None)
         assert result == []
 
+    def test_create_from_map_empty(self, factory):
+        """Test create_from_map with empty array."""
+        result = factory.create_from_map(np.array([]))
+        assert result == []
+
     def test_create_from_map_points(self, factory):
         """Test create_from_map with valid points."""
         points = np.array([[0, 1], [0, 1]])

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -129,7 +129,7 @@ class TestObjectFactory:
     def test_create_from_map_points(self, factory):
         """Test create_from_map with valid points."""
         points = np.array([[0, 1], [0, 1]])
-        result = factory.create_from_map(points, reso=0.1)
+        result = factory.create_from_map(points, reso=np.array([[0.1], [0.1]]))
         assert len(result) == 1
 
     def test_generate_state_list_manual(self, factory):


### PR DESCRIPTION
## Summary

- Replace `MultiPoint.buffer().boundary` (circle buffer) with vectorized `shapely.box` + `unary_union` for obstacle map geometry construction. Box cells tile perfectly on grids, producing ~3x fewer linestrings, ~24x fewer coordinates, and ~3.8x faster lidar step on map-based arenas. Circle buffers left diagonal gaps (~21% uncovered area) that allowed lidar rays to leak through walls; box union eliminates these gaps.
- Fix obstacle cell positions from grid corner (`index * reso`) to cell center (`(index + 0.5) * reso`) with world offset, aligning the geometry boundary with grid collision detection (`check_grid_collision`) and `imshow` rendering.
- Unify `reso` and `grid_reso` into a single `(2,1)` array parameter throughout the obstacle map pipeline. Remove the redundant `buffer_reso` property and simplify the `create_from_map` API.

## Test plan

- [x] All 717 existing tests pass
- [x] Verified geometry coordinates are exact (zero error vs expected cell edges)
- [x] Verified box boundary aligns with grid cells via visual overlay