### PR TITLE
docs(changelog): add release dates to all version headings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.9.4
+## 2.9.4 (2026-04-21)
 
 - Features:
   - Add `omni_angular` kinematics with 3-DOF body-frame control `[forward, lateral, yaw_rate]`, and refactor `omni` to body-frame `[forward, lateral]`. Body-frame velocities match how physical omni platforms are commanded, and `omni_angular` enables independent yaw control for holonomic/swerve use cases. Keyboard control is redesigned around the new axes. ([#270](https://github.com/hanruihua/ir-sim/pull/270))
@@ -18,7 +18,7 @@
 - Docs:
   - Fix broken cross-references across usage guides and the YAML configuration reference (Markdown `[Name](#irsim.path)` links replaced with Sphinx `{py:class/meth/func}` roles), and update omni velocity description to body-frame throughout EN + zh_CN. ([#278](https://github.com/hanruihua/ir-sim/pull/278))
 
-## 2.9.3
+## 2.9.3 (2026-04-06)
 
 - Features:
   - Add loop mode for waypoint navigation behavior. ([#266](https://github.com/hanruihua/ir-sim/pull/266))
@@ -36,7 +36,7 @@
 - Refactor:
   - Simplify `file_check` and `find_file` in util. ([#256](https://github.com/hanruihua/ir-sim/pull/256))
 
-## 2.9.2
+## 2.9.2 (2026-03-16)
 
 - Features:
   - Add `env.create_robot()` and `env.create_obstacle()` for programmatic object creation, and `env.add_object()` / `env.add_objects()` for adding them at runtime. ([#251](https://github.com/hanruihua/ir-sim/pull/251))
@@ -54,7 +54,7 @@
   - Add "Dynamic Object Management" section to the Make Environment documentation. ([#251](https://github.com/hanruihua/ir-sim/pull/251))
   - Fix and update Chinese translations.
 
-## 2.9.1
+## 2.9.1 (2026-02-16)
 
 - Features:
   - Add Perlin noise and image-based grid map generators, new JPS (Jump Point Search) and Informed RRT* path planners, and refactor existing planners (A*, RRT, RRT*, PRM) to use the `EnvGridMap` protocol. #215 (@KevinLADLee)
@@ -72,7 +72,7 @@
   - Refine README. #222
   - Add grid map configuration and path planning documentation. #215
 
-## 2.9.0
+## 2.9.0 (2026-01-26)
 
 Assistant by claude code, this version adds multi-environment support with instance-based parameters, allowing multiple independent simulation environments to run simultaneously. It also introduces 1D ToF sensor support and keyboard improvements.
 
@@ -100,7 +100,7 @@ Assistant by claude code, this version adds multi-environment support with insta
   - Refactor and improve test coverage from 94% to 97%. ([#189](https://github.com/hanruihua/ir-sim/pull/189))
   - Add tests for multi-env keyboard switching and display toggle.
 
-## 2.8.2
+## 2.8.2 (2026-01-05)
 
 - Features #183:
   - Add `group_name` YAML parameter to help user manage the objects in the same group.
@@ -112,11 +112,11 @@ Assistant by claude code, this version adds multi-environment support with insta
   - Fix Group ID parameter conflict issue #180 #183
   - Fix group behavior warning issue e8ca7df
 
-## 2.8.1
+## 2.8.1 (2025-12-13)
 
 Hotfix: Fix the autoapi extension issue in the documentation.
 
-## 2.8.0
+## 2.8.0 (2025-12-12)
 
 This version add the feature of `group_behavior` to support group-level behavior for all objects within the same group, which is more efficient for coordinated behaviors (like swarm or crowd simulation) as it computes actions for all members in a single step. The chinese (中文) version documentation is also supported.
 
@@ -135,7 +135,7 @@ This version add the feature of `group_behavior` to support group-level behavior
   - rng random in generate_polygon function
   - Group index increment issue
 
-## 2.7.5
+## 2.7.5 (2025-10-26)
 
 - Features:
   - Add features to set the seed in random environment generation for reproducibility. Simply add the seed parameter to the make function (e.g., `env = irsim.make("random_obstacle.yaml", seed=2)`) or set the seed using the `env.set_random_seed` function followed by `env.reload()`. See usage `random_obstacle_seed` for details.
@@ -145,7 +145,7 @@ This version add the feature of `group_behavior` to support group-level behavior
   - Fix issue where sampling time did not work.
   - Fix documentation errors.
 
-## 2.7.4
+## 2.7.4 (2025-10-06)
 
 - Features:
   - Add state normalization and an input-checking decorator function.
@@ -161,7 +161,7 @@ This version add the feature of `group_behavior` to support group-level behavior
   - Organize plot function for patch plot.
   - Organize logger info.
 
-## 2.7.3
+## 2.7.3 (2025-09-20)
 
 - Features:
   - Switch the default keyboard backend to `pynput` (global keyboard hook), with automatic fallback to Matplotlib (`mpl`) when `pynput` is unavailable. Note: `mpl` can introduce delays when plotting many objects.
@@ -184,7 +184,7 @@ This version add the feature of `group_behavior` to support group-level behavior
   - Clarify sensor update order.
   - Document keyboard control using the `pynput` backend.
 
-## 2.7.2
+## 2.7.2 (2025-08-31)
 
 - Features:
   - Add a new gui section to the YAML configuration for keyboard and mouse controls. see [gui configuration](https://ir-sim.readthedocs.io/en/latest/yaml_config/configuration.html#gui-configuration) 
@@ -202,7 +202,7 @@ This version add the feature of `group_behavior` to support group-level behavior
   
   - update corresponding documentation and usage.
 
-## 2.7.1
+## 2.7.1 (2025-08-25)
 
 - Features:
   - Add `name` attribute for the object. It can be configured in the yaml file. The duplicate name check is added to ensure there are no duplicate names.
@@ -212,7 +212,7 @@ This version add the feature of `group_behavior` to support group-level behavior
 - Bug Fixes:
   - Fix error in documentation and function comments.
 
-## ir-sim 2.7.0
+## ir-sim 2.7.0 (2025-08-10)
 
 This version improves the CI pipeline, GitHub Actions workflows, linting, and formatting to ensure consistent style and faster checks, with no API changes.
 
@@ -233,7 +233,7 @@ This version improves the CI pipeline, GitHub Actions workflows, linting, and fo
   - Renamed `doc/` to `docs/`.
   - Moved `irsim/usage/` to `usage/` at the repository root.
 
-## ir-sim 2.6.1
+## ir-sim 2.6.1 (2025-07-28)
 
 - Bug Fixes:
   - Fix documentation error.
@@ -242,7 +242,7 @@ This version improves the CI pipeline, GitHub Actions workflows, linting, and fo
   - Add WrapTo2Pi function.
   - WrapTo2Pi for lidar and fov angle range.
 
-## ir-sim 2.6.0
+## ir-sim 2.6.0 (2025-07-21)
 
 This version is a major update of the documentation website. The new website is more user-friendly and easier to navigate the parameters usage and the API.
 
@@ -260,7 +260,7 @@ This version is a major update of the documentation website. The new website is 
   - Rename `global_param` folder to be `config`. All the call of the `global_param` should be replaced to `config`.
   - Rename `keep_length` to `keep_traj_length` and `keep_trail_length`.
 
-## ir-sim 2.5.5
+## ir-sim 2.5.5 (2025-06-29)
 
 - New Features:
   - Add environment pause and resume function. You can pause/resume the environment by pressing `space` key in the keyboard control. see [keyboard control documentation](https://ir-sim.readthedocs.io/en/stable/usage/configure_keyboard_Mouse_control.html) for detail.
@@ -271,12 +271,12 @@ This version is a major update of the documentation website. The new website is 
   - Refine code style, log warning output, and website documentation.
 
 
-## ir-sim 2.5.4
+## ir-sim 2.5.4 (2025-06-16)
 
 - Bug Fixes:
   - Fix the pynput import error
 
-## ir-sim 2.5.3
+## ir-sim 2.5.3 (2025-06-15)
 
 - New Features:
   - Add GUI module, including keyboard and mouse control. 
@@ -292,13 +292,13 @@ This version is a major update of the documentation website. The new website is 
   - Add `mouse_left_pos`, `mouse_right_pos`, and `mouse_pos` attributes to the environment for mouse control.
   - Move keyboard_control.py to the gui folder. Thus the api of the keyboard is changed, such as from `env.alt_flag` to `env.keyboard.alt_flag`. 
 
-## ir-sim 2.5.2
+## ir-sim 2.5.2 (2025-06-02)
 
 - Bug Fixes:
   - Fix the bug of the clear components.
 
 
-## ir-sim 2.5.1
+## ir-sim 2.5.1 (2025-06-02)
 
 - Bug Fixes:
   - Fix the goal plot coordinate bug.
@@ -309,7 +309,7 @@ This version is a major update of the documentation website. The new website is 
 - New Features:
   - Add `center` for circular object.
 
-## ir-sim 2.5.0
+## ir-sim 2.5.0 (2025-05-26)
 
 This version improves performance (approximately 40% speed improvement) by refactoring the object plot function and the geometry transform operation for large environments.
 
@@ -328,7 +328,7 @@ This version improves performance (approximately 40% speed improvement) by refac
   - Rename `init_geometry` to `original_geometry`.  
   - Fix warning messages.
 
-## ir-sim 2.4.4
+## ir-sim 2.4.4 (2025-05-06)
 
 - Bug Fixes:
   - Fix geometry tree bug
@@ -342,7 +342,7 @@ This version improves performance (approximately 40% speed improvement) by refac
   - Update the distance function to accelerate the rvo algorithm
   - Update the robot image
 
-## ir-sim 2.4.3
+## ir-sim 2.4.3 (2025-04-30)
 
 - Bug Fixes:
   - Fix lidar offset plot bug.
@@ -353,7 +353,7 @@ This version improves performance (approximately 40% speed improvement) by refac
   - Add world plot parameters in yaml file.
   - Update requirements.
 
-## ir-sim 2.4.2
+## ir-sim 2.4.2 (2025-04-19)
 
 - Bug Fixes:
   - Change omni robot default state dim to be 3.
@@ -366,7 +366,7 @@ This version improves performance (approximately 40% speed improvement) by refac
   - Formulate the geometry tree for the collision check
   - Improve test coverage of this code (#50).
   
-## ir-sim 2.4.1
+## ir-sim 2.4.1 (2025-04-02)
 
 - Bug Fixes:
   - Fix the polygon trail type bug.
@@ -378,7 +378,7 @@ This version improves performance (approximately 40% speed improvement) by refac
   - Add the render `mode` to select the objects to render. `static`, `dynamic`, `all`.
   - Enhance readme and Documentation.
 
-## ir-sim 2.4.0
+## ir-sim 2.4.0 (2025-03-20)
 
 - New Features:
   - Add binary map generated from the 3D scene dataset (Hm3d).
@@ -393,7 +393,7 @@ This version improves performance (approximately 40% speed improvement) by refac
   - Fix the error in log message.
   - Fix the multi-object keyboard control error. 
 
-## ir-sim 2.3.6
+## ir-sim 2.3.6 (2025-03-12)
 
 - Bug Fixes:
   - Lidar2d sensor pass through the unobstructed objects now, see usage: `05lidar_world` for detail.
@@ -405,7 +405,7 @@ This version improves performance (approximately 40% speed improvement) by refac
   - Add the `obj_linestyle` parameter for the object to set the line style of the object edge. see usage: `05lidar_world` for detail.
   - Update object property comments and API documentation.
 
-## ir-sim 2.3.5
+## ir-sim 2.3.5 (2025-02-27)
 
 - Bug Fixes:
   - Dimension of init vertices for the polygon object
@@ -417,7 +417,7 @@ This version improves performance (approximately 40% speed improvement) by refac
   - Add get_Gh function for the object.
   - Update type hint for the functions and format the code with black.
   
-## ir-sim 2.3.4
+## ir-sim 2.3.4 (2025-02-18)
 
 - Bug Fixes:
   - omni robot dynamics
@@ -428,11 +428,11 @@ This version improves performance (approximately 40% speed improvement) by refac
   - Update random_obstacle_position function to support selection of obstacles and non-overlapping features.
   - Support saving the animation as video.
   
-## ir-sim 2.3.2
+## ir-sim 2.3.2 (2025-01-28)
 
 ir-sim 2.3.2 is a bug fix release with no new features compared to 2.3.1.
 
-## ir-sim 2.3.1
+## ir-sim 2.3.1 (2025-01-26)
 
 - Update relevant documentation.
 - Fix some bugs
@@ -441,7 +441,7 @@ ir-sim 2.3.2 is a bug fix release with no new features compared to 2.3.1.
   - Add arguments for function WrapToPi.
   - Add the role selection for the behaviors.
 
-## ir-sim 2.3.0
+## ir-sim 2.3.0 (2024-12-22)
 
 **Major Version Update:** 
 
@@ -453,7 +453,7 @@ ir-sim 2.3.2 is a bug fix release with no new features compared to 2.3.1.
 - Fix some bugs in the project.
 - Add a 3D plotting environment.
 
-## ir-sim 2.2.6
+## ir-sim 2.2.6 (2024-11-22)
 
 - Refactor the behavior library and add a custom behavior interface.
 See usage: 13custom_behavior for details.
@@ -465,7 +465,7 @@ See usage: 02robot_world for details.
 See usage: 07renderw_world for details.
 - Fix the 'display' bug in the env.end() function.
 
-## ir-sim 2.2.5
+## ir-sim 2.2.5 (2024-10-17)
 
 - Convert the GIF file to readme links to reduce the repository size
 - Modify the visualization of the arrow for the robot
@@ -474,7 +474,7 @@ See usage: 07renderw_world for details.
 - Change the matplotlib backend to TkAgg
 - Fix some bugs on the visualization
 
-## ir-sim 2.2.4
+## ir-sim 2.2.4 (2024-09-17)
 
 - Fix collision avoidance bug for obstacles
 - Arrange the kinematics functions
@@ -482,7 +482,7 @@ See usage: 07renderw_world for details.
 - Format all python code with black
 - Complete the function comments and generate api documentation
 
-## ir-sim 2.2.3
+## ir-sim 2.2.3 (2024-09-01)
 
 - Rename the module name from ir_sim to irsim, rename the package name from ir_sim to ir-sim
 - Add citation for the project
@@ -491,40 +491,40 @@ See usage: 07renderw_world for details.
 - Add the attribute unobstructed for obejcts, see usage: obstace_world for detail
 - Fix the state_dim bug
 
-## ir-sim 2.2.0
+## ir-sim 2.2.0 (2024-08-30)
 
 - Rename the module from ir_sim to irsim, rename the package name from ir_sim to ir-sim
 - Add citation for the project
 - Refine the comments for the functions
 
 
-## ir-sim 2.1.4
+## ir-sim 2.1.4 (2024-08-19)
 
 - Update function comments
 - Update the readme
 - Add interface to change the object distribution in the environment
 - Add Feature of obstacles random in the environment
 
-## ir-sim 2.1.3
+## ir-sim 2.1.3 (2024-08-11)
 - Fix errors in usages
 - delete some old files
 - Fix some bugs
 
-## ir-sim 2.1.2
+## ir-sim 2.1.2 (2024-08-04)
 
 - Fix bug for omni dynamics robots
 - Fix bug for rvo behavior
 - Replace the diff description for the object_base
 
 
-## ir-sim 2.1.1
+## ir-sim 2.1.1 (2024-07-15)
 
 - Update the YAML API
 - Enhance features in object_base (G, h)
 - Expand project development utilities
 - Fix some bugs
 
-## ir-sim 2.1.0
+## ir-sim 2.1.0 (2024-03-29)
 
 Big Version
 
@@ -535,20 +535,20 @@ Big Version
 - Add the object factory to create the objects
 - Add env logger to record and print the environment status
 
-## ir-sim 1.1.12
+## ir-sim 1.1.12 (2023-11-02)
 
 Update the refresh of the show_trail
 Add set robot goal method
 Fix some bugs
 
 
-## ir-sim 1.1.11
+## ir-sim 1.1.11 (2023-04-28)
 
 Add the function to change the edgecolor
 Add repeat mkdirs
 Fix some bugs
 
-## ir-sim 1.1.10
+## ir-sim 1.1.10 (2023-04-12)
 
 - Fix some bugs
 - Add the collision mode 'unobstructed'
@@ -556,18 +556,18 @@ Fix some bugs
 - Add radius for obstacle
 
 
-## ir-sim 1.1.9
+## ir-sim 1.1.9 (2023-03-20)
 
 - Fix some bugs
 - Add features for obstacles.
 
 
-## ir-sim 1.1.8
+## ir-sim 1.1.8 (2023-02-27)
 
 - Add map obstacles
 - Fix bugs of reset robot
 - Add different car models
 
-## ir-sim-v1.1.7
+## ir-sim-v1.1.7 (2023-01-16)
 
 - Fix bugs of pyproject.toml


### PR DESCRIPTION
## Summary

Add release dates (from git tags) to every `## <version>` heading in `changelog.md`, e.g. `## 2.9.4 (2026-04-21)`. For the few versions without a git tag (2.4.4), used the commit date when the changelog section was added.

Makes it easy to see when each version shipped without cross-referencing git tags.