### PR TITLE
fix: keep circle center consistent across collision, render, G/h, and RVO

### DIFF
--- a/docs/source/yaml_config/configuration.md
+++ b/docs/source/yaml_config/configuration.md
@@ -1034,7 +1034,7 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
 
   - **`'circle'`**: Represents a circular shape.
     - **`radius`** (`float`): Radius of the circle. Default is `0.2`.
-    - **`center`** (`list`): Center (x, y) of the circle. Default is `[0, 0]`.
+    - **`center`** (`list`): Body-frame `[x, y]` offset of the circle center. It rotates with the object's heading. Default is `[0, 0]`. For an Ackermann circle, the effective center is additionally shifted forward by `wheelbase / 2`.
     - **`random_shape`** (`bool`): Whether to generate a random radius. Default is `False`.
     - **`radius_range`** (`list`): Range `[min_radius, max_radius]` for random radius generation if `random_shape` is `True`. Default is `[0.1, 1.0]`.
     - **`wheelbase`** (`float`): Wheelbase of the Ackermann steering vehicle. Required when using `'acker'` kinematics. Default is `None`.

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -782,7 +782,8 @@ def draw_patch(
     Draw a geometric element (patch or line) on the given axes.
 
     Supported shapes and expected inputs (refer to irsim.world.object_base plotting patterns):
-    - circle: use ``state`` (x,y,theta) and ``radius``; created at origin and transformed
+    - circle: use ``state`` (x,y,theta), ``radius``, and optional ``center`` (body-frame
+      offset); created in the body frame and transformed, matching the collision geometry
     - rectangle: prefer ``vertices`` (2xN) else use ``width``/``height`` with ``state`` transform
     - polygon: use ``vertices`` (2xN)
     - ellipse: use ``width``/``height`` with ``state`` transform
@@ -803,6 +804,7 @@ def draw_patch(
     edgecolor = kwargs.pop("edgecolor", None)
     alpha = kwargs.pop("alpha", None)
     fill = kwargs.pop("fill", None)
+    center = kwargs.pop("center", None)
 
     state = state if state is not None else np.zeros((3, 1))
 
@@ -812,8 +814,14 @@ def draw_patch(
             raise ValueError("circle requires radius")
 
         use_radius = radius
-        # Create at origin; translate/rotate with transform
-        patch = Circle((0.0, 0.0), use_radius)
+        
+        if center is None:
+            xy = (0.0, 0.0)
+        else:
+            c = np.asarray(center, dtype=float).flatten()
+            xy = (c[0], c[1])
+        # Create at the body-frame center; translate/rotate with transform
+        patch = Circle(xy, use_radius)
         created_element = ax.add_patch(patch)
         set_patch_property(
             created_element,

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -814,7 +814,7 @@ def draw_patch(
             raise ValueError("circle requires radius")
 
         use_radius = radius
-        
+
         if center is None:
             xy = (0.0, 0.0)
         else:

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -782,6 +782,7 @@ def draw_patch(
     Draw a geometric element (patch or line) on the given axes.
 
     Supported shapes and expected inputs (refer to irsim.world.object_base plotting patterns):
+
     - circle: use ``state`` (x,y,theta), ``radius``, and optional ``center`` (body-frame
       offset); created in the body frame and transformed, matching the collision geometry
     - rectangle: prefer ``vertices`` (2xN) else use ``width``/``height`` with ``state`` transform
@@ -792,6 +793,7 @@ def draw_patch(
     - line|linestring: use ``vertices`` (2xN) to draw a line element
 
     Styling:
+
     - color/edgecolor/facecolor, alpha, zorder, linestyle are respected when applicable.
 
     Returns the created matplotlib artist (patch, line, or list from ax.plot).

--- a/irsim/lib/algorithm/rvo.py
+++ b/irsim/lib/algorithm/rvo.py
@@ -217,6 +217,11 @@ class reciprocal_vel_obs:
 
         ratio = (r + mr) / dis_mr
 
+        if ratio > 1:
+            ratio = 1
+        if ratio < -1:
+            ratio = -1
+
         half_angle = asin(ratio)
         line_left_ori = angle_mr + half_angle
         line_right_ori = angle_mr - half_angle

--- a/irsim/lib/handler/geometry_handler.py
+++ b/irsim/lib/handler/geometry_handler.py
@@ -78,8 +78,9 @@ class geometry_handler(ABC):
         """
 
         if self.name == "circle":
+            # The circle may be offset from the body origin (center/wheelbase).
             G = np.array([[1, 0], [0, 1], [0, 0]])
-            h = np.array([[0], [0], [-self.radius]])
+            h = np.vstack((self.original_centroid, [[-self.radius]]))
             cone_type = "norm2"
             convex_flag = True
 

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -1637,6 +1637,9 @@ class ObjectBase:
                         shape=self.shape,
                         state=state,
                         radius=self.radius,
+                        center=(
+                            self.original_centroid if self.shape == "circle" else None
+                        ),
                         vertices=vertices,
                         color=self.color,
                         linestyle=obj_linestyle,
@@ -1983,6 +1986,7 @@ class ObjectBase:
             state=state,
             vertices=vertices,
             radius=self.radius,
+            center=(self.original_centroid if trail_type == "circle" else None),
             width=self.length,
             height=self.width,
             edgecolor=trail_edgecolor,
@@ -2188,7 +2192,7 @@ class ObjectBase:
             tuple[np.ndarray, np.ndarray]: Tuple containing G matrix and h vector.
         """
         return self.gf.get_Gh(
-            center=self.position, radius=self.radius, vertices=self.vertices
+            center=self.centroid, radius=self.radius, vertices=self.vertices
         )
 
     def get_desired_omni_vel(self, goal_threshold=0.1, normalized=False) -> np.ndarray:
@@ -2661,15 +2665,17 @@ class ObjectBase:
         Get the RVO state for this object.
 
         Returns:
-            list: State [x, y, vx, vy, radius].
+            list: State [x, y, vx, vy, radius], with (x, y) at the geometry
+            centroid so the disc covers the collision geometry.
         """
         cached = getattr(self, "_rvo_neighbor_state_cache", None)
         if cached is not None:
             return cached
         vxy = self.velocity_xy
+        centroid = self.centroid
         out = [
-            self.state[0, 0],
-            self.state[1, 0],
+            centroid[0, 0],
+            centroid[1, 0],
             vxy[0, 0],
             vxy[1, 0],
             self.radius_extend,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,31 @@ YAML_CONFIGS = {
 }
 
 
+CIRCLE_CENTER_WORLD_YAML = """
+world:
+  height: 10
+  width: 10
+  step_time: 0.1
+
+obstacle:
+  - shape: {name: 'circle', radius: 1.0, center: [1, 1]}
+    state: [5, 5, 0]
+
+  - shape: {name: 'circle', radius: 0.5, center: [1, 0]}
+    state: [5, 5, 1.57]
+"""
+
+
+@pytest.fixture
+def circle_center_world(tmp_path):
+    """World with circle obstacles offset by a body-frame ``center``:
+    one translated only, one rotated. Used by the render/collision and
+    G-h/RVO consistency tests."""
+    path = tmp_path / "circle_center_world.yaml"
+    path.write_text(CIRCLE_CENTER_WORLD_YAML)
+    return str(path)
+
+
 # ---------------------------------------------------------------------------
 # Keyboard mock helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -7,6 +7,7 @@ Covers GeometryFactory and various geometry types.
 import numpy as np
 import pytest
 
+import irsim
 from irsim.lib.handler.geometry_handler import GeometryFactory
 
 
@@ -405,3 +406,42 @@ class TestPointsGeometry:
         points = np.array([[0.0], [0.0]])
         pg = PointsGeometry(points=points, reso=np.array([[0.2], [0.3]]))
         assert pg.geometry is not None
+
+
+class TestCircleCenterConsistency:
+    """Circles with a body-frame center offset: the G/h cone constraints and
+    the RVO neighbor disc must sit on the same circle the collision geometry
+    uses, for both a translated and a rotated object state."""
+
+    def test_circle_gh_matches_collision_geometry(self, circle_center_world):
+        env = irsim.make(circle_center_world, display=False)
+
+        for obj in env.obstacle_list:
+            # Body frame: init G/h must encode the body-frame circle center.
+            _, h0, cone_type, convex = obj.get_init_Gh()
+            assert cone_type == "norm2"
+            assert convex
+            np.testing.assert_allclose(
+                h0[:2, 0], obj.original_centroid.flatten(), atol=1e-9
+            )
+            np.testing.assert_allclose(h0[2, 0], -obj.radius, atol=1e-9)
+
+            # World frame: the G/h center must be the collision centroid.
+            _, h, _, _ = obj.get_Gh()
+            np.testing.assert_allclose(
+                h[:2, 0], np.array(obj.geometry.centroid.coords[0]), atol=1e-6
+            )
+
+        env.end()
+
+    def test_rvo_neighbor_disc_matches_collision_geometry(self, circle_center_world):
+        env = irsim.make(circle_center_world, display=False)
+
+        for obj in env.obstacle_list:
+            x, y, _, _, r = obj.rvo_neighbor_state
+            np.testing.assert_allclose(
+                [x, y], np.array(obj.geometry.centroid.coords[0]), atol=1e-6
+            )
+            assert r >= obj.radius
+
+        env.end()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+import irsim
 import irsim.env.env_plot as env_plot_module
 from irsim.env.env_plot import EnvPlot, draw_patch
 from irsim.env.env_plot3d import EnvPlot3D
@@ -730,3 +731,40 @@ class TestSaveAnimate:
             env_plot_module.imageio.imread = original_imread
 
         assert not buffer_dir.exists()
+
+
+class TestCircleCenterRender:
+    """Circles with a body-frame center offset must render on their collision
+    geometry, for both translated and rotated object states."""
+
+    @staticmethod
+    def _patch_center_in_data_coords(patch, ax):
+        """Map a Circle patch's center to data coords.
+
+        ``Circle.get_transform()`` maps unit-circle space to display space and
+        already includes the patch's own center, so the center is the image of
+        the unit-space origin.
+        """
+        display = patch.get_transform().transform((0.0, 0.0))
+        return ax.transData.inverted().transform(display)
+
+    def test_circle_center_offset_render_matches_collision(self, circle_center_world):
+        env = irsim.make(circle_center_world, display=False)
+        env.render()
+
+        ax = env._env_plot.ax
+        for obj in env.obstacle_list:
+            rendered = self._patch_center_in_data_coords(obj.object_patch, ax)
+            collision = np.array(obj.geometry.centroid.coords[0])
+            np.testing.assert_allclose(rendered, collision, atol=1e-6)
+
+        # Translated only: state (5, 5, 0) with center [1, 1] -> world (6, 6).
+        first = np.array(env.obstacle_list[0].geometry.centroid.coords[0])
+        np.testing.assert_allclose(first, [6.0, 6.0], atol=1e-6)
+
+        # Rotated: state (5, 5, 1.57) with center [1, 0] -> (5 + cos, 5 + sin).
+        second = np.array(env.obstacle_list[1].geometry.centroid.coords[0])
+        expected = [5.0 + np.cos(1.57), 5.0 + np.sin(1.57)]
+        np.testing.assert_allclose(second, expected, atol=1e-6)
+
+        env.end()

--- a/tests/test_rvo_line_obstacles.py
+++ b/tests/test_rvo_line_obstacles.py
@@ -439,3 +439,32 @@ class TestRVOLineSegmentsProperty:
         assert len(segments) == 2
         assert segments[0] == [0, 0, 1, 1]
         assert segments[1] == [1, 1, 2, 0]
+
+
+# ===================================================================
+# reciprocal_vel_obs — cal_vel robustness
+# ===================================================================
+
+
+class TestCalVelRobustness:
+    """cal_vel must return finite velocities for every vo mode whether the
+    ego is moving or momentarily stationary.
+
+    Regression: a stationary ego parses neighbors via the "sta_circular"
+    branch, which reads the neighbor tuple's third element as a radius; a
+    fast negative neighbor velocity produced ratio < -1 and an asin domain
+    error in hrvo, the one mode variant missing the ratio clamp.
+    """
+
+    def test_cal_vel_finite_for_all_modes_and_egos(self):
+        stationary_ego = _agent_state(x=5.0, y=5.0)
+        moving_ego = _agent_state(x=5.0, y=5.0, vx=0.5, vy=0.1)
+        fast_neighbor = [6.3, 5.2, -2.9, 0.3, 0.3]  # vx once drove ratio < -1
+        static_neighbor = [6.3, 5.2, 0.0, 0.0, 0.3]
+
+        for ego in (stationary_ego, moving_ego):
+            for neighbor in (fast_neighbor, static_neighbor):
+                rvo = reciprocal_vel_obs(ego, [neighbor])
+                for mode in ("rvo", "hrvo", "vo"):
+                    vel = rvo.cal_vel(mode)
+                    assert np.all(np.isfinite(vel))

--- a/tests/test_sfm.py
+++ b/tests/test_sfm.py
@@ -703,8 +703,8 @@ class TestReactiveStateCache:
         assert after_state is not first
         assert nb_after_state is not nb_first
         # x coordinate of the cached neighbour state must reflect the
-        # new pose, not the old one.
-        assert nb_after_state[0] == 5.0
+        # new pose, not the old one (centroid-based, so approximate).
+        assert nb_after_state[0] == pytest.approx(5.0)
 
         # Mutate velocity externally — caches must drop again.
         primed_vxy = robot.velocity_xy
@@ -751,7 +751,7 @@ class TestReactiveStateCache:
         # reset() must drop the cached velocity/neighbour-state.
         post_reset_nb = robot.rvo_neighbor_state
         assert post_reset_nb is not primed_nb
-        assert post_reset_nb[0] == 1.0  # back to initial x
+        assert post_reset_nb[0] == pytest.approx(1.0)  # back to initial x
         # velocity_xy was also invalidated; new lookup recomputes.
         assert robot.velocity_xy is not primed
         env.end(suppress_summary=True)


### PR DESCRIPTION
## Summary

A circle shape can define a body-frame `center` offset. The collision geometry applies this offset. Other parts did not. They treated the circle as centered at the object state. So the drawn circle, the convex constraints, and the collision avoidance disc could sit at a different place than the real collision circle.

This PR makes all representations follow the collision geometry:

- Render: the matplotlib patch is created at the body-frame center. The drawn circle now matches the collision circle. Trails are fixed in the same way.
- `get_init_Gh`: the `h` vector now encodes the body-frame center.
- `get_Gh`: the world-frame center now comes from the geometry centroid.
- `rvo_neighbor_state`: the neighbor disc now sits at the geometry centroid.

Acker robots with a circle shape are also affected, because `wheelbase / 2` shifts the circle center.

Configs with the default `center: [0, 0]` keep the same behavior.

## hrvo clamp

`config_rvo_mode` and `config_vo_mode` clamp the ratio before `asin`. `config_hrvo_mode` missed this clamp. A stationary ego with a fast neighbor could raise `ValueError: math domain error`. The clamp is added.

## Tests

- Render vs collision test in `test_plot.py`.
- G/h and RVO disc consistency tests in `test_geometry.py`.
- `cal_vel` robustness test in `test_rvo_line_obstacles.py`.
- The test world is an inline fixture in `conftest.py`.
- Two exact float asserts in `test_sfm.py` are relaxed to `pytest.approx`, because the centroid has floating point noise.

All 886 tests pass. `ruff check` and `ruff format` are clean.