### PR TITLE
docs: add IRSIM-3DGS-Bridge community project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ For more examples, see the [usage directory](https://github.com/hanruihua/ir-sim
 
 - [DRL-robot-navigation-IR-SIM](https://github.com/reiniscimurs/DRL-robot-navigation-IR-SIM) -- Deep reinforcement learning for robot navigation.
 - [AutoNavRL](https://github.com/harshmahesheka/AutoNavRL) -- Autonomous navigation using reinforcement learning.
+- [IRSIM-3DGS-Bridge](https://github.com/Wayneyujie/IRSIM-3DGS-Bridge) -- A closed-loop bridge from 3D Gaussian Splatting scenes to IR-SIM planning/following and back to Habitat-GS trajectory playback.
 
 ## Contributing
 
@@ -172,4 +173,3 @@ Contributions are welcome! Please see [CONTRIBUTING.md](https://github.com/hanru
 ## License
 
 IR-SIM is released under the [MIT License](https://github.com/hanruihua/ir-sim?tab=MIT-1-ov-file).
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -217,3 +217,4 @@ Projects using IR-SIM
 
         * `DRL-robot-navigation-IR-SIM <https://github.com/reiniscimurs/DRL-robot-navigation-IR-SIM>`_
         * `AutoNavRL <https://github.com/harshmahesheka/AutoNavRL>`_
+        * `IRSIM-3DGS-Bridge <https://github.com/Wayneyujie/IRSIM-3DGS-Bridge>`_ - A closed-loop bridge from 3D Gaussian Splatting scenes to IR-SIM planning/following and Habitat-GS trajectory playback.


### PR DESCRIPTION
## Summary
- add IRSIM-3DGS-Bridge to the README community projects list
- add the same project link to the docs landing page

## Why
This bridge shows a closed-loop workflow that uses IR-SIM as the 2D planning and following backend for 3D Gaussian Splatting scenes, then plays the resulting trajectory back in Habitat-GS.

## Testing
- not run (docs-only change)
