### PR TITLE
fix: reset object ID counter on environment init

### DIFF
--- a/irsim/env/env_base.py
+++ b/irsim/env/env_base.py
@@ -144,6 +144,9 @@ class EnvBase:
         log_level: str = "INFO",
         seed: int | None = None,
     ) -> None:
+        # Reset object ID counter so each environment starts from 0
+        ObjectBase.reset_id_iter()
+
         # Bind per-instance config objects
         self._env_param = EnvParam()
         self._world_param = WorldParam()


### PR DESCRIPTION
## Fix issue #274 

- Reset `ObjectBase.id_iter` at the start of `EnvBase.__init__()` so each environment gets object IDs starting from 0.
- Previously, the global class-level counter persisted across environments, causing IDs in subsequent environments to start from where the previous one left off (e.g., env2 objects starting at ID 2 instead of 0). This led to index mismatches during simulation step.

## Test plan

- [x] All 717 existing tests pass
- [ ] Verify multiple sequential `irsim.make()` calls produce objects with IDs starting from 0