### PR TITLE
chore: add security and quality CI tooling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repository.
+# Requested for review on every pull request.
+*       @hanruihua

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest released version of IR-SIM on PyPI.
+We recommend always running the most recent release.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+| older   | :x:                |
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub issues.
+
+Instead, report them privately via GitHub's
+[private vulnerability reporting](https://github.com/hanruihua/ir-sim/security/advisories/new),
+or by emailing the maintainer at **hanrh@connect.hku.hk**.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (a minimal scenario YAML or script is ideal).
+- The IR-SIM version and Python version affected.
+
+We aim to acknowledge reports within 7 days and to provide a remediation
+timeline after triage. Thank you for helping keep IR-SIM and its users safe.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "0 0 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: on-failure
+          fail-on-severity: high

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,3 +14,25 @@ jobs:
       - uses: astral-sh/ruff-action@v3
       - run: ruff check
       - run: ruff format --check
+
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Bandit security scan
+        run: pipx run 'bandit[toml]' -c pyproject.toml -r irsim
+
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+          enable-cache: true
+      - run: uv sync --locked --dev
+      # `ty` is in preview; surface findings without failing the build yet.
+      - name: Run ty type checker
+        run: uv run ty check
+        continue-on-error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,23 @@
 repos:
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.12.8
-  hooks:
-    # Run the linter.
-    - id: ruff-check
-      args: [ --fix ]
-    # Run the formatter.
-    - id: ruff-format
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version. Keep in sync with the `ruff` dev dependency in pyproject.toml.
+    rev: v0.15.14
+    hooks:
+      # Run the linter.
+      - id: ruff-check
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.0
+    hooks:
+      - id: bandit
+        args: [-c, pyproject.toml]
+        additional_dependencies: ["bandit[toml]"]
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.0.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]

--- a/irsim/env/env_config.py
+++ b/irsim/env/env_config.py
@@ -64,7 +64,7 @@ class EnvConfig:
 
         if self.world_file_path is not None:
             with open(self.world_file_path) as file:
-                com_list = yaml.load(file, Loader=yaml.FullLoader)
+                com_list = yaml.safe_load(file)
 
                 for key in com_list:
                     if key in self._kwargs_parse:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = ["setuptools>=61.0",
             ]
-                   
+
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -61,6 +61,7 @@ lint = [
     "black>=25.1.0",
     "ruff>=0.12.8",
     "ty>=0.0.1a17",
+    "bandit[toml]>=1.8.0",
 ]
 test = [
     "pytest>=8.4.1",
@@ -121,12 +122,21 @@ exclude = ["docs", "tests"]
 
 [tool.ty.rules]
 unused-ignore-comment = "warn"
-possibly-unbound-import = "error"
+possibly-missing-import = "error"
 invalid-argument-type = "ignore"
 unresolved-import = "ignore"
 redundant-cast = "ignore"
 unresolved-attribute = "ignore"
-possibly-unbound-attribute = "ignore"
+possibly-missing-attribute = "ignore"
+
+[tool.bandit]
+# Scan the library source only; tests and docs are not shipped.
+exclude_dirs = ["tests", "docs", ".venv"]
+# Skips justified for a simulation library (no security-sensitive context):
+#   B101 assert_used      - asserts guard internal invariants
+#   B311 blacklist        - PRNG is for simulation sampling, not cryptography
+#   B110 try_except_pass  - intentional best-effort cleanup paths
+skips = ["B101", "B311", "B110"]
 
 [project.urls]
 "Homepage" = "https://ir-sim.readthedocs.io/en/stable/"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -63,6 +63,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [[package]]
@@ -689,6 +709,7 @@ keyboard = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit", extra = ["toml"] },
     { name = "black" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -714,6 +735,7 @@ docs = [
     { name = "sphinx-rtd-theme" },
 ]
 lint = [
+    { name = "bandit", extra = ["toml"] },
     { name = "black" },
     { name = "ruff" },
     { name = "ty" },
@@ -741,6 +763,7 @@ provides-extras = ["keyboard", "all"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "bandit", extras = ["toml"], specifier = ">=1.8.0" },
     { name = "black", specifier = ">=25.1.0" },
     { name = "pre-commit", specifier = "==4.6.0" },
     { name = "pytest", specifier = ">=8.4.1" },
@@ -764,6 +787,7 @@ docs = [
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
 ]
 lint = [
+    { name = "bandit", extras = ["toml"], specifier = ">=1.8.0" },
     { name = "black", specifier = ">=25.1.0" },
     { name = "ruff", specifier = ">=0.12.8" },
     { name = "ty", specifier = ">=0.0.1a17" },
@@ -1765,6 +1789,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "roman-numerals-py"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2280,6 +2317,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/88/35e4d27d9177d7df76d060e0a18f69c6c5794c96960c94042e20a12c8ba2/stevedore-5.8.0.tar.gz", hash = "sha256:b49867b32ca3016e94100e68dbf26e72aa7b8708d0a3f73c08aeb220370ac715", size = 514710, upload-time = "2026-05-18T09:15:27.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/ac/19f9941c74add59d17694930ec8105d5eddeee4ce56dd8632b765ca16d6c/stevedore-5.8.0-py3-none-any.whl", hash = "sha256:88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b", size = 54553, upload-time = "2026-05-18T09:15:25.82Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR adds a few tools to improve code quality and security checks.

## Changes

- Add a Bandit security scan. It runs in CI and as a pre-commit hook.
- Switch config loading to `yaml.safe_load`. This is safer and fixes the only Bandit finding.
- Add a CodeQL workflow to scan the code for security issues.
- Add a dependency-review workflow. It checks new dependencies on each PR.
- Run the `ty` type checker in CI. It does not fail the build yet.
- Add `SECURITY.md` so people know how to report security problems.
- Add `CODEOWNERS` so pull requests request a review automatically.
- Enforce conventional commit messages with a pre-commit hook.
- Bump the pinned ruff hook to match the dev dependency.

## Test Plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `bandit -c pyproject.toml -r irsim` reports no issues
- [x] `pytest` passes (851 passed, 1 skipped)