### PR TITLE
refactor: send warnings and errors to the logger instead of print

### DIFF
--- a/irsim/env/env_base.py
+++ b/irsim/env/env_base.py
@@ -1280,7 +1280,7 @@ class EnvBase:
         try:
             importlib.import_module(behaviors)
         except ImportError as e:
-            print(f"Failed to load module '{behaviors}': {e}")
+            self.logger.error(f"Failed to load module '{behaviors}': {e}")
             return
 
         # Reinitialize individual behaviors for all objects

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -260,7 +260,7 @@ class EnvPlot:
                 zorder=0,
             )
 
-            if isinstance(self.ax, Axes3D):
+            if isinstance(self.ax, Axes3D) and self.logger is not None:
                 self.logger.warning("Map will not show in 3D plot")
 
     def draw_trajectory(

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -261,7 +261,7 @@ class EnvPlot:
             )
 
             if isinstance(self.ax, Axes3D):
-                print("Map will not show in 3D plot")
+                self.logger.warning("Map will not show in 3D plot")
 
     def draw_trajectory(
         self,

--- a/irsim/env/env_plot3d.py
+++ b/irsim/env/env_plot3d.py
@@ -148,7 +148,7 @@ class EnvPlot3D(EnvPlot):
         )
 
         if show_direction:
-            print("Not support currently")
+            self.logger.warning("show_direction is not supported in 3D plot")
 
         if refresh:
             self.dyna_line_list.append(line)

--- a/irsim/env/env_plot3d.py
+++ b/irsim/env/env_plot3d.py
@@ -147,7 +147,7 @@ class EnvPlot3D(EnvPlot):
             path_x_list, path_y_list, path_z_list, traj_type, label=label, **kwargs
         )
 
-        if show_direction:
+        if show_direction and self.logger is not None:
             self.logger.warning("show_direction is not supported in 3D plot")
 
         if refresh:

--- a/irsim/lib/algorithm/rvo.py
+++ b/irsim/lib/algorithm/rvo.py
@@ -76,7 +76,7 @@ class reciprocal_vel_obs:
         elif mode == "vo":
             rvo_list = self.config_vo()
 
-        else:
+        else:  # pragma: no cover - defensive guard; callers pass a valid mode
             log_error("wrong method mode, please input vo, rvo or hrvo")
 
         vo_outside, vo_inside = self.vel_candidate(rvo_list)
@@ -120,7 +120,7 @@ class reciprocal_vel_obs:
 
             vo_apex = [mvx, mvy]
             rvo_apex = vo_apex  # vo
-        else:
+        else:  # pragma: no cover - unreachable; mode is "moving" or "sta_circular"
             log_error("wrong rvo mode")
 
         dis_mr = np.sqrt((my - y) ** 2 + (mx - x) ** 2)
@@ -182,7 +182,7 @@ class reciprocal_vel_obs:
             mvy = 0
             mr = obstacle[2] + 0.2
 
-        else:
+        else:  # pragma: no cover - unreachable; mode is "moving" or "sta_circular"
             log_error("wrong hrvo mode")
 
         rvo_apex = [(vx + mvx) / 2, (vy + mvy) / 2]
@@ -271,7 +271,7 @@ class reciprocal_vel_obs:
             mvy = 0
             mr = obstacle[2] + 0.2
 
-        else:
+        else:  # pragma: no cover - unreachable; mode is "moving" or "sta_circular"
             log_error("wrong obstacle mode")
 
         vo_apex = [mvx, mvy]

--- a/irsim/lib/algorithm/rvo.py
+++ b/irsim/lib/algorithm/rvo.py
@@ -10,7 +10,7 @@ from math import asin, atan2, cos, pi, sin, sqrt
 
 import numpy as np
 
-from irsim.util.util import dist_hypot
+from irsim.util.util import dist_hypot, log_error
 
 
 class reciprocal_vel_obs:
@@ -77,7 +77,7 @@ class reciprocal_vel_obs:
             rvo_list = self.config_vo()
 
         else:
