### PR TITLE
feat(behavior): add orca group behavior for diff robots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## 2.10.1 (unreleased)
 
+- Features:
+  - Add `orca` group behavior support for `diff` robots; ORCA's holonomic velocity is mapped to `(linear, angular)` via `omni_to_diff`, with a `19orca_world/orca_diff_world` usage example. ([#333](https://github.com/hanruihua/ir-sim/pull/333))
+
 - Fix:
   - Suppress the default velocity arrow on static obstacles by gating the handler-derived `show_arrow` on `not self.static` (regression from v2.9.2's kinematics-handler registry refactor). ([#313](https://github.com/hanruihua/ir-sim/pull/313))
 

--- a/docs/locale/zh_CN/LC_MESSAGES/usage/configure_behavior.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/usage/configure_behavior.po
@@ -413,8 +413,8 @@ msgid "`dash`, `rvo`, `sfm` (kinematics-dependent — see matrix above)"
 msgstr "`dash`、`rvo`、`sfm`（取决于运动学模型 —— 见上方矩阵）"
 
 #: ../../source/usage/configure_behavior.md:218
-msgid "`orca`"
-msgstr "`orca`"
+msgid "`orca` (`omni`, `diff`)"
+msgstr "`orca`（`omni`、`diff`）"
 
 #: ../../source/usage/configure_behavior.md:260
 msgid "ORCA (Optimal Reciprocal Collision Avoidance)"
@@ -426,6 +426,20 @@ msgid ""
 "computes optimal velocities for multiple agents simultaneously. It ensures "
 "smooth, collision-free navigation even with hundreds of agents."
 msgstr "ORCA 是一种经典的内置群组级碰撞避免算法，可同时为多个智能体计算最优速度。即使有数百个智能体，也能确保平滑无碰撞的导航。"
+
+#: ../../source/usage/configure_behavior.md:264
+msgid ""
+"ORCA supports both `omni` and `diff` kinematics. It plans a holonomic "
+"velocity `(vx, vy)` for every member: `omni` robots use it directly, while "
+"`diff` robots map it to a `(linear, angular)` command, so a differential-"
+"drive robot turns toward the planned direction and slows down when it is not "
+"yet aligned. Set `kinematics: {name: 'diff'}` on the group to use the "
+"differential-drive variant; all ORCA parameters below stay the same."
+msgstr ""
+"ORCA 同时支持 `omni` 和 `diff` 运动学模型。它为每个成员规划一个完整（全向）"
+"速度 `(vx, vy)`：`omni` 机器人直接使用该速度，而 `diff` 机器人会将其映射为 "
+"`(线速度, 角速度)` 指令，因此差速机器人会朝规划方向转向，并在尚未对准时减速。"
+"在群组上设置 `kinematics: {name: 'diff'}` 即可使用差速变体；下方的所有 ORCA 参数保持不变。"
 
 #: ../../source/usage/configure_behavior.md:265
 msgid ""

--- a/docs/source/usage/configure_behavior.md
+++ b/docs/source/usage/configure_behavior.md
@@ -255,11 +255,13 @@ While `behavior` controls individual object movement, **`group_behavior`** enabl
 | Scope | Individual object | All objects in a group |
 | Computation | Per-object each step | All members at once |
 | Use case | Simple navigation | Coordinated multi-agent |
-| Available | `dash`, `rvo`, `sfm` (kinematics-dependent — see matrix above) | `orca` |
+| Available | `dash`, `rvo`, `sfm` (kinematics-dependent — see matrix above) | `orca` (`omni`, `diff`) |
 
 ### ORCA (Optimal Reciprocal Collision Avoidance)
 
 ORCA is a classical built-in group-level collision avoidance algorithm that computes optimal velocities for multiple agents simultaneously. It ensures smooth, collision-free navigation even with hundreds of agents.
+
+ORCA supports both `omni` and `diff` kinematics. It plans a holonomic velocity `(vx, vy)` for every member: `omni` robots use it directly, while `diff` robots map it to a `(linear, angular)` command, so a differential-drive robot turns toward the planned direction and slows down when it is not yet aligned. Set `kinematics: {name: 'diff'}` on the group to use the differential-drive variant; all ORCA parameters below stay the same.
 
 :::{note}
 ORCA requires the `pyrvo` library, which is a python binding for the ORCA C++ algorithm. Install it using:

--- a/irsim/lib/behavior/group_behavior_methods.py
+++ b/irsim/lib/behavior/group_behavior_methods.py
@@ -1,8 +1,10 @@
+from math import cos, sin
 from typing import Any
 
 import numpy as np
 
 from irsim.lib.behavior.behavior_registry import register_group_behavior_class
+from irsim.util.util import omni_to_diff, relative_position
 from irsim.world.object_base import ObjectBase
 
 
@@ -14,9 +16,22 @@ def beh_omni_orca(members: list[ObjectBase], **kwargs: Any):
     return OrcaGroupBehavior(members, **kwargs)
 
 
+@register_group_behavior_class("diff", "orca")
+def beh_diff_orca(members: list[ObjectBase], **kwargs: Any):
+    """
+    Registered initializer returning a class-based ORCA handler for
+    differential-drive robots.
+    """
+    return OrcaGroupBehavior(members, **kwargs)
+
+
 class OrcaGroupBehavior:
     """
     Class-based ORCA group behavior with one-time initialization.
+
+    ORCA plans a collision-free holonomic velocity ``(vx, vy)`` for every
+    member. ``omni`` members use it directly; ``diff`` members map it to a
+    ``(linear, angular)`` command via :func:`omni_to_diff`.
     """
 
     def __init__(
@@ -36,6 +51,7 @@ class OrcaGroupBehavior:
         self._timeHorizonObst = timeHorizonObst
         self._safe_radius = safe_radius
         self._maxSpeed = maxSpeed
+        self._kinematics = members[0].kinematics if members else None
         self._sim = self._build_sim(members, **kwargs)
 
     def _ensure_pyrvo(self):
@@ -82,6 +98,37 @@ class OrcaGroupBehavior:
 
         return sim
 
+    def _pref_velocity(self, member: ObjectBase) -> list[float]:
+        """ORCA preferred velocity for one member as world-frame ``[vx, vy]``.
+
+        ``diff`` ``vel_max`` is ``[linear, angular]``, so the raw desired omni
+        velocity would skew the preferred direction toward the x-axis. Build it
+        from the true goal bearing scaled by the translational speed limit
+        instead; ``omni`` members keep using the desired omni velocity.
+        """
+        if self._kinematics == "diff":
+            if member.goal is None:
+                return [0.0, 0.0]
+            _, radian = relative_position(member.state, member.goal)
+            speed = member.max_speed
+            return [speed * cos(radian), speed * sin(radian)]
+        return member.get_desired_omni_vel(normalized=True).flatten().tolist()
+
+    def _to_action(self, member: ObjectBase, vel_xy: tuple[float, float]) -> np.ndarray:
+        """Convert an ORCA world-frame velocity into a member control input.
+
+        ``omni`` members consume ``(vx, vy)`` directly; ``diff`` members get the
+        holonomic velocity mapped to ``(linear, angular)``.
+        """
+        if self._kinematics == "diff":
+            return omni_to_diff(
+                member.state[2, 0],
+                [vel_xy[0], vel_xy[1]],
+                w_max=float(member.vel_max[1, 0]),
+                guarantee_time=member._world_param.step_time,
+            )
+        return np.c_[list(vel_xy)]
+
     def __call__(self, members: list[ObjectBase], **kwargs: Any) -> list[np.ndarray]:
         """
         Generate the velocity for the group.
@@ -100,14 +147,12 @@ class OrcaGroupBehavior:
             self._sim = self._build_sim(members, **kwargs)
 
         for i, member in enumerate(members):
-            self._sim.set_agent_pref_velocity(
-                i, member.get_desired_omni_vel(normalized=True).flatten().tolist()
-            )
+            self._sim.set_agent_pref_velocity(i, self._pref_velocity(member))
             self._sim.set_agent_position(i, member.state[:2, 0].tolist())
 
         self._sim.do_step()
 
         return [
-            np.c_[list(self._sim.get_agent_velocity(i).to_tuple())]
+            self._to_action(members[i], self._sim.get_agent_velocity(i).to_tuple())
             for i in range(self._sim.get_num_agents())
         ]

--- a/irsim/lib/behavior/group_behavior_methods.py
+++ b/irsim/lib/behavior/group_behavior_methods.py
@@ -139,6 +139,11 @@ class OrcaGroupBehavior:
             list[np.ndarray]: the velocities of the members
         """
 
+        # Keep the kinematics mapping in sync with the call-time members, in
+        # case the group was rebuilt or its members changed since __init__.
+        if members:
+            self._kinematics = members[0].kinematics
+
         # If agent count mismatches, rebuild
         try:
             if self._sim.get_num_agents() != len(members):

--- a/tests/test_coverage_extra.py
+++ b/tests/test_coverage_extra.py
@@ -869,9 +869,10 @@ class TestOrcaGroupBehaviorCoverage:
 
         from irsim.lib.behavior.behavior_registry import group_behaviors_class_map
 
-        key = ("omni", "orca")
-        if key in group_behaviors_class_map:
-            del group_behaviors_class_map[key]
+        # ORCA registers both omni and diff handlers; clear both so a fresh
+        # import doesn't trip the duplicate-registration guard.
+        for key in (("omni", "orca"), ("diff", "orca")):
+            group_behaviors_class_map.pop(key, None)
 
         # Also clear the module cache
         if "irsim.lib.behavior.group_behavior_methods" in sys.modules:
@@ -884,9 +885,8 @@ class TestOrcaGroupBehaviorCoverage:
         from irsim.lib.behavior.behavior_registry import group_behaviors_class_map
 
         # Clear registration if it exists (from mock import)
-        key = ("omni", "orca")
-        if key in group_behaviors_class_map:
-            del group_behaviors_class_map[key]
+        for key in (("omni", "orca"), ("diff", "orca")):
+            group_behaviors_class_map.pop(key, None)
 
         # Clear module cache
         if "irsim.lib.behavior.group_behavior_methods" in sys.modules:

--- a/tests/test_group_behavior.py
+++ b/tests/test_group_behavior.py
@@ -281,6 +281,36 @@ class TestOrcaGroupBehaviorCoverage:
         orca = OrcaGroupBehavior([member])
         assert orca._pref_velocity(member) == [0.0, 0.0]
 
+    def test_orca_call_refreshes_kinematics_from_members(self):
+        """__call__ re-reads kinematics from the call-time members, so a reused
+        or rebuilt handler maps the ORCA output for the current members."""
+        import pytest
+
+        pytest.importorskip("pyrvo")
+        from irsim.lib.behavior.group_behavior_methods import OrcaGroupBehavior
+
+        member = Mock(spec=ObjectBase)
+        member.kinematics = "diff"
+        member.state = np.array([[0.0], [0.0], [0.0]])
+        member.goal = np.array([[10.0], [0.0], [0.0]])
+        member.radius = 0.2
+        member.max_speed = 1.5
+        member.vel_max = np.array([[1.5], [1.0]])
+        member._world_param = Mock()
+        member._world_param.step_time = 0.1
+
+        orca = OrcaGroupBehavior([member])
+        # Simulate a stale cached kinematics (e.g. handler reused after the
+        # group's members changed); __call__ must correct it.
+        orca._kinematics = "omni"
+        result = orca([member])
+
+        assert orca._kinematics == "diff"
+        assert result[0].shape == (2, 1)
+        # diff mapping: aligned with the goal -> forward, no turn.
+        assert result[0][0, 0] == pytest.approx(1.5, abs=1e-6)
+        assert result[0][1, 0] == pytest.approx(0.0, abs=1e-6)
+
     def test_orca_diff_integration_via_make(self, tmp_path):
         """End-to-end: a diff + orca scenario dispatches to ``beh_diff_orca``
         through the registry and drives the robots toward their goals."""

--- a/tests/test_group_behavior.py
+++ b/tests/test_group_behavior.py
@@ -225,6 +225,97 @@ class TestOrcaGroupBehaviorCoverage:
         result = orca([member1, member2])
         assert len(result) == 2
 
+    def test_orca_diff_outputs_unicycle_velocity(self):
+        """diff ORCA maps the holonomic plan to (linear, angular)."""
+        import pytest
+
+        pytest.importorskip("pyrvo")
+        from irsim.lib.behavior.group_behavior_methods import OrcaGroupBehavior
+
+        def make_member(theta):
+            m = Mock(spec=ObjectBase)
+            m.kinematics = "diff"
+            m.state = np.array([[0.0], [0.0], [theta]])
+            m.goal = np.array([[10.0], [0.0], [0.0]])
+            m.radius = 0.2
+            m.max_speed = 1.5
+            m.vel_max = np.array([[1.5], [1.0]])
+            m._world_param = Mock()
+            m._world_param.step_time = 0.1
+            return m
+
+        # Single isolated robot already facing its goal: the holonomic plan
+        # passes straight through, so it drives forward with no turn.
+        facing = make_member(0.0)
+        orca = OrcaGroupBehavior([facing])
+        result = orca([facing])
+        assert len(result) == 1
+        assert result[0].shape == (2, 1)
+        assert result[0][0, 0] == pytest.approx(1.5, abs=1e-6)
+        assert result[0][1, 0] == pytest.approx(0.0, abs=1e-6)
+
+        # Robot facing away from its goal turns in place instead of reversing.
+        backward = make_member(np.pi)
+        orca = OrcaGroupBehavior([backward])
+        result = orca([backward])
+        assert result[0][0, 0] == pytest.approx(0.0, abs=1e-6)
+        assert abs(result[0][1, 0]) > 0.0
+
+    def test_orca_diff_zero_when_no_goal(self):
+        """diff preferred velocity is zero when a member has no goal."""
+        import pytest
+
+        pytest.importorskip("pyrvo")
+        from irsim.lib.behavior.group_behavior_methods import OrcaGroupBehavior
+
+        member = Mock(spec=ObjectBase)
+        member.kinematics = "diff"
+        member.state = np.array([[0.0], [0.0], [0.0]])
+        member.goal = None
+        member.radius = 0.2
+        member.max_speed = 1.5
+        member.vel_max = np.array([[1.5], [1.0]])
+        member._world_param = Mock()
+        member._world_param.step_time = 0.1
+
+        orca = OrcaGroupBehavior([member])
+        assert orca._pref_velocity(member) == [0.0, 0.0]
+
+    def test_orca_diff_integration_via_make(self, tmp_path):
+        """End-to-end: a diff + orca scenario dispatches to ``beh_diff_orca``
+        through the registry and drives the robots toward their goals."""
+        import pytest
+
+        pytest.importorskip("pyrvo")
+        import irsim
+
+        config = tmp_path / "orca_diff.yaml"
+        config.write_text(
+            "world:\n"
+            "  height: 20\n"
+            "  width: 20\n"
+            "  step_time: 0.1\n"
+            "robot:\n"
+            "  - number: 3\n"
+            "    kinematics: {name: 'diff'}\n"
+            "    shape: {name: 'circle', radius: 0.3}\n"
+            "    distribution: {name: 'circle', radius: 5}\n"
+            "    vel_max: [2, 1.5]\n"
+            "    group_behavior: {name: 'orca', neighborDist: 8.0, safe_radius: 0.2}\n"
+        )
+
+        env = irsim.make(str(config), display=False, save_ani=False)
+        try:
+            start = np.array([r.state[:2, 0] for r in env.robot_list])
+            for _ in range(30):
+                env.step()
+            end = np.array([r.state[:2, 0] for r in env.robot_list])
+        finally:
+            env.end()
+
+        # ORCA produced non-zero diff velocities, so the robots moved.
+        assert np.linalg.norm(end - start, axis=1).max() > 0.1
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/usage/19orca_world/orca_diff_world.py
+++ b/usage/19orca_world/orca_diff_world.py
@@ -1,0 +1,12 @@
+import irsim
+
+env = irsim.make("orca_diff_world.yaml", save_ani=False, display=True)
+
+for _i in range(1000):
+    env.step()
+    env.render()
+
+    if env.done():
+        break
+
+env.end()

--- a/usage/19orca_world/orca_diff_world.yaml
+++ b/usage/19orca_world/orca_diff_world.yaml
@@ -1,0 +1,30 @@
+world:
+  height: 50
+  width: 50
+  step_time: 0.1
+  sample_time: 0.1
+  offset: [-25, -25]
+
+robot:
+  - number: 20
+    kinematics: {name: 'diff'}
+    shape: {name: 'circle', radius: 0.5}
+    distribution: {name: 'random', range_low: [-20, -20, -3.14], range_high: [20, 20, 3.14]}
+    color: 'g'
+    goal_threshold: 0.2
+    vel_max: [3, 2]
+    vel_min: [-3, -2]
+    plot:
+      show_trajectory: True
+      show_goal: True
+      keep_traj_length: 50
+    group_behavior:
+      name: 'orca'
+      neighborDist: 10.0
+      maxNeighbors: 10
+      timeHorizon: 5.0
+      timeHorizonObst: 5.0
+      safe_radius: 0.2
+      wander: True
+      range_low: [-20, -20, -3.14]
+      range_high: [20, 20, 3.14]


### PR DESCRIPTION
## Summary

ORCA was only available for `omni` robots. This adds `orca` group-behavior support for `diff` (differential-drive) robots.

ORCA plans a collision-free holonomic velocity `(vx, vy)` for every agent. For `diff` members this is now mapped to a `(linear, angular)` command via `omni_to_diff`, and the ORCA preferred velocity is built from the true goal bearing scaled by the translational speed limit (so the direction isn't skewed by the angular component of `diff` `vel_max`). The same `OrcaGroupBehavior` class handles both kinematics — `omni` output is byte-for-byte unchanged.

## Changes

- Register `("diff", "orca")` on `OrcaGroupBehavior`; add kinematics-aware `_pref_velocity` / `_to_action` helpers.
- New example `usage/19orca_world/orca_diff_world.{yaml,py}` (random + wander, continuous flow).
- Tests: 4 unit + 1 end-to-end (`irsim.make` → registry → `beh_diff_orca`). The reload-based ORCA coverage test now clears both the omni and diff registry keys.
- Bilingual docs (en `configure_behavior.md` + zh_CN `.po`).

## Testing

- Full suite: **858 passed, 1 skipped**.
- `ruff check` + `ruff format --check`: clean.
- Headless run of the new scenario: collision-free (min center distance > contact diameter), robots flow continuously.