### PR TITLE
fix: dash yaw oscillation, diff RVO stall when goal is behind, and headless keyboard queue overflow (#301)

### DIFF
--- a/irsim/gui/keyboard_control.py
+++ b/irsim/gui/keyboard_control.py
@@ -193,11 +193,12 @@ class KeyboardControl:
             pass
 
         # Keyboard input is only meaningful with an interactive display. When
-        # headless (display=False) skip installing any input hook: pynput's
-        # global listener triggers OS input-monitoring permission prompts and
-        # overflows the event queue when many environments are spawned for
-        # parallel training. The handlers stay callable directly so tests and
-        # programmatic use are unaffected.
+        # headless (display=False) skip installing the global OS keyboard
+        # listener (and the matplotlib key-event fallback): pynput's listener
+        # triggers OS input-monitoring permission prompts and can overflow the
+        # event queue when many environments are spawned for parallel training.
+        # The matplotlib focus wiring above still runs; the handlers stay
+        # callable directly so tests and programmatic use are unaffected.
         interactive = getattr(self.env_ref, "display", True) if self.env_ref else True
 
         if not interactive:

--- a/irsim/gui/keyboard_control.py
+++ b/irsim/gui/keyboard_control.py
@@ -192,7 +192,17 @@ class KeyboardControl:
         except Exception:
             pass
 
-        if self.backend == "pynput" and _PYNPUT_AVAILABLE:
+        # Keyboard input is only meaningful with an interactive display. When
+        # headless (display=False) skip installing any input hook: pynput's
+        # global listener triggers OS input-monitoring permission prompts and
+        # overflows the event queue when many environments are spawned for
+        # parallel training. The handlers stay callable directly so tests and
+        # programmatic use are unaffected.
+        interactive = getattr(self.env_ref, "display", True) if self.env_ref else True
+
+        if not interactive:
+            self.listener = None
+        elif self.backend == "pynput" and _PYNPUT_AVAILABLE:
             # Use pynput global keyboard listener
             self.listener = keyboard.Listener(
                 on_press=self._on_pynput_press, on_release=self._on_pynput_release

--- a/irsim/lib/behavior/behavior_methods.py
+++ b/irsim/lib/behavior/behavior_methods.py
@@ -115,8 +115,10 @@ def beh_diff_dash(
     state = ego_object.state
     goal = ego_object.goal
     goal_threshold = ego_object.goal_threshold
-    _, max_vel = ego_object.get_vel_range()
+    max_vel = ego_object.vel_max
     angle_tolerance = kwargs.get("angle_tolerance", 0.1)
+    angular_acce = ego_object.info.acce[1, 0]
+    dt = ego_object._world_param.step_time
 
     if goal is None:
         if ego_object._world_param.count % 10 == 0:
@@ -126,7 +128,9 @@ def beh_diff_dash(
 
         return np.zeros((2, 1))
 
-    return DiffDash(state, goal, max_vel, goal_threshold, angle_tolerance)
+    vel = DiffDash(state, goal, max_vel, goal_threshold, angle_tolerance, angular_acce, dt)
+    min_step, max_step = ego_object.get_vel_range()
+    return np.clip(vel, min_step, max_step)
 
 
 @register_behavior("omni", "dash")
@@ -155,8 +159,10 @@ def beh_omni_dash(
     state = ego_object.state
     goal = ego_object.goal
     goal_threshold = ego_object.goal_threshold
-    _, max_vel = ego_object.get_vel_range()
-    return OmniDash(state, goal, max_vel, goal_threshold)
+    max_vel = ego_object.vel_max
+    vel = OmniDash(state, goal, max_vel, goal_threshold)
+    min_step, max_step = ego_object.get_vel_range()
+    return np.clip(vel, min_step, max_step)
 
 
 @register_behavior("omni", "rvo")
@@ -336,9 +342,14 @@ def beh_omni_angular_dash(
     state = ego_object.state
     goal = ego_object.goal
     goal_threshold = ego_object.goal_threshold
-    _, max_vel = ego_object.get_vel_range()
+    max_vel = ego_object.vel_max
     angle_tolerance = kwargs.get("angle_tolerance", 0.1)
-    return OmniAngularDash(state, goal, max_vel, goal_threshold, angle_tolerance)
+    acce = ego_object.info.acce
+    angular_acce = acce[2, 0] if acce.shape[0] > 2 else float("inf")
+    dt = ego_object._world_param.step_time
+    vel = OmniAngularDash(state, goal, max_vel, goal_threshold, angle_tolerance, angular_acce, dt)
+    min_step, max_step = ego_object.get_vel_range()
+    return np.clip(vel, min_step, max_step)
 
 
 @register_behavior("acker", "dash")
@@ -368,10 +379,11 @@ def beh_acker_dash(
     state = ego_object.state
     goal = ego_object.goal
     goal_threshold = ego_object.goal_threshold
-    _, max_vel = ego_object.get_vel_range()
+    max_vel = ego_object.vel_max
     angle_tolerance = kwargs.get("angle_tolerance", 0.1)
-
-    return AckerDash(state, goal, max_vel, goal_threshold, angle_tolerance)
+    vel = AckerDash(state, goal, max_vel, goal_threshold, angle_tolerance)
+    min_step, max_step = ego_object.get_vel_range()
+    return np.clip(vel, min_step, max_step)
 
 
 def SFMVelocity(
@@ -600,6 +612,8 @@ def OmniAngularDash(
     max_vel: np.ndarray,
     goal_threshold: float = 0.3,
     angle_tolerance: float = 0.1,
+    angular_acce: float = float("inf"),
+    dt: float = 0.0,
 ) -> np.ndarray:
     """
     Calculate body-frame velocity to reach a goal.
@@ -608,12 +622,22 @@ def OmniAngularDash(
     to face it. After arriving at the goal position, rotates in place
     to match the goal orientation.
 
+    The yaw rate is ramped down near the target so the robot can decelerate
+    to a stop within the remaining angle. The ramp uses the exact discrete-time
+    formula ``ω ≤ -a·dt + √(a²·dt² + 2·a·remaining)`` so the robot stops
+    cleanly within one step of ``angle_tolerance`` without overshoot.
+
     Args:
         state (np.array): Current state [x, y, theta] (3x1).
         goal (np.array): Goal state [x, y, theta] (3x1).
-        max_vel (np.array): Maximum velocity [forward, lateral, yaw_rate] (3x1).
+        max_vel (np.array): Absolute maximum velocity [forward, lateral, yaw_rate] (3x1).
         goal_threshold (float): Distance threshold to consider goal reached (default 0.3).
         angle_tolerance (float): Allowable angular deviation (default 0.1).
+        angular_acce (float): Angular acceleration limit (rad/s^2). Used to cap
+            yaw rate so the robot can always stop within the remaining angle.
+            ``inf`` (default) gives bang-bang behaviour.
+        dt (float): Simulation time step (s). Used for exact discrete-time decel
+            ramp. 0 (default) falls back to the continuous-time approximation.
 
     Returns:
         np.array: Body-frame velocity [forward, lateral, yaw_rate] (3x1).
@@ -632,10 +656,19 @@ def OmniAngularDash(
         target_angle = goal[2, 0] if goal.shape[0] > 2 else theta
 
     diff_angle = WrapToPi(target_angle - theta)
-    if abs(diff_angle) > angle_tolerance:
-        yaw_rate = max_vel[2, 0] * np.sign(diff_angle)
+    if abs(diff_angle) <= angle_tolerance:
+        yaw_rate = 0.0
     else:
-        yaw_rate = 0
+        if np.isfinite(angular_acce) and angular_acce > 0:
+            remaining = abs(diff_angle) - angle_tolerance
+            # Exact discrete-time limit: robot moves ω·dt this step before braking,
+            # so the true stopping condition is ω·dt + ω²/(2a) ≤ remaining.
+            # Solving: ω ≤ -a·dt + √(a²·dt² + 2·a·remaining)
+            a_dt = angular_acce * dt
+            max_yaw = -a_dt + np.sqrt(a_dt**2 + 2.0 * angular_acce * remaining)
+        else:
+            max_yaw = abs(max_vel[2, 0])
+        yaw_rate = np.sign(diff_angle) * max_yaw
 
     return np.array([[forward], [lateral], [yaw_rate]])
 
@@ -646,6 +679,8 @@ def DiffDash(
     max_vel: np.ndarray,
     goal_threshold: float = 0.1,
     angle_tolerance: float = 0.2,
+    angular_acce: float = float("inf"),
+    dt: float = 0.0,
 ) -> np.ndarray:
     """
     Calculate the differential drive velocity to reach a goal.
@@ -653,9 +688,12 @@ def DiffDash(
     Args:
         state (np.array): Current state [x, y, theta] (3x1).
         goal (np.array): Goal position [x, y] (2x1).
-        max_vel (np.array): Maximum velocity [linear, angular] (2x1).
+        max_vel (np.array): Absolute maximum velocity [linear, angular] (2x1).
         goal_threshold (float): Distance threshold to consider goal reached (default 0.1).
         angle_tolerance (float): Allowable angular deviation (default 0.2).
+        angular_acce (float): Angular acceleration limit (rad/s^2) for the decel ramp.
+            ``inf`` (default) gives bang-bang behaviour.
+        dt (float): Simulation time step (s) for exact discrete-time decel ramp.
 
     Returns:
         np.array: Velocity [linear, angular] (2x1).
@@ -669,9 +707,15 @@ def DiffDash(
     linear = max_vel[0, 0] * np.cos(diff_radian)
 
     if abs(diff_radian) < angle_tolerance:
-        angular = 0
+        angular = 0.0
     else:
-        angular = max_vel[1, 0] * np.sign(diff_radian)
+        if np.isfinite(angular_acce) and angular_acce > 0:
+            remaining = abs(diff_radian) - angle_tolerance
+            a_dt = angular_acce * dt
+            max_ang = -a_dt + np.sqrt(a_dt**2 + 2.0 * angular_acce * remaining)
+        else:
+            max_ang = abs(max_vel[1, 0])
+        angular = np.sign(diff_radian) * max_ang
 
     return np.array([[linear], [angular]])
 

--- a/irsim/lib/behavior/behavior_methods.py
+++ b/irsim/lib/behavior/behavior_methods.py
@@ -575,7 +575,21 @@ def DiffRVO(
         line_obs_list=line_segments,
     )
     rvo_vel = rvo_behavior.cal_vel(mode)
-    return omni_to_diff(state_tuple[-1], rvo_vel)
+    diff_vel = omni_to_diff(state_tuple[-1], rvo_vel)
+
+    if not diff_vel.any() and not filtered_neighbor_list and not line_segments:
+        # With no neighbors or obstacles in range, a fully frozen command means
+        # the holonomic RVO solution collapsed toward zero velocity because the
+        # goal lies behind the robot (it cannot represent a reversal), so the
+        # diff robot would freeze forever instead of turning around. Rotate in
+        # place toward the desired heading; forward speed stays zero and
+        # ``omni_to_diff`` naturally stops the rotation once the robot faces its
+        # goal. When neighbors are present the freeze is collision avoidance and
+        # the robot must keep waiting, so this branch is skipped entirely.
+        diff_vel = omni_to_diff(state_tuple[-1], [state_tuple[5], state_tuple[6]])
+        diff_vel[0, 0] = 0.0
+
+    return diff_vel
 
 
 def OmniDash(

--- a/irsim/lib/behavior/behavior_methods.py
+++ b/irsim/lib/behavior/behavior_methods.py
@@ -684,6 +684,9 @@ def OmniAngularDash(
             # Solving: ω ≤ -a·dt + √(a²·dt² + 2·a·remaining)
             a_dt = angular_acce * dt
             max_yaw = -a_dt + np.sqrt(a_dt**2 + 2.0 * angular_acce * remaining)
+            # The decel ramp grows unbounded with ``remaining``; never exceed
+            # the configured yaw-rate limit.
+            max_yaw = min(abs(max_vel[2, 0]), max_yaw)
         else:
             max_yaw = abs(max_vel[2, 0])
         yaw_rate = np.sign(diff_angle) * max_yaw
@@ -731,6 +734,9 @@ def DiffDash(
             remaining = abs(diff_radian) - angle_tolerance
             a_dt = angular_acce * dt
             max_ang = -a_dt + np.sqrt(a_dt**2 + 2.0 * angular_acce * remaining)
+            # The decel ramp grows unbounded with ``remaining``; never exceed
+            # the configured angular-speed limit.
+            max_ang = min(abs(max_vel[1, 0]), max_ang)
         else:
             max_ang = abs(max_vel[1, 0])
         angular = np.sign(diff_radian) * max_ang

--- a/irsim/lib/behavior/behavior_methods.py
+++ b/irsim/lib/behavior/behavior_methods.py
@@ -128,7 +128,9 @@ def beh_diff_dash(
 
         return np.zeros((2, 1))
 
-    vel = DiffDash(state, goal, max_vel, goal_threshold, angle_tolerance, angular_acce, dt)
+    vel = DiffDash(
+        state, goal, max_vel, goal_threshold, angle_tolerance, angular_acce, dt
+    )
     min_step, max_step = ego_object.get_vel_range()
     return np.clip(vel, min_step, max_step)
 
@@ -347,7 +349,9 @@ def beh_omni_angular_dash(
     acce = ego_object.info.acce
     angular_acce = acce[2, 0] if acce.shape[0] > 2 else float("inf")
     dt = ego_object._world_param.step_time
-    vel = OmniAngularDash(state, goal, max_vel, goal_threshold, angle_tolerance, angular_acce, dt)
+    vel = OmniAngularDash(
+        state, goal, max_vel, goal_threshold, angle_tolerance, angular_acce, dt
+    )
     min_step, max_step = ego_object.get_vel_range()
     return np.clip(vel, min_step, max_step)
 

--- a/tests/test_all_objects.py
+++ b/tests/test_all_objects.py
@@ -542,6 +542,21 @@ def test_keyboard_control():
     assert True  # Add keyboard control related assertions
 
 
+def test_keyboard_listener_skipped_when_headless():
+    """Headless envs must not start the global pynput keyboard listener.
+
+    The listener installs a global OS keyboard hook; starting one per env
+    triggers input-monitoring permission prompts and overflows the event queue
+    when many environments are created for parallel training. With display=False
+    the KeyboardControl object is still created (its handlers stay callable) but
+    no listener thread is started.
+    """
+    env = irsim.make("test_keyboard_control.yaml", save_ani=False, display=False)
+    assert hasattr(env, "keyboard")
+    assert env.keyboard.listener is None
+    env.end()
+
+
 def test_keyboard_control_mpl_backend():
     """Test keyboard control via Matplotlib backend key events."""
     # Ensure world is set to keyboard mode via YAML; KeyboardControl defaults to mpl backend

--- a/tests/test_behaviors.py
+++ b/tests/test_behaviors.py
@@ -277,6 +277,48 @@ class TestBehaviorMethodsGoalNone:
         )
         assert res_inf[2, 0] == pytest.approx(3.0)
 
+    def test_omni_angular_dash_yaw_capped_at_max_vel(self, dummy_logger):
+        """Large heading error: the decel ramp is capped at max_vel, not exceeded."""
+        from irsim.lib.behavior.behavior_methods import OmniAngularDash
+
+        # At goal position, but goal heading is ~pi away -> large remaining, so the
+        # uncapped decel ramp (~3.9) would exceed the 3.0 yaw-rate limit.
+        state = np.array([[0.0], [0.0], [0.0]])
+        goal = np.array([[0.0], [0.0], [3.0]])
+        max_vel = np.array([[1.0], [1.0], [3.0]])
+
+        res = OmniAngularDash(
+            state,
+            goal,
+            max_vel,
+            goal_threshold=0.5,
+            angle_tolerance=0.05,
+            angular_acce=3.0,
+            dt=0.1,
+        )
+        assert res[2, 0] == pytest.approx(3.0)
+
+    def test_diff_dash_angular_capped_at_max_vel(self, dummy_logger):
+        """Large heading error: DiffDash decel ramp is capped at max_vel."""
+        from irsim.lib.behavior.behavior_methods import DiffDash
+
+        # Goal directly behind -> heading error ~pi, so the uncapped ramp (~4.0)
+        # would exceed the 2.0 angular limit.
+        state = np.array([[0.0], [0.0], [0.0]])
+        goal = np.array([[-5.0], [0.0]])
+        max_vel = np.array([[1.0], [2.0]])
+
+        res = DiffDash(
+            state,
+            goal,
+            max_vel,
+            goal_threshold=0.1,
+            angle_tolerance=0.05,
+            angular_acce=3.0,
+            dt=0.1,
+        )
+        assert abs(res[1, 0]) == pytest.approx(2.0)
+
 
 class TestBehaviorMethodsFunctions:
     """Tests for standalone behavior method functions."""

--- a/tests/test_behaviors.py
+++ b/tests/test_behaviors.py
@@ -127,9 +127,13 @@ class TestBehaviorCoverage:
         ego.state = np.array([[0], [0], [0]])
         ego.goal = np.array([[1], [1]])
         ego.goal_threshold = 0.1
+        ego.vel_max = np.array([[1.0], [1.0]])
+        ego.info = Mock()
+        ego.info.acce = np.array([[1.0], [1.0]])
         ego.get_vel_range = Mock(
-            return_value=(np.array([[0], [0]]), np.array([[1], [1]]))
+            return_value=(np.array([[-1.0], [-1.0]]), np.array([[1.0], [1.0]]))
         )
+        ego._world_param.step_time = 0.1
         ego.max_speed = 1.0
 
         # This should filter out the obstacle and keep only the robot
@@ -206,17 +210,54 @@ class TestBehaviorMethodsGoalNone:
         ego.state = np.array([[0.0], [0.0], [0.0]])
         ego.goal = np.array([[5.0], [3.0], [1.0]])
         ego.goal_threshold = 0.3
+        ego.vel_max = np.array([[1.0], [1.0], [0.5]])
+        ego.info = Mock()
+        ego.info.acce = np.array([[1.0], [1.0], [3.0]])
         ego.get_vel_range = Mock(
-            return_value=(
-                np.array([[-1.0], [-1.0], [-0.5]]),
-                np.array([[1.0], [1.0], [0.5]]),
-            )
+            return_value=(np.array([[-1.0], [-1.0], [-0.5]]), np.array([[1.0], [1.0], [0.5]]))
         )
         ego._world_param = Mock()
+        ego._world_param.step_time = 0.1
         ego.logger = Mock()
 
         result = beh_omni_angular_dash(ego, [])
         assert result.shape == (3, 1)
+
+    def test_omni_angular_dash_yaw_deceleration(self, dummy_logger):
+        """OmniAngularDash decel ramp: caps yaw below max, mirrors CCW/CW, inf → bang-bang."""
+        from irsim.lib.behavior.behavior_methods import OmniAngularDash
+
+        state = np.array([[0.0], [0.0], [0.0]])
+        goal_pos = np.array([[5.0], [0.0], [0.3]])  # goal heading 0.3 rad away
+        max_vel = np.array([[1.0], [1.0], [3.0]])
+        dt = 0.1
+
+        res = OmniAngularDash(
+            state, goal_pos, max_vel, goal_threshold=6.0,
+            angle_tolerance=0.05, angular_acce=3.0, dt=dt,
+        )
+        assert abs(res[2, 0]) < 3.0, "decel ramp should limit yaw rate"
+
+        # Discrete-time ramp: ω·dt + ω²/(2a) ≤ remaining → no overshoot in one step
+        remaining = 0.3 - 0.05
+        a, omega = 3.0, abs(res[2, 0])
+        assert omega * dt + omega**2 / (2 * a) <= remaining + 1e-9, "overshoot in one step"
+
+        # CW goal must produce same magnitude as CCW
+        goal_cw = np.array([[5.0], [0.0], [-0.3]])
+        res_cw = OmniAngularDash(
+            state, goal_cw, max_vel, goal_threshold=6.0,
+            angle_tolerance=0.05, angular_acce=3.0, dt=dt,
+        )
+        assert abs(res[2, 0]) == pytest.approx(abs(res_cw[2, 0]))
+        assert res_cw[2, 0] < 0
+
+        # inf acce → bang-bang (full yaw)
+        res_inf = OmniAngularDash(
+            state, goal_pos, max_vel, goal_threshold=6.0,
+            angle_tolerance=0.05,
+        )
+        assert res_inf[2, 0] == pytest.approx(3.0)
 
 
 class TestBehaviorMethodsFunctions:

--- a/tests/test_behaviors.py
+++ b/tests/test_behaviors.py
@@ -214,7 +214,10 @@ class TestBehaviorMethodsGoalNone:
         ego.info = Mock()
         ego.info.acce = np.array([[1.0], [1.0], [3.0]])
         ego.get_vel_range = Mock(
-            return_value=(np.array([[-1.0], [-1.0], [-0.5]]), np.array([[1.0], [1.0], [0.5]]))
+            return_value=(
+                np.array([[-1.0], [-1.0], [-0.5]]),
+                np.array([[1.0], [1.0], [0.5]]),
+            )
         )
         ego._world_param = Mock()
         ego._world_param.step_time = 0.1
@@ -233,28 +236,43 @@ class TestBehaviorMethodsGoalNone:
         dt = 0.1
 
         res = OmniAngularDash(
-            state, goal_pos, max_vel, goal_threshold=6.0,
-            angle_tolerance=0.05, angular_acce=3.0, dt=dt,
+            state,
+            goal_pos,
+            max_vel,
+            goal_threshold=6.0,
+            angle_tolerance=0.05,
+            angular_acce=3.0,
+            dt=dt,
         )
         assert abs(res[2, 0]) < 3.0, "decel ramp should limit yaw rate"
 
         # Discrete-time ramp: ω·dt + ω²/(2a) ≤ remaining → no overshoot in one step
         remaining = 0.3 - 0.05
         a, omega = 3.0, abs(res[2, 0])
-        assert omega * dt + omega**2 / (2 * a) <= remaining + 1e-9, "overshoot in one step"
+        assert omega * dt + omega**2 / (2 * a) <= remaining + 1e-9, (
+            "overshoot in one step"
+        )
 
         # CW goal must produce same magnitude as CCW
         goal_cw = np.array([[5.0], [0.0], [-0.3]])
         res_cw = OmniAngularDash(
-            state, goal_cw, max_vel, goal_threshold=6.0,
-            angle_tolerance=0.05, angular_acce=3.0, dt=dt,
+            state,
+            goal_cw,
+            max_vel,
+            goal_threshold=6.0,
+            angle_tolerance=0.05,
+            angular_acce=3.0,
+            dt=dt,
         )
         assert abs(res[2, 0]) == pytest.approx(abs(res_cw[2, 0]))
         assert res_cw[2, 0] < 0
 
         # inf acce → bang-bang (full yaw)
         res_inf = OmniAngularDash(
-            state, goal_pos, max_vel, goal_threshold=6.0,
+            state,
+            goal_pos,
+            max_vel,
+            goal_threshold=6.0,
             angle_tolerance=0.05,
         )
         assert res_inf[2, 0] == pytest.approx(3.0)

--- a/tests/test_behaviors.py
+++ b/tests/test_behaviors.py
@@ -299,6 +299,27 @@ class TestBehaviorMethodsFunctions:
         result = DiffRVO(state_tuple, neighbor_list=None)
         assert result.shape == (2, 1)
 
+    def test_diff_rvo_goal_behind_rotates(self):
+        """DiffRVO must turn around instead of freezing when the goal is behind.
+
+        Holonomic RVO collapses toward zero velocity when the goal lies behind
+        the robot (it cannot encode a reversal). With a tight acceleration
+        window the converted command would be all-zeros and a diff robot would
+        freeze forever facing away from its goal. With no neighbors in range the
+        behavior should instead rotate in place toward the desired heading.
+        """
+        from irsim.lib.behavior.behavior_methods import DiffRVO
+
+        # rvo_state = [x, y, vx, vy, radius, vx_des, vy_des, theta]
+        # robot faces +x (theta=0) but the desired velocity points behind it.
+        state_tuple = [0.0, 0.0, 0.0, 0.0, 0.5, -1.0, 0.0, 0.0]
+        # Tight acce window forces the RVO solution below the deadband.
+        result = DiffRVO(state_tuple, neighbor_list=[], acce=0.01)
+
+        assert result.shape == (2, 1)
+        assert result[0, 0] == 0.0  # no forward creep while turning around
+        assert abs(result[1, 0]) > 0.1  # rotates toward the goal instead of freezing
+
     def test_omni_dash_at_goal(self):
         """Test OmniDash when at goal."""
         from irsim.lib.behavior.behavior_methods import OmniDash


### PR DESCRIPTION
## Summary

Fixes the three bugs reported in issue #301.

## Changes

- **omni_angular dash**: the robot used to keep spinning slightly in place when it started facing away from the goal, because the two turn directions fought for control. It now turns one way and reaches the goal (fixes yaw overshoot and velocity starvation).
- **diff rvo**: the robot used to stall when the goal was behind it, because the holonomic RVO solution cannot represent a turn-around. It now turns toward the goal instead of stopping.
- **keyboard**: creating an environment started a global keyboard listener even with `display=False`. Launching many headless environments (parallel training) then overflowed the input event queue. The listener is now skipped when headless.

## Tests

- Full test suite passes.
- Added regression tests for each fix.