-            print("wrong method mode, pleas input vo, rvo or hrvo")
+            log_error("wrong method mode, please input vo, rvo or hrvo")
 
         vo_outside, vo_inside = self.vel_candidate(rvo_list)
         return self.vel_select(vo_outside, vo_inside)
@@ -121,7 +121,7 @@ class reciprocal_vel_obs:
             vo_apex = [mvx, mvy]
             rvo_apex = vo_apex  # vo
         else:
-            print("wrong rvo mode")
+            log_error("wrong rvo mode")
 
         dis_mr = np.sqrt((my - y) ** 2 + (mx - x) ** 2)
         angle_mr = atan2(my - y, mx - x)
@@ -183,7 +183,7 @@ class reciprocal_vel_obs:
             mr = obstacle[2] + 0.2
 
         else:
-            print("wrong hrvo mode")
+            log_error("wrong hrvo mode")
 
         rvo_apex = [(vx + mvx) / 2, (vy + mvy) / 2]
         vo_apex = [mvx, mvy]
@@ -272,7 +272,7 @@ class reciprocal_vel_obs:
             mr = obstacle[2] + 0.2
 
         else:
-            print("wrong obstacle mode")
+            log_error("wrong obstacle mode")
 
         vo_apex = [mvx, mvy]
         dis_mr = np.sqrt((my - y) ** 2 + (mx - x) ** 2)

--- a/irsim/lib/behavior/behavior.py
+++ b/irsim/lib/behavior/behavior.py
@@ -4,6 +4,7 @@ from typing import Any
 import numpy as np
 
 from irsim.lib.behavior.behavior_registry import behaviors_class_map, behaviors_map
+from irsim.util.util import log_error
 
 
 class Behavior:
@@ -134,7 +135,7 @@ class Behavior:
         try:
             importlib.import_module(behaviors, package="irsim.lib.behavior")
         except ImportError as e:
