### PR TITLE
docs: document env.refresh(), add 2.9.4 changelog, codify changelog style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,13 +215,25 @@ When releasing a new version, follow these steps in order:
 
 1. Update the version number in `pyproject.toml`
 2. Add a new entry to `docs/source/_static/switcher.json` (mark the new version as `(stable)`, remove that label from the previous one)
-3. Summarize the version changes in `changelog.md` (`docs/source/changelog.md` auto-includes it via `{include}`)
-   - Only include changes that are merged into `main`; do not list work still on feature branches
-   - For PRs not authored by hanruihua, append the contributor's GitHub handle (e.g., `(@username)`)
-   - For performance improvements, include the measured speedup (e.g., "~48% faster lidar step")
+3. Summarize the version changes in `changelog.md` (`docs/source/changelog.md` auto-includes it via `{include}`). See the **Changelog Style** section below for entry formatting.
 4. Run `uv lock` to update `uv.lock`
 5. Run `ruff check` and `ruff format`; commit formatting changes separately (e.g., `style: apply ruff format`) before the version bump commit
 6. Commit the version bump. Confirm with the user before committing
    - Must be on the `main` branch
    - Commit message format: `version bump to v<version>`
 7. Create a git tag: `git tag v<version>`
+
+## Changelog Style
+
+Rules for writing entries in `changelog.md`:
+
+- **Scope**: only include changes merged into `main`. Do not list work still on feature branches. Skip dependency-only PRs (`chore(deps)`, `chore(deps-dev)`).
+- **Section structure**: use `## <version>` as the top heading, then grouped subsections in this order — `Features`, `Performance`, `Fix`, `Refactor`, `Docs`, `Tests`. Include only the categories that apply.
+- **Entry format**: one bullet per PR, written as a complete sentence (or two). Lead with the technical change, then state the *motivation/target* — the "why", not just the "what". For example:
+  - Good: "Add `random_uniform` sampler with pairwise min-distance. Prevents object overlap in random sampling, and world-derived defaults adapt to the world size/offset so users don't restate bounds per scene."
+  - Avoid: "Add `random_uniform` sampler." (what, but no why)
+- **PR link**: end every entry with the PR link: `([#NNN](https://github.com/hanruihua/ir-sim/pull/NNN))`.
+- **Contributor credit**: for PRs not authored by `hanruihua`, append the GitHub handle after the PR link: `([#NNN](...)) (@username)`.
+- **Performance metrics**: quote concrete numbers — measured speedups, coordinate/linestring counts, memory reductions, etc. (e.g., "~48% faster lidar step", "~3× fewer linestrings").
+- **Version boundary**: if the current version in `pyproject.toml` has already been tagged/released, open a new `## <next-version>` section at the top instead of appending to the released one.
+- **PR and commit alignment**: when opening a PR or writing the commit that introduces a changelog entry, mirror the same summary in the PR description and commit message so the three sources stay in sync.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.9.4
+
+- Features:
+  - Add `omni_angular` kinematics with 3-DOF body-frame control `[forward, lateral, yaw_rate]`, and refactor `omni` to body-frame `[forward, lateral]`. Body-frame velocities match how physical omni platforms are commanded, and `omni_angular` enables independent yaw control for holonomic/swerve use cases. Keyboard control is redesigned around the new axes. ([#270](https://github.com/hanruihua/ir-sim/pull/270))
+  - Add `env.reset(random=True)` to re-sample randomized scenes from the cached YAML parse. Lets you quickly restart with a fresh random scene (new positions, new random shapes) without re-reading the YAML file from disk, which is useful for RL rollouts and batched experiments. ([#283](https://github.com/hanruihua/ir-sim/pull/283))
+  - Add `random_uniform` sampler with pairwise min-distance, and world-derived defaults for `random` and `circle` distributions. The pairwise min-distance prevents object overlap in random sampling, and world-derived defaults make the sampling ranges adapt automatically to the world size/offset so users don't have to restate bounds per scene. ([#283](https://github.com/hanruihua/ir-sim/pull/283))
+  - Add `env.refresh()` and `ObjectBase.refresh()` to sync geometry, sensors, and collision tree without advancing the simulation. Useful after mutating object states directly (e.g. `robot.set_state(...)`) so sensors and collision data are up to date before the next `env.step()`. ([#284](https://github.com/hanruihua/ir-sim/pull/284))
+
+- Performance:
+  - Replace circle-buffer obstacle-map geometry with vectorized `shapely.box` + `unary_union`. Box cells tile the grid perfectly — ~3× fewer linestrings, ~24× fewer coordinates, ~3.8× faster lidar step, and proportionally lighter obstacle-map collision queries — and close diagonal gaps in the old circle buffer that previously let lidar rays leak through walls. ([#276](https://github.com/hanruihua/ir-sim/pull/276))
+
+- Fix:
+  - Reset `ObjectBase.id_iter` at `EnvBase.__init__` so each environment starts object IDs at 0. Previously the class-level counter persisted across environments, causing index mismatches when multiple environments were created sequentially. ([#277](https://github.com/hanruihua/ir-sim/pull/277))
+  - Preserve initial velocity across `env.reset()` so `set_velocity(init=True)` takes effect. Previously an internal zero-action step inside `reset` clobbered `_velocity` right after it was restored, so users could not set a non-zero starting velocity. ([#284](https://github.com/hanruihua/ir-sim/pull/284))
+
+- Docs:
+  - Fix broken cross-references across usage guides and the YAML configuration reference (Markdown `[Name](#irsim.path)` links replaced with Sphinx `{py:class/meth/func}` roles), and update omni velocity description to body-frame throughout EN + zh_CN. ([#278](https://github.com/hanruihua/ir-sim/pull/278))
+
 ## 2.9.3
 
 - Features:

--- a/docs/locale/zh_CN/LC_MESSAGES/usage/make_environment.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/usage/make_environment.po
@@ -269,11 +269,23 @@ msgstr ""
 
 #: ../../source/usage/make_environment.md:123
 msgid ""
+"**`env.refresh()`**: Refreshes state-derived attributes (geometry, sensor"
+" readings, collision tree, and status) without advancing the simulation."
+" Useful after mutating object states directly (e.g. "
+"`robot.set_state(...)`) when you need sensors and collisions brought up "
+"to date before the next `env.step()`."
+msgstr ""
+"**`env.refresh()`**：在不推进仿真的前提下，刷新由状态派生的属性（几何、传感器读数、"
+"碰撞树以及状态）。当你直接修改对象状态（例如 `robot.set_state(...)`）后，若希望在下一次 "
+"`env.step()` 之前让传感器和碰撞信息同步到最新状态，使用此方法。"
+
+#: ../../source/usage/make_environment.md:124
+msgid ""
 "**`env.reload(world_name=None)`**: Re-parses the YAML file (optionally a "
 "different one) and rebuilds world/objects."
 msgstr "**`env.reload(world_name=None)`**：重新解析 YAML 文件（可选指定其他文件）并重建世界/对象。"
 
-#: ../../source/usage/make_environment.md:124
+#: ../../source/usage/make_environment.md:125
 msgid "**`env.end()`**: Properly closes the environment and releases resources"
 msgstr "**`env.end()`**：正确关闭环境并释放资源"
 

--- a/docs/source/usage/make_environment.md
+++ b/docs/source/usage/make_environment.md
@@ -120,6 +120,7 @@ env.end()  # Clean up resources
 - **`env.render(interval)`**: Updates the visualization with specified time interval between frames
 - **`env.done()`**: Returns `True` if simulation completion conditions are met
 - **`env.reset(random=False)`**: Restores objects to their initial states. With `random=True`, rebuilds the world from the cached YAML parse so any randomized elements (e.g. `distribution: random`, random shape generators) are re-sampled from the current RNG state — use together with `irsim.util.random.set_seed(seed)` for reproducible fresh scenes. The YAML file on disk is **not** re-read; to pick up on-disk edits, use `env.reload()` instead.
+- **`env.refresh()`**: Refreshes state-derived attributes (geometry, sensor readings, collision tree, and status) without advancing the simulation. Useful after mutating object states directly (e.g. `robot.set_state(...)`) when you need sensors and collisions brought up to date before the next `env.step()`.
 - **`env.reload(world_name=None)`**: Re-parses the YAML file (optionally a different one) and rebuilds world/objects.
 - **`env.end()`**: Properly closes the environment and releases resources
 - **`env.close()`**: Alias for `env.end()`, provided for [Gym](https://gymnasium.farama.org/)-style API compatibility


### PR DESCRIPTION
## Summary

- Document `env.refresh()` in `make_environment.md` (EN + zh_CN).
- Open the 2.9.4 changelog section for all non-dependency PRs merged since v2.9.3.
- Codify changelog conventions (section structure, motivation, PR linking, contributor credit, metrics, version boundary, PR/commit alignment) in `CLAUDE.md`.