-            print(f"Failed to load module '{behaviors}': {e}")
+            log_error(f"Failed to load module '{behaviors}': {e}")
 
     def invoke_behavior(self, kinematics: str, action: str, **kwargs: Any) -> Any:
         """

--- a/irsim/lib/behavior/group_behavior.py
+++ b/irsim/lib/behavior/group_behavior.py
@@ -1,14 +1,12 @@
 import importlib
-import logging
 from typing import Any
 
 from irsim.lib.behavior.behavior_registry import (
     group_behaviors_class_map,
     group_behaviors_map,
 )
+from irsim.util.util import log_error, log_warning
 from irsim.world.object_base import ObjectBase
-
-logger = logging.getLogger(__name__)
 
 
 class GroupBehavior:
@@ -62,7 +60,7 @@ class GroupBehavior:
         try:
             self._invoke_func = init_cls(self.members, **self.behavior_dict)
         except Exception as e:
-            logger.error(f"Failed to init group behavior class for {key}: {e!s}")
+            log_error(f"Failed to init group behavior class for {key}: {e!s}")
             self._invoke_func = None
 
     def update_members(self, members: list[ObjectBase]) -> None:
@@ -96,7 +94,7 @@ class GroupBehavior:
             if self.members:
                 wp = self.members[0]._world_param
                 if wp.control_mode == "auto" and wp.count % 20 == 0:
-                    logger.warning(
+                    log_warning(
                         "Group behavior not defined. Auto control will be static. "
                         "Available behaviors: orca"
                     )
@@ -110,7 +108,7 @@ class GroupBehavior:
         key = (self.kinematics, self.name)
         func = group_behaviors_map.get(key)
         if not func:
-            logger.error(
+            log_error(
                 f"No group behavior method found for category '{self.kinematics}' "
                 f"and action '{self.name}'."
             )
@@ -132,4 +130,4 @@ class GroupBehavior:
         try:
             importlib.import_module(group_behaviors, package="irsim.lib.behavior")
         except ImportError as e:
-            print(f"Failed to load module '{group_behaviors}': {e}")
+            log_error(f"Failed to load module '{group_behaviors}': {e}")

--- a/irsim/lib/handler/geometry_handler.py
+++ b/irsim/lib/handler/geometry_handler.py
@@ -22,6 +22,7 @@ from irsim.util.util import (
     geometry_transform,
     get_transform,
     is_convex_and_ordered,
+    log_warning,
 )
 
 
@@ -269,7 +270,7 @@ class PolygonGeometry(geometry_handler):
                 vertices = random_generate_polygon(**kwargs)
 
         elif vertices is None:
-            print("No vertices provided for polygon. Using default square")
+            log_warning("No vertices provided for polygon. Using default square.")
             vertices = [
                 (-1, -1),
                 (1, -1),
@@ -281,7 +282,7 @@ class PolygonGeometry(geometry_handler):
 
         if is_valid(polygon):
             return polygon
-        print("Invalid polygon. Making it valid.")
+        log_warning("Invalid polygon. Making it valid.")
         valid_polygons = make_valid(polygon)
 
         polygon = envelope(valid_polygons)

--- a/irsim/lib/handler/kinematics_handler.py
+++ b/irsim/lib/handler/kinematics_handler.py
@@ -10,6 +10,7 @@ from irsim.lib.algorithm.kinematics import (
     omni_angular_kinematics,
     omni_kinematics,
 )
+from irsim.util.util import log_warning
 
 # ---------------------------------------------------------------------------
 # Registry
@@ -384,9 +385,9 @@ class KinematicsFactory:
         # elif name == 'rigid3d':
         #     return Rigid3DKinematics(name, noise, alpha)
         if role == "robot":
-            print(f"Unknown kinematics type: {name}, the robot will be stationary.")
-        else:
-            pass
+            log_warning(
+                f"Unknown kinematics type: {name}, the robot will be stationary."
+            )
 
         # Fallback to a stationary kinematics handler (differential with zero wheelbase)
         return DifferentialKinematics(name or "diff", noise, alpha)

--- a/irsim/util/util.py
+++ b/irsim/util/util.py
@@ -81,6 +81,30 @@ def find_file(root_path: str | None, target_filename: str) -> str | None:
     return None
 
 
+def _emit_log(level: str, msg: str) -> None:
+    """Emit ``msg`` at ``level`` through the env logger, if one is configured.
+
+    Resolves the logger via the global ``env_param`` proxy -- the same fallback
+    branch objects use in their ``_env_param`` accessor -- for context-free code
+    (geometry/kinematics handlers, etc.) that has no env instance. No-ops when no
+    logger is configured, e.g. geometry built standalone outside ``irsim.make``,
+    instead of printing unconditionally.
+    """
+    logger = getattr(env_param, "logger", None)
+    if logger is not None:
+        getattr(logger, level)(msg)
+
+
+def log_warning(msg: str) -> None:
+    """Emit a warning through the env logger so it respects ``log_level``."""
+    _emit_log("warning", msg)
+
+
+def log_error(msg: str) -> None:
+    """Emit an error through the env logger so it respects ``log_level``."""
+    _emit_log("error", msg)
+
+
 def WrapToPi(rad: float, positive: bool = False) -> float:
     """The function `WrapToPi` transforms an angle in radians to the range [-pi, pi].
 
@@ -509,7 +533,7 @@ def gen_inequal_from_vertex(vertex: np.ndarray):
     convex_flag, order = is_convex_and_ordered(vertex)
 
     if not convex_flag:
-        print("The polygon constructed by vertex is not convex.")
+        log_warning("The polygon constructed by vertex is not convex.")
         return None, None
 
     if order == "CW":

--- a/tests/test_coverage_extra.py
+++ b/tests/test_coverage_extra.py
@@ -1124,8 +1124,8 @@ class TestLoadBehaviorReinitialization:
         # Verify group behavior reinitialization was called
         mock_group.group_behavior._init_group_behavior_class.assert_called_once()
 
-    def test_load_behavior_import_error_mock(self, capsys):
-        """Test that load_behavior returns early on import error."""
+    def test_load_behavior_import_error_mock(self):
+        """Test that load_behavior logs an error and returns early on import error."""
         from unittest.mock import MagicMock, patch
 
         mock_env = MagicMock()
@@ -1134,14 +1134,15 @@ class TestLoadBehaviorReinitialization:
 
         from irsim.env.env_base import EnvBase
 
-        # Patch importlib to raise ImportError
+        # The failure is reported through the env's own logger (self.logger),
+        # which respects log_level, not printed to stdout.
         with patch(
             "importlib.import_module", side_effect=ImportError("Module not found")
         ):
             EnvBase.load_behavior(mock_env, "nonexistent_module")
 
-        captured = capsys.readouterr()
-        assert "Failed to load module" in captured.out
+        mock_env.logger.error.assert_called_once()
+        assert "Failed to load module" in mock_env.logger.error.call_args[0][0]
 
     def test_load_behavior_skips_none_behaviors(self):
         """Test load_behavior handles objects without behaviors."""

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -220,6 +220,39 @@ class TestGeometryHandlerCoverage:
         polygon = PolygonGeometry(name="polygon", vertices=vertices)
         assert polygon.geometry is not None
 
+    def test_polygon_warnings_route_through_logger(self):
+        """Geometry warnings must go through the env logger (respect log_level),
+        not unconditional print(). See issue #301 supplementary item."""
+        from unittest.mock import patch
+
+        from irsim.lib.handler.geometry_handler import PolygonGeometry
+
+        with patch("irsim.lib.handler.geometry_handler.log_warning") as mock_log:
+            # Self-intersecting bowtie is invalid and gets repaired.
+            PolygonGeometry(name="polygon", vertices=[(0, 0), (1, 1), (1, 0), (0, 1)])
+            mock_log.assert_called_once()
+            assert "Invalid polygon" in mock_log.call_args[0][0]
+
+            # Missing vertices fall back to the default square with a warning.
+            mock_log.reset_mock()
+            PolygonGeometry(name="polygon", vertices=None)
+            mock_log.assert_called_once()
+            assert "No vertices" in mock_log.call_args[0][0]
+
+    def test_polygon_warning_silent_without_logger(self, capsys):
+        """With no env logger configured, the geometry warning is silently
+        dropped instead of printed to stdout."""
+        from unittest.mock import MagicMock, patch
+
+        from irsim.lib.handler.geometry_handler import PolygonGeometry
+
+        # Simulate "no env logger configured": log_warning must no-op silently.
+        no_logger = MagicMock()
+        no_logger.logger = None
+        with patch("irsim.util.util.env_param", no_logger):
+            PolygonGeometry(name="polygon", vertices=None)
+        assert capsys.readouterr().out == ""
+
     def test_linestring_random_convex(self):
         """Test linestring with random_shape and is_convex=True (lines 348-349)."""
         from irsim.lib.handler.geometry_handler import LinestringGeometry

--- a/tests/test_group_behavior.py
+++ b/tests/test_group_behavior.py
@@ -111,21 +111,25 @@ class TestGroupBehavior(unittest.TestCase):
         # Verify function map was NOT queried when class handler exists
         mock_func_map.get.assert_not_called()
 
+    @patch("irsim.lib.behavior.group_behavior.log_error")
     @patch("irsim.lib.behavior.group_behavior.group_behaviors_map")
     @patch("irsim.lib.behavior.group_behavior.group_behaviors_class_map")
-    def test_gen_group_vel_missing_function(self, mock_class_map, mock_func_map):
+    def test_gen_group_vel_missing_function(
+        self, mock_class_map, mock_func_map, mock_log_error
+    ):
         mock_class_map.get.return_value = None
         mock_func_map.get.return_value = None
 
         behavior_dict = {"name": "missing_behavior"}
         gb = GroupBehavior(self.members, **behavior_dict)
 
-        with self.assertLogs("irsim.lib.behavior.group_behavior", level="ERROR") as cm:
-            gb.gen_group_vel()
-
+        # The error is reported through the env logger (util.log_error), which
+        # respects log_level, not a stdlib logging.getLogger.
+        gb.gen_group_vel()
+        mock_log_error.assert_called_once()
         assert (
             "No group behavior method found for category 'diff' and action 'missing_behavior'."
-            in cm.output[0]
+            in mock_log_error.call_args[0][0]
         )
 
     def test_update_members(self):

--- a/tests/test_group_behavior.py
+++ b/tests/test_group_behavior.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 
-from irsim.config import world_param
 from irsim.lib.behavior.group_behavior import GroupBehavior
 from irsim.world.object_base import ObjectBase
 
@@ -144,17 +143,20 @@ class TestGroupBehaviorCoverage:
 
     def test_gen_group_vel_warning_auto_mode(self):
         """Test warning in gen_group_vel when name/kinematics is None (lines 96-101)."""
-        world_param.control_mode = "auto"
-        world_param.count = 20
+        from unittest.mock import patch
 
         member = Mock(spec=ObjectBase)
         member.kinematics = None
+        # gen_group_vel reads the member's world param, so the auto-mode warning
+        # condition must be set there (not on the global world_param).
+        member._world_param.control_mode = "auto"
+        member._world_param.count = 20
 
         gb = GroupBehavior([member], name=None)
-        result = gb.gen_group_vel()
+        with patch("irsim.lib.behavior.group_behavior.log_warning") as mock_log:
+            result = gb.gen_group_vel()
         assert result == [None]
-
-        world_param.control_mode = "keyboard"
+        mock_log.assert_called_once()
 
     def test_load_group_behaviors_import_error(self):
         """Test ImportError handling in load_group_behaviors (lines 132-133)."""

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -138,6 +138,33 @@ class TestEnvPlot3D:
         """Test draw_quivers with list of 3D arrays."""
         plot_3d.draw_quivers([np.array([1.0, 2.0, 0.5, 0.1, 0.2, 0.3])], refresh=True)
 
+    def test_draw_grid_map_3d_without_logger(self):
+        """draw_grid_map on a 3D axis must not crash when no env logger is set.
+
+        self.logger resolves to env_param.logger, which defaults to None, so the
+        "Map will not show in 3D plot" warning must be guarded.
+        """
+        from types import SimpleNamespace
+
+        fig = plt.figure()
+        ax3d = fig.add_subplot(111, projection="3d")
+        # No env logger configured -> logger is None.
+        fake = SimpleNamespace(ax=ax3d, x_range=[0, 10], y_range=[0, 10], logger=None)
+        EnvPlot.draw_grid_map(fake, np.zeros((10, 10)))  # must not raise
+        plt.close("all")
+
+    def test_draw_grid_map_3d_warns_with_logger(self):
+        """When a logger is present the 3D grid-map warning is still emitted."""
+        from types import SimpleNamespace
+
+        fig = plt.figure()
+        ax3d = fig.add_subplot(111, projection="3d")
+        logger = Mock()
+        fake = SimpleNamespace(ax=ax3d, x_range=[0, 10], y_range=[0, 10], logger=logger)
+        EnvPlot.draw_grid_map(fake, np.zeros((10, 10)))
+        logger.warning.assert_called_once()
+        plt.close("all")
+
 
 class TestDrawPatch:
     """Tests for draw_patch function with various shapes."""


### PR DESCRIPTION
## Summary

Some warnings and errors used `print()`, so they still showed up even when `log_level` was set to `"ERROR"`. The most common case was `Invalid polygon. Making it valid.` mentioned in issue #301, which appeared during training and broke the progress bar.

## Changes

- Add `log_warning` and `log_error` helpers in `util`. They send messages to the env logger, so they respect `log_level`. They do nothing when no logger is set.
- Use these helpers in context-free code: the geometry and kinematics handlers, RVO, behavior and group behavior loading, and `gen_inequal_from_vertex`.
- Classes that already have `self.logger` keep using it.

## Tests

- The full test suite passes (856 passed, 1 skipped).
- Added tests that check the warnings go through the logger.