### PR TITLE
refactor(plot): extract object rendering and encapsulate options

### DIFF
--- a/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
@@ -2361,9 +2361,11 @@ msgstr "`obj_linestyle`（str）：对象轮廓线型（如 '-', '--', ':', '-.'
 
 #: ../../source/yaml_config/configuration.md:1348
 msgid ""
-"`obj_zorder` (int/`3`): Z-order (drawing layer) for object elements. Default"
-" is 3 for robots, 1 for obstacles."
-msgstr "`obj_zorder`（int）：对象元素的绘制层级，机器人默认 3、障碍物默认 1。"
+"`obj_zorder` (int): Z-order (drawing layer) for object elements. Default is "
+"3 for robot patches, 1 for obstacle patches, and 2 for description images."
+msgstr ""
+"`obj_zorder`（int）：对象元素的绘制层级。机器人图形默认 3，障碍物图形默认 1，"
+"描述图片默认 2。"
 
 #: ../../source/yaml_config/configuration.md:1349
 msgid ""
@@ -2376,10 +2378,8 @@ msgid "`obj_alpha` (float/`1.0`): Transparency of the object (0.0 to 1.0)."
 msgstr "`obj_alpha`（float）：对象透明度（0.0-1.0），默认 1.0。"
 
 #: ../../source/yaml_config/configuration.md:1351
-msgid ""
-"`obj_linewidth` (float/`None`): Width of the object outline. Default varies "
-"by object type."
-msgstr "`obj_linewidth`（float）：轮廓线宽，默认随对象类型而定。"
+msgid "`obj_linewidth` (float/`1.0`): Width of the object outline in Matplotlib points."
+msgstr "`obj_linewidth`（float/`1.0`）：对象轮廓线宽，单位为 Matplotlib 点。"
 
 #: ../../source/yaml_config/configuration.md:1353
 msgid "**Goal Visualization:**"
@@ -2475,8 +2475,8 @@ msgid "`arrow_alpha` (float/`1.0`): Transparency of the arrow (0.0 to 1.0)."
 msgstr "`arrow_alpha`（float）：箭头透明度，默认 1.0。"
 
 #: ../../source/yaml_config/configuration.md:1376
-msgid "`arrow_zorder` (int/`4`): Z-order of the arrow."
-msgstr "`arrow_zorder`（int）：箭头层级，默认 4。"
+msgid "`arrow_zorder` (int/`3`): Z-order of the arrow."
+msgstr "`arrow_zorder`（int/`3`）：箭头的绘制层级。"
 
 #: ../../source/yaml_config/configuration.md:1378
 msgid "**Trajectory Path Visualization:**"
@@ -2499,9 +2499,9 @@ msgstr "`traj_style`（str）：路径线型（如 '-', '--', ':', '-.'），默
 
 #: ../../source/yaml_config/configuration.md:1382
 msgid ""
-"`traj_width` (float/`None`): Width of the trajectory line. Default is the "
-"object's width."
-msgstr "`traj_width`（float）：路径线宽，默认为对象宽度。"
+"`traj_width` (float/object width): Width of the trajectory line. Default is "
+"the object's width."
+msgstr "`traj_width`（float/对象宽度）：轨迹线宽，默认为对象宽度。"
 
 #: ../../source/yaml_config/configuration.md:1383
 msgid ""

--- a/docs/source/yaml_config/configuration.md
+++ b/docs/source/yaml_config/configuration.md
@@ -291,8 +291,8 @@ A complete IR-SIM scene is described by up to four top-level keys: `world`, `rob
           <div class="yt-leaf"><a class="yt-key" href="#p-o-plot">obj_color</a><span class="yt-type yt-t-str"><b class="yt-pill">str</b></span><span class="yt-def">object's color</span><span class="yt-desc">outline / fill colour</span></div>
           <div class="yt-leaf"><a class="yt-key" href="#p-o-plot">obj_alpha</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">1.0</span><span class="yt-desc">transparency 0–1</span></div>
           <div class="yt-leaf"><a class="yt-key" href="#p-o-plot">obj_linestyle</a><span class="yt-type yt-t-str"><b class="yt-pill">str</b></span><span class="yt-def">"-"</span><span class="yt-desc">outline line style</span></div>
-          <div class="yt-leaf"><a class="yt-key" href="#p-o-plot">obj_linewidth</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">object's width</span></div>
-          <div class="yt-leaf"><a class="yt-key" href="#p-o-plot">obj_zorder</a><span class="yt-type yt-t-num"><b class="yt-pill">int</b></span><span class="yt-def">3 / 1</span><span class="yt-desc">draw order (robot / obstacle)</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-plot">obj_linewidth</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">1.0</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-plot">obj_zorder</a><span class="yt-type yt-t-num"><b class="yt-pill">int</b></span><span class="yt-def">3 / 1; image 2</span><span class="yt-desc">draw order (robot / obstacle / image)</span></div>
         </div>
         <div class="yt-utabpanel">
           <input type="checkbox" class="yt-gate" id="yt-g-goal">
@@ -1361,10 +1361,10 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
 
   **Object Visualization Properties:**
   - `obj_linestyle` (str/`'-'`): Line style for object outline (e.g., '-', '--', ':', '-.').
-  - `obj_zorder` (int/`3`): Z-order (drawing layer) for object elements. Default is 3 for robots, 1 for obstacles.
+  - `obj_zorder` (int): Z-order (drawing layer) for object elements. Default is 3 for robot patches, 1 for obstacle patches, and 2 for description images.
   - `obj_color` (str): Color of the object. Default is the object's color property.
   - `obj_alpha` (float/`1.0`): Transparency of the object (0.0 to 1.0).
-  - `obj_linewidth` (float/`None`): Width of the object outline. Default varies by object type.
+  - `obj_linewidth` (float/`1.0`): Width of the object outline in Matplotlib points.
 
   **Goal Visualization:**
   - `show_goal` (bool/`False`): Whether to show the goal position.
@@ -1389,13 +1389,13 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
     - `arrow_length` (float/`0.4`): Length of the arrow.
     - `arrow_width` (float/`0.6`): Width of the arrow.
     - `arrow_alpha` (float/`1.0`): Transparency of the arrow (0.0 to 1.0).
-    - `arrow_zorder` (int/`4`): Z-order of the arrow.
+    - `arrow_zorder` (int/`3`): Z-order of the arrow.
 
   **Trajectory Path Visualization:**
   - `show_trajectory` (bool/`False`): Whether to show the trajectory line.
     - `traj_color` (str): Color of the trajectory. Default is the object's color.
     - `traj_style` (str): Line style of the trajectory (e.g., '-', '--', ':', '-.'). Default is "-".
-    - `traj_width` (float/`None`): Width of the trajectory line. Default is the object's width.
+    - `traj_width` (float/object width): Width of the trajectory line. Default is the object's width.
     - `traj_alpha` (float/`0.5`): Transparency of the trajectory (0.0 to 1.0).
     - `traj_zorder` (int/`0`): Z-order for trajectory elements.
     - `keep_traj_length` (int/`0`): Number of steps to keep from the end of trajectory. Default is 0 (keep all steps).

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -1136,7 +1136,7 @@ class ObjectBase:
         **kwargs: Any,
     ) -> list[str]:
         """Create this object's configured Matplotlib artists."""
-        return self._object_plot._plot(ax, state, vertices, initial=initial, **kwargs)
+        return self._object_plot.draw(ax, state, vertices, initial=initial, **kwargs)
 
     def _step_plot(self, **kwargs: Any) -> None:
         """Update this object's Matplotlib artists."""

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -5,29 +5,23 @@ from dataclasses import dataclass
 from math import cos, pi, sin
 from typing import Any, ClassVar
 
-import matplotlib.transforms as mtransforms
 import numpy as np
 import shapely
-from matplotlib import image
-from matplotlib.patches import Arrow, Circle, Wedge
-from mpl_toolkits.mplot3d import Axes3D
 from shapely.geometry.base import BaseGeometry
 
-from irsim.config.path_param import path_manager
-from irsim.env.env_plot import draw_patch, linewidth_from_data_units, set_patch_property
 from irsim.lib import Behavior, GeometryFactory, KinematicsFactory
 from irsim.util.util import (
     WrapTo2Pi,
     WrapToPi,
     WrapToRegion,
     check_unknown_kwargs,
-    file_check,
     is_2d_list,
     random_point_range,
     relative_position,
     to_numpy,
     vertices_transform,
 )
+from irsim.world.object_plot import ObjectPlot
 from irsim.world.sensors.sensor_factory import SensorFactory
 
 
@@ -456,6 +450,7 @@ class ObjectBase:
         self._custom_goal_text: str | None = None
         self.collision_obj = []
         self.plot_trail_list = []
+        self._object_plot = ObjectPlot(self)
 
         # --- 13. Validate kwargs ---
         check_unknown_kwargs(kwargs, self._VALID_PARAMS, context=f" in '{role}' config")
@@ -1120,781 +1115,97 @@ class ObjectBase:
 
     def plot(
         self,
-        ax,
+        ax: Any,
         state: np.ndarray | None = None,
         vertices: np.ndarray | None = None,
-        **kwargs,
-    ):
-        """
-        Plot the object on the given axis.
-
-        Args:
-            ax: Matplotlib axis object for plotting.
-            state: State vector [x, y, theta, ...] defining object position and orientation.
-            vertices: Vertices array defining object shape for polygon/rectangle objects.
-            **kwargs: Plotting configuration options.
-        """
-
-        if state is None:
-            state = self.state
-        if vertices is None:
-            vertices = self.vertices
-
-        self._plot(ax, state, vertices, **kwargs)
-
-    def _init_plot(self, ax, **kwargs):
-        """
-        Initialize plotting elements using zero state and initial vertices.
-
-        Returns:
-            list: Names of plot attributes created (e.g., 'object_patch', 'goal_patch').
-        """
-        # Apply handler-derived show_arrow default only when the object is
-        # dynamic (has a kinematics handler and is not flagged static).
-        # Static objects: YAML obstacles without `kinematics:`, kf=None
-        # robots, anything routed through ObjectStatic; default to no arrow.
-        if (
-            self.kf is not None
-            and not self.static
-            and "show_arrow" not in self.plot_kwargs
-            and "show_arrow" not in kwargs
-        ):
-            kwargs.setdefault("show_arrow", self.kf.show_arrow)
-        return self._plot(
-            ax, self.original_state, self.original_vertices, initial=True, **kwargs
-        )
-
-    def _plot(self, ax, state, vertices, initial: bool = False, **kwargs):
-        """
-        Plot the object with the specified state and vertices.
-
-        Args:
-            ax: Matplotlib axis object for plotting.
-            state: State vector [x, y, theta, ...] defining object position and orientation.
-            vertices: Vertices array defining object shape for polygon/rectangle objects.
-            initial: Whether the plot is for the initial state. Defaults to False.
-            **kwargs: Plotting configuration options:
-
-            Object visualization properties:
-                - obj_linestyle (str): Line style for object outline (e.g., '-', '--', ':', '-.').
-                - obj_zorder (int): Z-order (drawing layer) for object elements; defaults to 3 for robots, 1 for obstacles.
-                - obj_color (str): Color of the object.
-                - obj_alpha (float): Transparency of the object (0.0 to 1.0).
-
-                - show_goal (bool): Whether to show the goal position. Defaults to False.
-                    - goal_color (str): Color of the goal marker. Defaults to object color.
-                    - goal_zorder (int): Z-order of the goal marker. Defaults to 1.
-                    - goal_alpha (float): Transparency of the goal marker. Defaults to 0.5.
-                - show_text (bool): Whether to show text information. Defaults to False.
-                    - text_color (str): Color of the text. Defaults to 'k'.
-                    - text_size (int): Font size of the text. Defaults to 10.
-                    - text_zorder (int): Z-order of the text. Defaults to 2.
-                - show_arrow (bool): Whether to show the velocity arrow. Defaults to False.
-                    - arrow_color (str): Color of the arrow. Defaults to "gold".
-                    - arrow_length (float): Length of the arrow. Defaults to 0.4.
-                    - arrow_width (float): Width of the arrow. Defaults to 0.6.
-                    - arrow_zorder (int): Z-order of the arrow. Defaults to 4.
-                - show_trajectory (bool): Whether to show the trajectory line. Defaults to False.
-                    - traj_color (str): Color of the trajectory. Defaults to object color.
-                    - traj_style (str): Line style of the trajectory. Defaults to "-".
-                    - traj_width (float): Width of the trajectory line. Defaults to object width.
-                    - traj_alpha (float): Transparency of the trajectory. Defaults to 0.5.
-                - show_trail (bool): Whether to show object trails. Defaults to False.
-                    - trail_freq (int): Frequency of trail display (every N steps). Defaults to 2.
-                    - trail_edgecolor (str): Edge color of the trail. Defaults to object color.
-                    - trail_linewidth (float): Width of the trail outline. Defaults to 0.8.
-                    - trail_alpha (float): Transparency of the trail. Defaults to 0.7.
-                    - trail_fill (bool): Whether to fill the trail shape. Defaults to False.
-                    - trail_color (str): Fill color of the trail. Defaults to object color.
-                - show_sensor (bool): Whether to show sensor visualizations. Defaults to True.
-                - show_fov (bool): Whether to show field of view visualization. Defaults to False.
-                    - fov_color (str): Fill color of the field of view. Defaults to "lightblue".
-                    - fov_edge_color (str): Edge color of the field of view. Defaults to "blue".
-                    - fov_zorder (int): Z-order of the field of view. Defaults to 1.
-                    - fov_alpha (float): Transparency of the field of view. Defaults to 0.5.
-
-        Creates and stores the following plot elements:
-            - object_patch: Main object visualization (patch)
-            - object_line: Object outline for linestring shapes (line)
-            - object_img: Object image for description-based visualization
-            - goal_patch: Goal position marker (patch)
-            - _text: Object text label
-            - _goal_text: Goal text label
-            - arrow_patch: Velocity direction arrow (patch)
-            - trajectory_line: Trajectory path visualization (line)
-            - fov_patch: Field of view visualization (patch)
-
-        Returns:
-            list: List of plot attribute names that were created.
-        """
-
-        self.plot_attr_list = [
-            "object_patch",
-            "object_line",
-            "object_img",
-            "goal_patch",
-            "_text",
-            "_goal_text",
-            "arrow_patch",
-            "trajectory_line",
-            "fov_patch",
-        ]
-
-        self.plot_kwargs.update(kwargs)
-        self.ax = ax
-
-        self.show_goal = self.plot_kwargs.get("show_goal", False)
-        self.show_goal_text = self.plot_kwargs.get("show_goal_text", False)
-        self.show_goals = self.plot_kwargs.get("show_goals", False)
-        show_text = self.plot_kwargs.get("show_text", False)
-        show_arrow = self.plot_kwargs.get("show_arrow", False)
-        show_trajectory = self.plot_kwargs.get("show_trajectory", False)
-        self.show_trail = self.plot_kwargs.get("show_trail", False)
-        self.show_sensor = self.plot_kwargs.get("show_sensor", True)
-        show_fov = self.plot_kwargs.get("show_fov", False)
-
-        self.trail_freq = self.plot_kwargs.get("trail_freq", 2)
-
-        if self.shape != "map":
-            self.plot_object(ax, state, vertices, **self.plot_kwargs)
-
-        if self.show_goal:
-            goal_state = state if initial else self.goal
-            goal_vertices = vertices if initial else self.goal_vertices
-            self.plot_goal(ax, goal_state, goal_vertices, **self.plot_kwargs)
-
-        if show_text:
-            self.plot_text(ax, state, **self.plot_kwargs)
-
-        if show_arrow:
-            current_velocity = self.velocity_xy if np.any(state) else np.zeros((2, 1))
-            arrow_theta = 0.0 if initial else self.heading
-            self.plot_arrow(
-                ax, state, current_velocity, arrow_theta, **self.plot_kwargs
-            )
-
-        if show_trajectory:
-            trajectory_data = self.trajectory if np.any(state) else []
-            self.plot_trajectory(ax, trajectory_data, **self.plot_kwargs)
-
-        if (
-            self.show_trail
-            and self._world_param.count % self.trail_freq == 0
-            and self._world_param.count > 0
-        ):
-            self.plot_trail(ax, state, self.vertices, **self.plot_kwargs)
-
-        if self.show_sensor:
-            [sensor.plot(ax, state, **self.plot_kwargs) for sensor in self.sensors]
-
-        if show_fov:
-            self.plot_fov(ax, **self.plot_kwargs)
-
-        return self.plot_attr_list
-
-    def _step_plot(self, **kwargs):
-        """
-        Update the positions and properties of all plot elements created in _init_plot.
-        Elements are updated using transforms for patches and set_data/set_data_3d for lines,
-        based on the object's current state, in both 2D and 3D.
-
-        Update methods by element type:
-        - Patches (object_patch, goal_patch, arrow_patch, fov_patch): Updated using matplotlib transforms
-        - Lines (object_line, trajectory_line): Updated using set_data method
-        - Text (_text): Updated using set_position method
-        - Images (object_img): Updated using extent and transform methods
-
-        Args:
-            **kwargs: Dynamic plotting properties to update during rendering:
-
-                Object visualization properties:
-                - obj_linestyle (str): Line style for object outline (e.g., '-', '--', ':', '-.').
-                - obj_zorder (int): Z-order (drawing layer) for object elements.
-                - obj_color (str): Color of the object.
-                - obj_alpha (float): Transparency of the object (0.0 to 1.0).
-
-                Goal visualization properties:
-                - goal_color (str): Color of the goal marker.
-                - goal_alpha (float): Transparency of the goal marker.
-                - goal_zorder (int): Z-order for goal elements.
-
-                Arrow visualization properties:
-                - arrow_color (str): Color of the velocity arrow.
-                - arrow_alpha (float): Transparency of the arrow.
-                - arrow_zorder (int): Z-order for arrow elements.
-
-                Trajectory visualization properties:
-                - traj_color (str): Color of the trajectory line.
-                - traj_style (str): Line style of the trajectory (e.g., '-', '--', ':', '-.').
-                - traj_width (float): Width of the trajectory line.
-                - traj_alpha (float): Transparency of the trajectory line.
-                - traj_zorder (int): Z-order for trajectory elements.
-
-                Text visualization properties:
-                - text_color (str): Color of the text label.
-                - text_size (int): Font size of the text.
-                - text_alpha (float): Transparency of the text.
-                - text_zorder (int): Z-order for text elements.
-
-                Field of view properties:
-                - fov_color (str): Fill color of the field of view.
-                - fov_alpha (float): Transparency of the field of view.
-                - fov_edge_color (str): Edge color of the field of view.
-                - fov_zorder (int): Z-order of the field of view.
-
-                Trail visualization properties (for new trail elements):
-                - trail_edgecolor (str): Edge color of the trail.
-                - trail_linewidth (float): Width of the trail outline.
-                - trail_alpha (float): Transparency of the trail.
-                - trail_fill (bool): Whether to fill the trail shape.
-                - trail_color (str): Fill color of the trail.
-                - trail_zorder (int): Z-order for trail elements.
-
-        Note:
-            This method updates existing plot elements in place. Trail elements are created
-            new each time based on trail_freq setting and are not updated but recreated.
-        """
-
-        x = self.state[0, 0]
-        y = self.state[1, 0]
-        r_phi = self.state[2, 0]
-        r_phi_ang = 180 * r_phi / pi
-
-        for attr in self.plot_attr_list:
-            if hasattr(self, attr):
-                element = getattr(self, attr)
-
-                if attr == "object_patch":
-                    # For patches created at origin in _init_plot, use transform to position them
-                    obj_kwargs = {
-                        "color": kwargs.get("obj_color", self.color),
-                        "alpha": kwargs.get("obj_alpha"),
-                        "zorder": kwargs.get("obj_zorder"),
-                        "linestyle": kwargs.get("obj_linestyle"),
-                    }
-
-                    set_patch_property(element, self.ax, state=self.state, **obj_kwargs)
-
-                elif attr == "object_line":
-                    # For lines, use set_data to update coordinates (works for both 2D and 3D)
-                    vertices = self.vertices
-                    cos_phi = np.cos(r_phi)
-                    sin_phi = np.sin(r_phi)
-                    rotation_matrix = np.array(
-                        [[cos_phi, -sin_phi], [sin_phi, cos_phi]]
-                    )
-                    rotated_vertices = np.dot(vertices.T, rotation_matrix.T).T
-                    translated_vertices = rotated_vertices + np.array([[x], [y]])
-
-                    element.set_data(
-                        translated_vertices[0, :], translated_vertices[1, :]
-                    )
-
-                    # Update object line properties
-                    if "obj_linestyle" in kwargs:
-                        element.set_linestyle(kwargs["obj_linestyle"])
-
-                    if "obj_color" in kwargs:
-                        element.set_color(kwargs["obj_color"])
-
-                    if "obj_alpha" in kwargs:
-                        element.set_alpha(kwargs["obj_alpha"])
-
-                    if "obj_zorder" in kwargs:
-                        element.set_zorder(kwargs["obj_zorder"])
-
-                elif attr == "object_img":
-                    # Update image position and rotation using transform
-                    start_x = self.vertices[0, 0]
-                    start_y = self.vertices[1, 0]
-
-                    if not isinstance(self.ax, Axes3D):
-                        # Update image extent based on current vertices
-                        element.set_extent(
-                            [
-                                start_x,
-                                start_x + self.length,
-                                start_y,
-                                start_y + self.width,
-                            ]
-                        )
-
-                        # Create new transform for image
-                        trans_data = (
-                            mtransforms.Affine2D().rotate_deg_around(
-                                start_x, start_y, r_phi_ang
-                            )
-                            + self.ax.transData
-                        )
-                        element.set_transform(trans_data)
-
-                elif attr == "goal_patch":
-                    goal_kwargs = {
-                        "color": kwargs.get("goal_color"),
-                        "alpha": kwargs.get("goal_alpha"),
-                        "zorder": kwargs.get("goal_zorder"),
-                    }
-
-                    if self.goal is None:
-                        element.set_visible(False)
-                        continue
-                    if not element.get_visible():
-                        element.set_visible(True)
-
-                    if self.goal.shape[0] > 2:
-                        goal_state = self.goal
-                    else:
-                        goal_state = np.pad(
-                            self.goal, (0, 1), "constant", constant_values=0
-                        )
-
-                    set_patch_property(
-                        element, self.ax, state=goal_state, **goal_kwargs
-                    )
-
-                elif attr == "arrow_patch":
-                    # Update arrow patch using set_element_property
-                    if isinstance(element, Arrow):
-                        # Calculate orientation for arrow direction
-                        theta = self.heading
-
-                        arrow_state = np.array([[x], [y], [theta]])
-
-                        arrow_kwargs = {
-                            "color": kwargs.get("arrow_color"),
-                            "alpha": kwargs.get("arrow_alpha"),
-                            "zorder": kwargs.get("arrow_zorder"),
-                        }
-
-                        set_patch_property(
-                            element, self.ax, state=arrow_state, **arrow_kwargs
-                        )
-
-                elif attr == "trajectory_line":
-                    # Update trajectory line using set_data (works for both 2D and 3D)
-                    if isinstance(element, list) and len(element) > 0:
-                        line = element[0]
-                        x_list = [
-                            t[0, 0] for t in self.trajectory[-self.keep_traj_length :]
-                        ]
-                        y_list = [
-                            t[1, 0] for t in self.trajectory[-self.keep_traj_length :]
-                        ]
-
-                        if isinstance(self.ax, Axes3D):
-                            # For 3D, add z-coordinate (set to 0)
-                            z_list = [0] * len(x_list)
-                            line.set_data_3d(x_list, y_list, z_list)
-                        else:
-                            line.set_data(x_list, y_list)
-
-                        ax = line.axes
-                        if ax is not None:
-                            linewidth = kwargs.get("traj_width", self.width)
-                            linewidth_data = linewidth_from_data_units(
-                                linewidth, ax, "y"
-                            )
-                            line.set_linewidth(linewidth_data)
-
-                        if "traj_color" in kwargs:
-                            line.set_color(kwargs["traj_color"])
-
-                        if "traj_style" in kwargs:
-                            line.set_linestyle(kwargs["traj_style"])
-
-                        if "traj_alpha" in kwargs:
-                            line.set_alpha(kwargs["traj_alpha"])
-
-                        if "traj_zorder" in kwargs:
-                            line.set_zorder(kwargs["traj_zorder"])
-
-                elif attr == "fov_patch":
-                    # Update FOV patch using set_element_property
-                    if isinstance(element, Wedge | Circle):
-                        direction = r_phi if self.state_dim >= 3 else 0
-                        fov_state = np.array([[x], [y], [direction]])
-
-                        fov_kwargs = {
-                            "alpha": kwargs.get("fov_alpha"),
-                            "zorder": kwargs.get("fov_zorder"),
-                        }
-
-                        set_patch_property(
-                            element, self.ax, state=fov_state, **fov_kwargs
-                        )
-
-        # Update text position using set_position (works for both 2D and 3D)
-        if hasattr(self, "_text"):
-            text = self._text
-            # Prefer runtime kwargs, then initial plot kwargs, fallback to default
-            default_text_pos = [-self.radius - 0.1, self.radius + 0.1]
-            text_position = kwargs.get(
-                "text_position",
-                self.plot_kwargs.get("text_position", default_text_pos),
-            )
-
-            text.set_position((x + text_position[0], y + text_position[1]))
-
-            # Sync display text (may have been changed via set_text)
-            text.set_text(self._get_text())
-
-            # Update text properties
-            if "text_color" in kwargs:
-                text.set_color(kwargs["text_color"])
-
-            if "text_size" in kwargs:
-                text.set_fontsize(kwargs["text_size"])
-
-            if "text_alpha" in kwargs:
-                text.set_alpha(kwargs["text_alpha"])
-
-            if "text_zorder" in kwargs:
-                text.set_zorder(kwargs["text_zorder"])
-
-        # Update goal text position using set_position (works for both 2D and 3D)
-        if self.goal is not None:
-            goal_x = self.goal[0, 0]
-            goal_y = self.goal[1, 0]
-            if hasattr(self, "_goal_text"):
-                goal_text = self._goal_text
-                # Prefer runtime kwargs, then initial plot kwargs, fallback to default
-                default_text_pos = [-self.radius - 0.1, self.radius + 0.1]
-                text_position = kwargs.get(
-                    "text_position",
-                    self.plot_kwargs.get("text_position", default_text_pos),
-                )
-
-                goal_text.set_position(
-                    (goal_x + text_position[0], goal_y + text_position[1])
-                )
-
-                # Sync goal display text (may have been changed via set_goal_text)
-                goal_text.set_text(self._get_goal_text())
-
-                # Update text properties
-                if "text_color" in kwargs:
-                    goal_text.set_color(kwargs["text_color"])
-
-                if "text_size" in kwargs:
-                    goal_text.set_fontsize(kwargs["text_size"])
-
-                if "text_alpha" in kwargs:
-                    goal_text.set_alpha(kwargs["text_alpha"])
-
-                if "text_zorder" in kwargs:
-                    goal_text.set_zorder(kwargs["text_zorder"])
-
-        # Handle trail plotting (creates new elements each time)
-        if self.show_trail and self._world_param.count % self.trail_freq == 0:
-            self.plot_trail(
-                self.ax, self.state, self.original_vertices, **self.plot_kwargs
-            )
-
-        # Update sensors
-        if self.show_sensor:
-            [sensor.step_plot() for sensor in self.sensors]
+        **kwargs: Any,
+    ) -> None:
+        """Plot this object through its dedicated renderer."""
+        self._object_plot.plot(ax, state, vertices, **kwargs)
+
+    def _init_plot(self, ax: Any, **kwargs: Any) -> list[str]:
+        """Initialize this object's Matplotlib artists."""
+        return self._object_plot.init(ax, **kwargs)
+
+    def _plot(
+        self,
+        ax: Any,
+        state: np.ndarray,
+        vertices: np.ndarray,
+        initial: bool = False,
+        **kwargs: Any,
+    ) -> list[str]:
+        """Create this object's configured Matplotlib artists."""
+        return self._object_plot._plot(ax, state, vertices, initial=initial, **kwargs)
+
+    def _step_plot(self, **kwargs: Any) -> None:
+        """Update this object's Matplotlib artists."""
+        self._object_plot.step(**kwargs)
 
     def plot_object(
         self,
-        ax,
+        ax: Any,
         state: np.ndarray | None = None,
         vertices: np.ndarray | None = None,
-        **kwargs,
-    ):
-        """
-        Plot the object itself in the specified coordinate system.
-
-        Args:
-            ax: Matplotlib axis object
-            state: State of the object (x, y, r_phi) defining position and orientation.
-                   If None, uses the object's current state. Defaults to None.
-            vertices: Vertices of the object [[x1, y1], [x2, y2], ...] for polygon and rectangle shapes.
-                     If None, uses the object's current vertices. Defaults to None.
-            **kwargs: Additional plotting options
-                - obj_linestyle (str): Line style for object outline, defaults to '-'
-                - obj_zorder (int): Drawing layer order, defaults to 3 if object is robot, 1 if object is the obstacle.
-                - obj_color (str): Color of the object, defaults to 'k' (black).
-                - obj_alpha (float): Transparency of the object, defaults to 1.0.
-
-        Returns:
-            None
-
-        Raises:
-            Exception: If the underlying patch creation fails (e.g., unsupported shape or backend issues).
-        """
-        obj_linestyle = kwargs.get("obj_linestyle", "-")
-        obj_zorder = kwargs.get("obj_zorder", 3) if self.role == "robot" else 1
-
-        state = self.state if state is None else state
-        vertices = self.vertices if vertices is None else vertices
-
-        # Handle 3D plot or no description case
-        if self.description is None or isinstance(ax, Axes3D):
-            try:
-                if self.shape != "map":
-                    self.object_patch = draw_patch(
-                        ax,
-                        shape=self.shape,
-                        state=state,
-                        radius=self.radius,
-                        center=(
-                            self.original_centroid if self.shape == "circle" else None
-                        ),
-                        vertices=vertices,
-                        color=self.color,
-                        linestyle=obj_linestyle,
-                        zorder=obj_zorder,
-                    )
-
-                    self.plot_patch_list.append(self.object_patch)
-
-            except Exception as e:
-                self.logger.error(f"Error occurred while plotting object: {e!s}")
-                raise
-
-        else:
-            self.plot_object_image(ax, state, vertices, self.description, **kwargs)
+        **kwargs: Any,
+    ) -> None:
+        """Draw this object's geometry or description image."""
+        self._object_plot.plot_object(ax, state, vertices, **kwargs)
 
     def plot_object_image(
         self,
-        ax,
+        ax: Any,
         state: np.ndarray | None = None,
         vertices: np.ndarray | None = None,
         description: str | None = None,
-        **kwargs,
-    ):
-        """
-        Plot the object using an image file based on the description.
-
-        Args:
-            ax: Matplotlib axis object for plotting.
-            state (Optional[np.ndarray]): State of the object (x, y, r_phi) defining position and orientation.
-                                        If None, uses the object's current state. Defaults to None.
-            vertices (Optional[np.ndarray]): Vertices of the object for positioning the image.
-                                           If None, uses the object's current vertices. Defaults to None.
-            description (str): Path or name of the image file to display. Defaults to None.
-            **kwargs: Additional plotting options (currently unused).
-
-        Note:
-            The image file is searched in the world/description/ directory relative to the project root.
-            The image is rotated and positioned according to the object's state and vertices.
-        """
-        if vertices is None or state is None:
-            return
-        robot_image_path = file_check(
-            description, root_path=path_manager.root_path + "/world/description/"
-        )
-        if robot_image_path is None:
-            return
-        start_x = float(vertices[0, 0])
-        start_y = float(vertices[1, 0])
-        r_phi = float(state[2, 0])
-        r_phi_ang = 180 * r_phi / pi
-        obj_zorder = kwargs.get("obj_zorder", 2)
-
-        robot_img_read = image.imread(robot_image_path)
-
-        robot_img = ax.imshow(
-            robot_img_read,
-            extent=[
-                float(start_x),
-                float(start_x + self.length),
-                float(start_y),
-                float(start_y + self.width),
-            ],
-            zorder=obj_zorder,
-        )
-        trans_data = (
-            mtransforms.Affine2D().rotate_deg_around(start_x, start_y, r_phi_ang)
-            + ax.transData
-        )
-        robot_img.set_transform(trans_data)
-
-        self.plot_patch_list.append(robot_img)
-        self.object_img = robot_img
+        **kwargs: Any,
+    ) -> None:
+        """Draw this object's configured description image."""
+        self._object_plot.plot_object_image(ax, state, vertices, description, **kwargs)
 
     def plot_trajectory(
-        self, ax, trajectory: list | None = None, keep_traj_length: int = 0, **kwargs
-    ):
-        """
-        Plot the trajectory path of the object using the specified trajectory data.
-
-        Args:
-            ax: Matplotlib axis.
-            trajectory: List of trajectory points to plot, where each point is a numpy array [x, y, theta, ...].
-                       If None, uses self.trajectory. Defaults to None.
-            keep_traj_length (int): Number of steps to keep from the end of trajectory.
-                              If 0, plots entire trajectory. Defaults to 0.
-            **kwargs: Additional plotting options:
-                traj_color (str): Color of the trajectory line.
-                traj_style (str): Line style of the trajectory.
-                traj_width (float): Width of the trajectory line.
-                traj_alpha (float): Transparency of the trajectory line.
-                traj_zorder (int): Zorder of the trajectory.
-        """
-
-        if trajectory is None:
-            trajectory = self.trajectory
-
-        self.keep_traj_length = keep_traj_length
-
-        traj_color = kwargs.get("traj_color", self.color)
-        traj_style = kwargs.get("traj_style", "-")
-        traj_width = kwargs.get("traj_width", self.width)
-        traj_alpha = kwargs.get("traj_alpha", 0.5)
-        traj_zorder = kwargs.get("traj_zorder", 0)
-
-        x_list = [t[0, 0] for t in trajectory[-self.keep_traj_length :]]
-        y_list = [t[1, 0] for t in trajectory[-self.keep_traj_length :]]
-
-        linewidth = linewidth_from_data_units(traj_width, ax, "y")
-
-        if isinstance(ax, Axes3D):
-            linewidth = traj_width * 10
-
-        solid_capstyle = "round" if self.shape == "circle" else "butt"
-
-        self.trajectory_line = ax.plot(
-            x_list,
-            y_list,
-            color=traj_color,
-            linestyle=traj_style,
-            linewidth=linewidth,
-            solid_joinstyle="round",
-            solid_capstyle=solid_capstyle,
-            alpha=traj_alpha,
-            zorder=traj_zorder,
-        )
-
-        self.plot_line_list.append(self.trajectory_line)
+        self,
+        ax: Any,
+        trajectory: list | None = None,
+        keep_traj_length: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        """Draw this object's trajectory."""
+        self._object_plot.plot_trajectory(ax, trajectory, keep_traj_length, **kwargs)
 
     def plot_goal(
         self,
-        ax,
+        ax: Any,
         goal_state: np.ndarray | None = None,
         vertices: np.ndarray | None = None,
         goal_color: str | None = None,
         goal_zorder: int | None = 1,
         goal_alpha: float | None = 0.5,
-        **kwargs,
-    ):
-        """
-        Plot the goal position of the object in the specified coordinate system.
-
-        Args:
-            ax: Matplotlib axis.
-            goal_state: State of the goal (x, y, r_phi) defining goal position and orientation.
-                       If None, nothing is plotted. Defaults to None.
-            vertices: Vertices for polygon/rectangle goal shapes.
-                     If None, uses original_vertices. Defaults to None.
-            goal_color (str): Color of the goal marker. Defaults to be the color of the object.
-            goal_zorder (int): Zorder of the goal marker. Defaults to 1.
-            goal_alpha (float): Transparency of the goal marker. Defaults to 0.5.
-        """
-
-        goal_color = self.color if goal_color is None else goal_color
-
-        if goal_state is None:
-            return
-
-        self.goal_patch = draw_patch(
+        **kwargs: Any,
+    ) -> None:
+        """Draw this object's goal."""
+        self._object_plot.plot_goal(
             ax,
-            shape=self.shape,
-            state=goal_state,
-            radius=self.radius,
-            vertices=vertices,
-            color=goal_color,
-            alpha=goal_alpha,
-            zorder=goal_zorder,
+            goal_state,
+            vertices,
+            goal_color,
+            goal_zorder,
+            goal_alpha,
+            **kwargs,
         )
 
-        self.plot_patch_list.append(self.goal_patch)
-
-    def plot_text(self, ax, state: np.ndarray | None = None, **kwargs):
-        """
-        Plot the text label of the object at the specified position.
-
-        Args:
-            ax: Matplotlib axis.
-            state: State of the object (x, y, r_phi) to determine text position.
-                   If None, uses the object's current state. Defaults to None.
-            **kwargs: Additional plotting options.
-
-                - text_color (str): Color of the text, default is 'k'.
-                - text_size (int): Font size of the text, default is 10.
-                - text_position (list): Position offset from object center [dx, dy],
-                  default is [-radius-0.1, radius+0.1].
-                - text_zorder (int): Zorder of the text. Defaults to 2.
-                - text_alpha (float): Transparency of the text. Defaults to 1.
-
-        Note:
-            Subsequent updates via _step_plot honor the configured text_position if provided.
-        """
-
-        if state is None:
-            state = self.state
-
-        text_color = kwargs.get("text_color", "k")
-        text_size = kwargs.get("text_size", 10)
-        text_position = kwargs.get(
-            "text_position", [-self.radius - 0.1, self.radius + 0.1]
-        )
-        text_zorder = kwargs.get("text_zorder", 2)
-        text_alpha = kwargs.get("text_alpha", 1)
-
-        x, y = state[0, 0], state[1, 0]
-
-        if isinstance(ax, Axes3D):
-            self._text = ax.text(
-                x + text_position[0],
-                y + text_position[1],
-                self.z,
-                self._get_text(),
-                fontsize=text_size,
-                color=text_color,
-                zorder=text_zorder,
-                alpha=text_alpha,
-            )
-        else:
-            self._text = ax.text(
-                x + text_position[0],
-                y + text_position[1],
-                self._get_text(),
-                fontsize=text_size,
-                color=text_color,
-                zorder=text_zorder,
-                alpha=text_alpha,
-            )
-        self.plot_text_list.append(self._text)
-
-        if self.show_goal and self.show_goal_text:
-            goal_x, goal_y = self.goal[0, 0], self.goal[1, 0]
-            if isinstance(ax, Axes3D):
-                self._goal_text = ax.text(
-                    goal_x + text_position[0],
-                    goal_y + text_position[1],
-                    self.z,
-                    self._get_goal_text(),
-                    fontsize=text_size,
-                    color=text_color,
-                    zorder=text_zorder,
-                    alpha=text_alpha,
-                )
-            else:
-                self._goal_text = ax.text(
-                    goal_x + text_position[0],
-                    goal_y + text_position[1],
-                    self._get_goal_text(),
-                    fontsize=text_size,
-                    color=text_color,
-                    zorder=text_zorder,
-                    alpha=text_alpha,
-                )
-            self.plot_text_list.append(self._goal_text)
+    def plot_text(
+        self,
+        ax: Any,
+        state: np.ndarray | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Draw this object's text labels."""
+        self._object_plot.plot_text(ax, state, **kwargs)
 
     def plot_arrow(
         self,
-        ax,
+        ax: Any,
         state: np.ndarray | None = None,
         velocity: np.ndarray | None = None,
         arrow_theta: float | None = 0.0,
@@ -1902,182 +1213,43 @@ class ObjectBase:
         arrow_width: float = 0.6,
         arrow_color: str | None = None,
         arrow_zorder: int = 3,
-        **kwargs,
-    ):
-        """
-        Plot an arrow indicating the velocity orientation of the object at the specified position.
-
-        Args:
-            ax: Matplotlib axis.
-            state: State of the object (x, y, r_phi) to determine arrow position.
-                   If None, uses the object's current state. Defaults to None.
-            velocity: Velocity of the object to determine arrow direction.
-                     If None, uses the object's current velocity_xy. Defaults to None.
-            arrow_length (float): Length of the arrow. Defaults to 0.4.
-            arrow_width (float): Width of the arrow. Defaults to 0.6.
-            arrow_color (str): Color of the arrow. Defaults to "gold".
-            arrow_zorder (int): Z-order for drawing layer. Defaults to 4.
-        """
-
-        if state is None:
-            state = self.state
-        if velocity is None:
-            velocity = self.velocity_xy
-        if arrow_color is None:
-            arrow_color = "gold"
-
-        self.arrow_patch = draw_patch(
+        **kwargs: Any,
+    ) -> None:
+        """Draw this object's velocity arrow."""
+        self._object_plot.plot_arrow(
             ax,
-            shape="arrow",
-            state=state,
-            color=arrow_color,
-            zorder=arrow_zorder,
-            arrow_length=arrow_length,
-            arrow_width=arrow_width,
-            theta=arrow_theta,
+            state,
+            velocity,
+            arrow_theta,
+            arrow_length,
+            arrow_width,
+            arrow_color,
+            arrow_zorder,
+            **kwargs,
         )
-
-        self.plot_patch_list.append(self.arrow_patch)
 
     def plot_trail(
         self,
-        ax,
+        ax: Any,
         state: np.ndarray | None = None,
         vertices: np.ndarray | None = None,
         keep_trail_length: int = 0,
-        **kwargs,
-    ):
-        """
-        Plot the trail/outline of the object at the specified position for visualization purposes.
+        **kwargs: Any,
+    ) -> None:
+        """Draw one historical outline for this object."""
+        self._object_plot.plot_trail(ax, state, vertices, keep_trail_length, **kwargs)
 
-        Args:
-            ax: Matplotlib axis.
-            state: State of the object (x, y, r_phi) to determine trail position and orientation.
-                   If None, uses the object's current state. Defaults to None.
-            vertices: Original vertices of the object for polygon and rectangle trail shapes.
-                     If None, uses the object's current vertices. Defaults to None.
-            keep_trail_length (int): Number of steps to keep from the recent trajectory of trail.
-            **kwargs: Additional plotting options:
-                trail_type (str): Type of trail shape, defaults to object's shape.
-                trail_edgecolor (str): Edge color of the trail.
-                trail_linewidth (float): Line width of the trail edge.
-                trail_alpha (float): Transparency of the trail.
-                trail_fill (bool): Whether to fill the trail shape.
-                trail_color (str): Fill color of the trail.
-                trail_zorder (int): Z-order of the trail.
-        """
+    def plot_fov(self, ax: Any, **kwargs: Any) -> None:
+        """Draw this object's field of view."""
+        self._object_plot.plot_fov(ax, **kwargs)
 
-        if vertices is None:
-            vertices = self.original_vertices
+    def plot_uncertainty(self, ax: Any, **kwargs: Any) -> None:
+        """Draw this object's uncertainty visualization."""
+        self._object_plot.plot_uncertainty(ax, **kwargs)
 
-        trail_type = kwargs.get("trail_type", self.shape)
-        trail_edgecolor = kwargs.get("trail_edgecolor", self.color)
-        trail_linewidth = kwargs.get("trail_linewidth", 0.8)
-        trail_alpha = kwargs.get("trail_alpha", 0.7)
-        trail_fill = kwargs.get("trail_fill", False)
-        trail_color = kwargs.get("trail_color", self.color)
-        trail_zorder = kwargs.get("trail_zorder", 0)
-
-        # angle in degrees, no longer needed due to generic draw_patch usage
-
-        trail = draw_patch(
-            ax,
-            shape=trail_type,
-            state=state,
-            vertices=vertices,
-            radius=self.radius,
-            center=(self.original_centroid if trail_type == "circle" else None),
-            width=self.length,
-            height=self.width,
-            edgecolor=trail_edgecolor,
-            facecolor=trail_color,
-            fill=trail_fill,
-            alpha=trail_alpha,
-            linewidth=trail_linewidth,
-            zorder=trail_zorder,
-        )
-
-        self.plot_trail_list.append(trail)
-
-        if len(self.plot_trail_list) > keep_trail_length and keep_trail_length > 0:
-            self.plot_trail_list.pop(0).remove()
-
-    def plot_fov(self, ax, **kwargs):
-        """
-        Plot the field of view of the object.
-        Creates FOV wedge at origin, will be positioned using transforms in step_plot.
-
-        if fov is 2*pi, plot a circle, otherwise plot a wedge.
-
-        Args:
-            ax: Matplotlib axis.
-            **kwargs: Additional plotting options.
-                fov_color (str): Color of the field of view. Default is 'lightblue'.
-                fov_edge_color (str): Edge color of the field of view. Default is 'blue'.
-                fov_zorder (int): Z-order of the field of view. Default is 1.
-                fov_alpha (float): Transparency of the field of view. Default is 0.5.
-
-        Note:
-            No-op when FOV is not configured (fov or fov_radius is None).
-        """
-
-        if self.fov is None or self.fov_radius is None:
-            return
-
-        fov_color = kwargs.get("fov_color", "lightblue")
-        fov_edge_color = kwargs.get("fov_edge_color", "blue")
-        fov_zorder = kwargs.get("fov_zorder", 1)
-        fov_alpha = kwargs.get("fov_alpha", 0.5)
-
-        # Create FOV wedge at origin with no rotation (-fov/2 to +fov/2 around 0 degrees)
-        start_degree = -180 * self.fov / (2 * pi)
-        end_degree = 180 * self.fov / (2 * pi)
-
-        state = np.array([[0.0], [0.0], [0.0]])
-
-        shape = "circle" if abs(self.fov - 2 * pi) < 0.01 else "wedge"
-
-        self.fov_patch = draw_patch(
-            ax,
-            shape=shape,
-            state=state,
-            radius=self.fov_radius,
-            theta1=start_degree,
-            theta2=end_degree,
-            facecolor=fov_color,
-            edgecolor=fov_edge_color,
-            alpha=fov_alpha,
-            zorder=fov_zorder,
-        )
-
-        self.plot_patch_list.append(self.fov_patch)
-
-    def plot_uncertainty(self, ax, **kwargs):
-        """
-        To be completed.
-        """
-        pass
-
-    def plot_clear(self, all: bool = False):
-        """
-        Clear all plotted elements from the axis.
-
-        Args:
-            all (bool): If True, also clears trail elements. If False, keeps trail elements. Defaults to False.
-        """
-        [patch.remove() for patch in self.plot_patch_list]
-        [line.pop(0).remove() for line in self.plot_line_list]
-        [text.remove() for text in self.plot_text_list]
-
-        if all:
-            [trail.remove() for trail in self.plot_trail_list]
-            self.plot_trail_list = []
-
-        self.plot_patch_list = []
-        self.plot_line_list = []
-        self.plot_text_list = []
-
-        [sensor.plot_clear() for sensor in self.sensors]
+    def plot_clear(self, all: bool = False) -> None:
+        """Clear this object's artists."""
+        self._object_plot.clear(all=all)
 
     def done(self):
         """

--- a/irsim/world/object_plot.py
+++ b/irsim/world/object_plot.py
@@ -18,6 +18,18 @@ from irsim.util.util import file_check
 if TYPE_CHECKING:
     from irsim.world.object_base import ObjectBase
 
+_PLOT_ATTRIBUTES = (
+    "object_patch",
+    "object_line",
+    "object_img",
+    "goal_patch",
+    "_text",
+    "_goal_text",
+    "arrow_patch",
+    "trajectory_line",
+    "fov_patch",
+)
+
 
 class ObjectPlot:
     """Render and update the Matplotlib artists for one simulation object.
@@ -27,19 +39,13 @@ class ObjectPlot:
     behavior out of the simulation model.
     """
 
-    def __init__(self, obj: ObjectBase) -> None:
-        object.__setattr__(self, "_object", obj)
+    def __init__(self, owner: ObjectBase) -> None:
+        self._owner = owner
 
     def __getattr__(self, name: str) -> Any:
-        """Read object state and existing artist attributes transparently."""
-        return getattr(self._object, name)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Keep artist state on the object for backward compatibility."""
-        if name == "_object":
-            object.__setattr__(self, name, value)
-        else:
-            setattr(self._object, name, value)
+        """Read simulation and compatibility state from the owning object."""
+        owner = object.__getattribute__(self, "_owner")
+        return getattr(owner, name)
 
     def plot(
         self,
@@ -51,7 +57,7 @@ class ObjectPlot:
         """Plot the object on ``ax`` using optional state and vertices."""
         state = self.state if state is None else state
         vertices = self.vertices if vertices is None else vertices
-        self._plot(ax, state, vertices, **kwargs)
+        self.draw(ax, state, vertices, **kwargs)
 
     def init(self, ax: Any, **kwargs: Any) -> list[str]:
         """Create the object's artists at its original state."""
@@ -63,7 +69,7 @@ class ObjectPlot:
         ):
             kwargs.setdefault("show_arrow", self.kf.show_arrow)
 
-        return self._plot(
+        return self.draw(
             ax,
             self.original_state,
             self.original_vertices,
@@ -71,7 +77,7 @@ class ObjectPlot:
             **kwargs,
         )
 
-    def _plot(
+    def draw(
         self,
         ax: Any,
         state: np.ndarray,
@@ -80,31 +86,22 @@ class ObjectPlot:
         **kwargs: Any,
     ) -> list[str]:
         """Create the configured artists for one object."""
-        self.plot_attr_list = [
-            "object_patch",
-            "object_line",
-            "object_img",
-            "goal_patch",
-            "_text",
-            "_goal_text",
-            "arrow_patch",
-            "trajectory_line",
-            "fov_patch",
-        ]
+        owner = self._owner
+        owner.plot_attr_list = list(_PLOT_ATTRIBUTES)
 
         self.plot_kwargs.update(kwargs)
-        self.ax = ax
+        owner.ax = ax
 
-        self.show_goal = self.plot_kwargs.get("show_goal", False)
-        self.show_goal_text = self.plot_kwargs.get("show_goal_text", False)
-        self.show_goals = self.plot_kwargs.get("show_goals", False)
+        owner.show_goal = self.plot_kwargs.get("show_goal", False)
+        owner.show_goal_text = self.plot_kwargs.get("show_goal_text", False)
+        owner.show_goals = self.plot_kwargs.get("show_goals", False)
         show_text = self.plot_kwargs.get("show_text", False)
         show_arrow = self.plot_kwargs.get("show_arrow", False)
         show_trajectory = self.plot_kwargs.get("show_trajectory", False)
-        self.show_trail = self.plot_kwargs.get("show_trail", False)
-        self.show_sensor = self.plot_kwargs.get("show_sensor", True)
+        owner.show_trail = self.plot_kwargs.get("show_trail", False)
+        owner.show_sensor = self.plot_kwargs.get("show_sensor", True)
         show_fov = self.plot_kwargs.get("show_fov", False)
-        self.trail_freq = self.plot_kwargs.get("trail_freq", 2)
+        owner.trail_freq = self.plot_kwargs.get("trail_freq", 2)
 
         if self.shape != "map":
             self.plot_object(ax, state, vertices, **self.plot_kwargs)
@@ -142,120 +139,167 @@ class ObjectPlot:
         if show_fov:
             self.plot_fov(ax, **self.plot_kwargs)
 
-        return self.plot_attr_list
+        return owner.plot_attr_list
 
     def step(self, **kwargs: Any) -> None:
-        """Update the existing artists from the object's current state."""
-        x = self.state[0, 0]
-        y = self.state[1, 0]
-        r_phi = self.state[2, 0]
-        r_phi_ang = 180 * r_phi / pi
+        """Update existing artists from the owner's current state."""
+        state = self.state
+        x = float(state[0, 0])
+        y = float(state[1, 0])
+        heading = float(state[2, 0])
 
-        for attr in self.plot_attr_list:
-            if not hasattr(self, attr):
-                continue
-
-            element = getattr(self, attr)
-            if attr == "object_patch":
-                obj_kwargs = {
-                    "color": kwargs.get("obj_color", self.color),
-                    "alpha": kwargs.get("obj_alpha"),
-                    "zorder": kwargs.get("obj_zorder"),
-                    "linestyle": kwargs.get("obj_linestyle"),
-                }
-                set_patch_property(element, self.ax, state=self.state, **obj_kwargs)
-
-            elif attr == "object_line":
-                vertices = self.vertices
-                cos_phi = np.cos(r_phi)
-                sin_phi = np.sin(r_phi)
-                rotation_matrix = np.array([[cos_phi, -sin_phi], [sin_phi, cos_phi]])
-                rotated_vertices = np.dot(vertices.T, rotation_matrix.T).T
-                translated_vertices = rotated_vertices + np.array([[x], [y]])
-                element.set_data(translated_vertices[0, :], translated_vertices[1, :])
-                if "obj_linestyle" in kwargs:
-                    element.set_linestyle(kwargs["obj_linestyle"])
-                if "obj_color" in kwargs:
-                    element.set_color(kwargs["obj_color"])
-                if "obj_alpha" in kwargs:
-                    element.set_alpha(kwargs["obj_alpha"])
-                if "obj_zorder" in kwargs:
-                    element.set_zorder(kwargs["obj_zorder"])
-
-            elif attr == "object_img":
-                start_x = self.vertices[0, 0]
-                start_y = self.vertices[1, 0]
-                if not isinstance(self.ax, Axes3D):
-                    element.set_extent(
-                        [
-                            start_x,
-                            start_x + self.length,
-                            start_y,
-                            start_y + self.width,
-                        ]
-                    )
-                    transform = (
-                        mtransforms.Affine2D().rotate_deg_around(
-                            start_x, start_y, r_phi_ang
-                        )
-                        + self.ax.transData
-                    )
-                    element.set_transform(transform)
-
-            elif attr == "goal_patch":
-                goal_kwargs = {
-                    "color": kwargs.get("goal_color"),
-                    "alpha": kwargs.get("goal_alpha"),
-                    "zorder": kwargs.get("goal_zorder"),
-                }
-                if self.goal is None:
-                    element.set_visible(False)
-                    continue
-                if not element.get_visible():
-                    element.set_visible(True)
-
-                goal_state = (
-                    self.goal
-                    if self.goal.shape[0] > 2
-                    else np.pad(self.goal, (0, 1), "constant", constant_values=0)
-                )
-                set_patch_property(element, self.ax, state=goal_state, **goal_kwargs)
-
-            elif attr == "arrow_patch" and isinstance(element, Arrow):
-                arrow_state = np.array([[x], [y], [self.heading]])
-                arrow_kwargs = {
-                    "color": kwargs.get("arrow_color"),
-                    "alpha": kwargs.get("arrow_alpha"),
-                    "zorder": kwargs.get("arrow_zorder"),
-                }
-                set_patch_property(element, self.ax, state=arrow_state, **arrow_kwargs)
-
-            elif attr == "trajectory_line":
-                self._step_trajectory(element, kwargs)
-
-            elif attr == "fov_patch" and isinstance(element, Wedge | Circle):
-                direction = r_phi if self.state_dim >= 3 else 0
-                fov_state = np.array([[x], [y], [direction]])
-                fov_kwargs = {
-                    "alpha": kwargs.get("fov_alpha"),
-                    "zorder": kwargs.get("fov_zorder"),
-                }
-                set_patch_property(element, self.ax, state=fov_state, **fov_kwargs)
-
-        self._step_text(x, y, kwargs)
-        self._step_goal_text(kwargs)
+        self._update_object_patch(kwargs)
+        self._update_object_line(x, y, heading, kwargs)
+        self._update_object_image(heading)
+        self._update_goal_patch(kwargs)
+        self._update_arrow_patch(x, y, kwargs)
+        self._update_trajectory(kwargs)
+        self._update_fov_patch(x, y, heading, kwargs)
+        self._update_text(x, y, kwargs)
+        self._update_goal_text(kwargs)
 
         if self.show_trail and self._world_param.count % self.trail_freq == 0:
-            self.plot_trail(
-                self.ax, self.state, self.original_vertices, **self.plot_kwargs
-            )
+            self.plot_trail(self.ax, state, self.original_vertices, **self.plot_kwargs)
 
         if self.show_sensor:
             for sensor in self.sensors:
                 sensor.step_plot()
 
-    def _step_trajectory(self, element: Any, kwargs: dict[str, Any]) -> None:
+    def _artist(self, name: str) -> Any | None:
+        """Return an artist stored on the owner, if it has been created."""
+        return getattr(self._owner, name, None)
+
+    def _update_object_patch(self, kwargs: dict[str, Any]) -> None:
+        element = self._artist("object_patch")
+        if element is None:
+            return
+
+        set_patch_property(
+            element,
+            self.ax,
+            state=self.state,
+            color=kwargs.get("obj_color", self.color),
+            alpha=kwargs.get("obj_alpha"),
+            zorder=kwargs.get("obj_zorder"),
+            linestyle=kwargs.get("obj_linestyle"),
+        )
+
+    def _update_object_line(
+        self,
+        x: float,
+        y: float,
+        heading: float,
+        kwargs: dict[str, Any],
+    ) -> None:
+        element = self._artist("object_line")
+        if element is None:
+            return
+
+        cos_heading = np.cos(heading)
+        sin_heading = np.sin(heading)
+        rotation = np.array([[cos_heading, -sin_heading], [sin_heading, cos_heading]])
+        vertices = rotation @ self.vertices + np.array([[x], [y]])
+        element.set_data(vertices[0, :], vertices[1, :])
+
+        if "obj_linestyle" in kwargs:
+            element.set_linestyle(kwargs["obj_linestyle"])
+        if "obj_color" in kwargs:
+            element.set_color(kwargs["obj_color"])
+        if "obj_alpha" in kwargs:
+            element.set_alpha(kwargs["obj_alpha"])
+        if "obj_zorder" in kwargs:
+            element.set_zorder(kwargs["obj_zorder"])
+
+    def _update_object_image(self, heading: float) -> None:
+        element = self._artist("object_img")
+        if element is None or isinstance(self.ax, Axes3D):
+            return
+
+        start_x = float(self.vertices[0, 0])
+        start_y = float(self.vertices[1, 0])
+        element.set_extent(
+            [
+                start_x,
+                start_x + self.length,
+                start_y,
+                start_y + self.width,
+            ]
+        )
+        transform = (
+            mtransforms.Affine2D().rotate_around(start_x, start_y, heading)
+            + self.ax.transData
+        )
+        element.set_transform(transform)
+
+    def _update_goal_patch(self, kwargs: dict[str, Any]) -> None:
+        element = self._artist("goal_patch")
+        if element is None:
+            return
+
+        if self.goal is None:
+            element.set_visible(False)
+            return
+
+        element.set_visible(True)
+        goal_state = (
+            self.goal
+            if self.goal.shape[0] > 2
+            else np.pad(self.goal, (0, 1), "constant", constant_values=0)
+        )
+        set_patch_property(
+            element,
+            self.ax,
+            state=goal_state,
+            color=kwargs.get("goal_color"),
+            alpha=kwargs.get("goal_alpha"),
+            zorder=kwargs.get("goal_zorder"),
+        )
+
+    def _update_arrow_patch(
+        self,
+        x: float,
+        y: float,
+        kwargs: dict[str, Any],
+    ) -> None:
+        element = self._artist("arrow_patch")
+        if not isinstance(element, Arrow):
+            return
+
+        arrow_state = np.array([[x], [y], [self.heading]])
+        set_patch_property(
+            element,
+            self.ax,
+            state=arrow_state,
+            color=kwargs.get("arrow_color"),
+            alpha=kwargs.get("arrow_alpha"),
+            zorder=kwargs.get("arrow_zorder"),
+        )
+
+    def _update_fov_patch(
+        self,
+        x: float,
+        y: float,
+        heading: float,
+        kwargs: dict[str, Any],
+    ) -> None:
+        element = self._artist("fov_patch")
+        if not isinstance(element, Wedge | Circle):
+            return
+
+        direction = heading if self.state_dim >= 3 else 0.0
+        set_patch_property(
+            element,
+            self.ax,
+            state=np.array([[x], [y], [direction]]),
+            facecolor=kwargs.get("fov_color"),
+            edgecolor=kwargs.get("fov_edge_color"),
+            alpha=kwargs.get("fov_alpha"),
+            zorder=kwargs.get("fov_zorder"),
+        )
+
+    def _update_trajectory(self, kwargs: dict[str, Any]) -> None:
         """Update a trajectory line and its runtime style properties."""
+        element = self._artist("trajectory_line")
         if not isinstance(element, list) or not element:
             return
 
@@ -283,7 +327,7 @@ class ObjectPlot:
         if "traj_zorder" in kwargs:
             line.set_zorder(kwargs["traj_zorder"])
 
-    def _step_text(self, x: float, y: float, kwargs: dict[str, Any]) -> None:
+    def _update_text(self, x: float, y: float, kwargs: dict[str, Any]) -> None:
         """Update the object label when it exists."""
         if not hasattr(self, "_text"):
             return
@@ -298,7 +342,7 @@ class ObjectPlot:
         text.set_text(self._get_text())
         self._set_text_properties(text, kwargs)
 
-    def _step_goal_text(self, kwargs: dict[str, Any]) -> None:
+    def _update_goal_text(self, kwargs: dict[str, Any]) -> None:
         """Update the goal label when the object has a goal."""
         if self.goal is None or not hasattr(self, "_goal_text"):
             return
@@ -340,13 +384,15 @@ class ObjectPlot:
         """Draw the object's geometry or configured description image."""
         obj_linestyle = kwargs.get("obj_linestyle", "-")
         obj_zorder = kwargs.get("obj_zorder", 3) if self.role == "robot" else 1
+        obj_color = kwargs.get("obj_color", self.color)
+        obj_alpha = kwargs.get("obj_alpha")
         state = self.state if state is None else state
         vertices = self.vertices if vertices is None else vertices
 
         if self.description is None or isinstance(ax, Axes3D):
             try:
                 if self.shape != "map":
-                    self.object_patch = draw_patch(
+                    self._owner.object_patch = draw_patch(
                         ax,
                         shape=self.shape,
                         state=state,
@@ -355,7 +401,8 @@ class ObjectPlot:
                             self.original_centroid if self.shape == "circle" else None
                         ),
                         vertices=vertices,
-                        color=self.color,
+                        color=obj_color,
+                        alpha=obj_alpha,
                         linestyle=obj_linestyle,
                         zorder=obj_zorder,
                     )
@@ -408,7 +455,7 @@ class ObjectPlot:
         object_image.set_transform(transform)
 
         self.plot_patch_list.append(object_image)
-        self.object_img = object_image
+        self._owner.object_img = object_image
 
     def plot_trajectory(
         self,
@@ -419,7 +466,7 @@ class ObjectPlot:
     ) -> None:
         """Draw the object's trajectory."""
         trajectory = self.trajectory if trajectory is None else trajectory
-        self.keep_traj_length = keep_traj_length
+        self._owner.keep_traj_length = keep_traj_length
 
         traj_color = kwargs.get("traj_color", self.color)
         traj_style = kwargs.get("traj_style", "-")
@@ -436,7 +483,7 @@ class ObjectPlot:
             linewidth = traj_width * 10
 
         solid_capstyle = "round" if self.shape == "circle" else "butt"
-        self.trajectory_line = ax.plot(
+        self._owner.trajectory_line = ax.plot(
             x_list,
             y_list,
             color=traj_color,
@@ -464,7 +511,7 @@ class ObjectPlot:
             return
 
         goal_color = self.color if goal_color is None else goal_color
-        self.goal_patch = draw_patch(
+        self._owner.goal_patch = draw_patch(
             ax,
             shape=self.shape,
             state=goal_state,
@@ -494,7 +541,7 @@ class ObjectPlot:
         x, y = state[0, 0], state[1, 0]
 
         if isinstance(ax, Axes3D):
-            self._text = ax.text(
+            self._owner._text = ax.text(
                 x + text_position[0],
                 y + text_position[1],
                 self.z,
@@ -505,7 +552,7 @@ class ObjectPlot:
                 alpha=text_alpha,
             )
         else:
-            self._text = ax.text(
+            self._owner._text = ax.text(
                 x + text_position[0],
                 y + text_position[1],
                 self._get_text(),
@@ -516,7 +563,7 @@ class ObjectPlot:
             )
         self.plot_text_list.append(self._text)
 
-        if self.show_goal and self.show_goal_text:
+        if self.show_goal and self.show_goal_text and self.goal is not None:
             self._plot_goal_text(
                 ax,
                 text_position,
@@ -544,7 +591,7 @@ class ObjectPlot:
         if isinstance(ax, Axes3D):
             args.append(self.z)
 
-        self._goal_text = ax.text(
+        self._owner._goal_text = ax.text(
             *args,
             self._get_goal_text(),
             fontsize=text_size,
@@ -568,15 +615,14 @@ class ObjectPlot:
     ) -> None:
         """Draw an arrow indicating the object's velocity orientation."""
         state = self.state if state is None else state
-        if velocity is None:
-            velocity = self.velocity_xy
         arrow_color = "gold" if arrow_color is None else arrow_color
 
-        self.arrow_patch = draw_patch(
+        self._owner.arrow_patch = draw_patch(
             ax,
             shape="arrow",
             state=state,
             color=arrow_color,
+            alpha=kwargs.get("arrow_alpha"),
             zorder=arrow_zorder,
             arrow_length=arrow_length,
             arrow_width=arrow_width,
@@ -636,7 +682,7 @@ class ObjectPlot:
         end_degree = 180 * self.fov / (2 * pi)
         shape = "circle" if abs(self.fov - 2 * pi) < 0.01 else "wedge"
 
-        self.fov_patch = draw_patch(
+        self._owner.fov_patch = draw_patch(
             ax,
             shape=shape,
             state=np.zeros((3, 1)),
@@ -665,11 +711,11 @@ class ObjectPlot:
         if all:
             for trail in self.plot_trail_list:
                 trail.remove()
-            self.plot_trail_list = []
+            self._owner.plot_trail_list = []
 
-        self.plot_patch_list = []
-        self.plot_line_list = []
-        self.plot_text_list = []
+        self._owner.plot_patch_list = []
+        self._owner.plot_line_list = []
+        self._owner.plot_text_list = []
 
         for sensor in self.sensors:
             sensor.plot_clear()

--- a/irsim/world/object_plot.py
+++ b/irsim/world/object_plot.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
 from math import pi
 from typing import TYPE_CHECKING, Any
 
@@ -17,6 +19,265 @@ from irsim.util.util import file_check
 
 if TYPE_CHECKING:
     from irsim.world.object_base import ObjectBase
+
+
+@dataclass(frozen=True, slots=True)
+class VisibilityOptions:
+    """Control which components of an object are rendered."""
+
+    goal: bool = False  # Draw the goal geometry.
+    goal_text: bool = False  # Draw the goal label with object text.
+    goals: bool = False  # Preserve the legacy multi-goal flag.
+    text: bool = False  # Draw the object label.
+    arrow: bool = False  # Draw the velocity-direction arrow.
+    trajectory: bool = False  # Draw the continuous trajectory line.
+    trail: bool = False  # Draw historical shape snapshots.
+    sensor: bool = True  # Draw attached sensor overlays.
+    fov: bool = False  # Draw the field-of-view region.
+
+
+@dataclass(frozen=True, slots=True)
+class PatchStyle:
+    """Style shared by object and goal patches."""
+
+    color: Any  # Matplotlib-compatible color.
+    alpha: float | None  # Opacity; None keeps the artist default.
+    zorder: int | None  # Layer order; larger values render above.
+    linestyle: str | None = None  # Patch boundary style.
+
+
+@dataclass(frozen=True, slots=True)
+class LineStyle:
+    """Style and history length for a trajectory line."""
+
+    color: Any  # Matplotlib-compatible line color.
+    style: str  # Line style, such as "-" or "--".
+    width: float  # Width in environment data units.
+    alpha: float | None  # Opacity; None keeps the artist default.
+    zorder: int | None  # Matplotlib layer order.
+    keep_length: int = 0  # Recent states retained; 0 keeps all.
+
+
+@dataclass(frozen=True, slots=True)
+class TextStyle:
+    """Style and offset for object and goal labels."""
+
+    color: Any  # Matplotlib-compatible text color.
+    size: float  # Font size in points.
+    position: tuple[float, float]  # Label offset in data coordinates.
+    alpha: float | None  # Opacity; None keeps the artist default.
+    zorder: int | None  # Matplotlib layer order.
+
+
+@dataclass(frozen=True, slots=True)
+class TrailStyle:
+    """Style, frequency, and retention policy for object trails."""
+
+    shape: str  # Geometry used for each snapshot.
+    edge_color: Any  # Matplotlib-compatible boundary color.
+    line_width: float  # Boundary width passed to Matplotlib.
+    alpha: float | None  # Snapshot opacity.
+    fill: bool  # Fill the snapshot interior when true.
+    color: Any  # Matplotlib-compatible interior color.
+    zorder: int | None  # Matplotlib layer order.
+    frequency: int = 2  # Simulation steps between snapshots.
+    keep_length: int = 0  # Maximum snapshots; 0 keeps all.
+
+
+@dataclass(frozen=True, slots=True)
+class ArrowStyle:
+    """Style and dimensions for the velocity arrow."""
+
+    color: Any  # Matplotlib-compatible arrow color.
+    alpha: float | None  # Opacity; None keeps the artist default.
+    zorder: int | None  # Matplotlib layer order.
+    length: float = 0.4  # Length in environment data units.
+    width: float = 0.6  # Arrow-head width in data units.
+
+
+@dataclass(frozen=True, slots=True)
+class FovStyle:
+    """Style for the field-of-view patch."""
+
+    color: Any  # Matplotlib-compatible interior color.
+    edge_color: Any  # Matplotlib-compatible boundary color.
+    alpha: float | None  # Region opacity.
+    zorder: int | None  # Matplotlib layer order.
+
+
+@dataclass(frozen=True, slots=True)
+class ObjectPlotOptions:
+    """Complete immutable plotting configuration for one object."""
+
+    visibility: VisibilityOptions  # Component visibility switches.
+    object: PatchStyle  # Physical object patch style.
+    goal: PatchStyle  # Goal marker patch style.
+    trajectory: LineStyle  # Trajectory style and retention.
+    text: TextStyle  # Object and goal label style.
+    trail: TrailStyle  # Snapshot style and retention.
+    arrow: ArrowStyle  # Velocity-arrow style and dimensions.
+    fov: FovStyle  # Field-of-view region style.
+
+    @classmethod
+    def defaults(
+        cls,
+        *,
+        color: Any,
+        width: float,
+        radius: float,
+        shape: str,
+        object_zorder: int,
+    ) -> ObjectPlotOptions:
+        """Create owner-dependent plotting defaults."""
+        return cls(
+            visibility=VisibilityOptions(),
+            object=PatchStyle(color, None, object_zorder, "-"),
+            goal=PatchStyle(color, 0.5, 1),
+            trajectory=LineStyle(color, "-", width, 0.5, 0),
+            text=TextStyle(
+                color="k",
+                size=10,
+                position=(-radius - 0.1, radius + 0.1),
+                alpha=1,
+                zorder=2,
+            ),
+            trail=TrailStyle(
+                shape=shape,
+                edge_color=color,
+                line_width=0.8,
+                alpha=0.7,
+                fill=False,
+                color=color,
+                zorder=0,
+            ),
+            arrow=ArrowStyle("gold", None, 3),
+            fov=FovStyle("lightblue", "blue", 0.5, 1),
+        )
+
+    def with_overrides(self, values: Mapping[str, Any]) -> ObjectPlotOptions:
+        """Return a new options value with legacy keyword overrides applied."""
+        visibility = _replace_fields(
+            self.visibility,
+            values,
+            {
+                "show_goal": "goal",
+                "show_goal_text": "goal_text",
+                "show_goals": "goals",
+                "show_text": "text",
+                "show_arrow": "arrow",
+                "show_trajectory": "trajectory",
+                "show_trail": "trail",
+                "show_sensor": "sensor",
+                "show_fov": "fov",
+            },
+        )
+        object_style = _replace_fields(
+            self.object,
+            values,
+            {
+                "obj_color": "color",
+                "obj_alpha": "alpha",
+                "obj_zorder": "zorder",
+                "obj_linestyle": "linestyle",
+            },
+        )
+        goal = _replace_fields(
+            self.goal,
+            values,
+            {
+                "goal_color": "color",
+                "goal_alpha": "alpha",
+                "goal_zorder": "zorder",
+            },
+        )
+        trajectory = _replace_fields(
+            self.trajectory,
+            values,
+            {
+                "traj_color": "color",
+                "traj_style": "style",
+                "traj_width": "width",
+                "traj_alpha": "alpha",
+                "traj_zorder": "zorder",
+                "keep_traj_length": "keep_length",
+            },
+        )
+        text = _replace_fields(
+            self.text,
+            values,
+            {
+                "text_color": "color",
+                "text_size": "size",
+                "text_alpha": "alpha",
+                "text_zorder": "zorder",
+            },
+        )
+        if "text_position" in values:
+            text = replace(text, position=tuple(values["text_position"]))
+
+        trail = _replace_fields(
+            self.trail,
+            values,
+            {
+                "trail_type": "shape",
+                "trail_edgecolor": "edge_color",
+                "trail_linewidth": "line_width",
+                "trail_alpha": "alpha",
+                "trail_fill": "fill",
+                "trail_color": "color",
+                "trail_zorder": "zorder",
+                "trail_freq": "frequency",
+                "keep_trail_length": "keep_length",
+            },
+        )
+        arrow = _replace_fields(
+            self.arrow,
+            values,
+            {
+                "arrow_color": "color",
+                "arrow_alpha": "alpha",
+                "arrow_zorder": "zorder",
+                "arrow_length": "length",
+                "arrow_width": "width",
+            },
+        )
+        fov = _replace_fields(
+            self.fov,
+            values,
+            {
+                "fov_color": "color",
+                "fov_edge_color": "edge_color",
+                "fov_alpha": "alpha",
+                "fov_zorder": "zorder",
+            },
+        )
+
+        return replace(
+            self,
+            visibility=visibility,
+            object=object_style,
+            goal=goal,
+            trajectory=trajectory,
+            text=text,
+            trail=trail,
+            arrow=arrow,
+            fov=fov,
+        )
+
+
+def _replace_fields(
+    value: Any,
+    options: Mapping[str, Any],
+    field_names: Mapping[str, str],
+) -> Any:
+    """Replace dataclass fields whose legacy option keys are present."""
+    changes = {
+        field_name: options[option_name]
+        for option_name, field_name in field_names.items()
+        if option_name in options
+    }
+    return replace(value, **changes) if changes else value
+
 
 _PLOT_ATTRIBUTES = (
     "object_patch",
@@ -34,18 +295,20 @@ _PLOT_ATTRIBUTES = (
 class ObjectPlot:
     """Render and update the Matplotlib artists for one simulation object.
 
-    Artist attributes intentionally remain on ``ObjectBase`` during this
-    refactor. This preserves the existing plotting API while moving rendering
-    behavior out of the simulation model.
+    Simulation and artist state is accessed explicitly through ``owner``.
+    Artist attributes intentionally remain on ``ObjectBase`` to preserve the
+    existing plotting API while moving rendering behavior out of the model.
     """
 
     def __init__(self, owner: ObjectBase) -> None:
-        self._owner = owner
-
-    def __getattr__(self, name: str) -> Any:
-        """Read simulation and compatibility state from the owning object."""
-        owner = object.__getattribute__(self, "_owner")
-        return getattr(owner, name)
+        self.owner: ObjectBase = owner
+        self.options = ObjectPlotOptions.defaults(
+            color=owner.color,
+            width=owner.width,
+            radius=owner.radius,
+            shape=owner.shape,
+            object_zorder=3 if owner.role == "robot" else 1,
+        ).with_overrides(owner.plot_kwargs)
 
     def plot(
         self,
@@ -55,24 +318,24 @@ class ObjectPlot:
         **kwargs: Any,
     ) -> None:
         """Plot the object on ``ax`` using optional state and vertices."""
-        state = self.state if state is None else state
-        vertices = self.vertices if vertices is None else vertices
+        state = self.owner.state if state is None else state
+        vertices = self.owner.vertices if vertices is None else vertices
         self.draw(ax, state, vertices, **kwargs)
 
     def init(self, ax: Any, **kwargs: Any) -> list[str]:
         """Create the object's artists at its original state."""
         if (
-            self.kf is not None
-            and not self.static
-            and "show_arrow" not in self.plot_kwargs
+            self.owner.kf is not None
+            and not self.owner.static
+            and "show_arrow" not in self.owner.plot_kwargs
             and "show_arrow" not in kwargs
         ):
-            kwargs.setdefault("show_arrow", self.kf.show_arrow)
+            kwargs.setdefault("show_arrow", self.owner.kf.show_arrow)
 
         return self.draw(
             ax,
-            self.original_state,
-            self.original_vertices,
+            self.owner.original_state,
+            self.owner.original_vertices,
             initial=True,
             **kwargs,
         )
@@ -86,102 +349,111 @@ class ObjectPlot:
         **kwargs: Any,
     ) -> list[str]:
         """Create the configured artists for one object."""
-        owner = self._owner
-        owner.plot_attr_list = list(_PLOT_ATTRIBUTES)
+        owner = self.owner
+        options = self.options.with_overrides(kwargs)
+        if initial:
+            self.options = options
 
-        self.plot_kwargs.update(kwargs)
+        owner.plot_attr_list = list(_PLOT_ATTRIBUTES)
         owner.ax = ax
 
-        owner.show_goal = self.plot_kwargs.get("show_goal", False)
-        owner.show_goal_text = self.plot_kwargs.get("show_goal_text", False)
-        owner.show_goals = self.plot_kwargs.get("show_goals", False)
-        show_text = self.plot_kwargs.get("show_text", False)
-        show_arrow = self.plot_kwargs.get("show_arrow", False)
-        show_trajectory = self.plot_kwargs.get("show_trajectory", False)
-        owner.show_trail = self.plot_kwargs.get("show_trail", False)
-        owner.show_sensor = self.plot_kwargs.get("show_sensor", True)
-        show_fov = self.plot_kwargs.get("show_fov", False)
-        owner.trail_freq = self.plot_kwargs.get("trail_freq", 2)
+        visibility = options.visibility
+        owner.show_goal = visibility.goal
+        owner.show_goal_text = visibility.goal_text
+        owner.show_goals = visibility.goals
+        owner.show_trail = visibility.trail
+        owner.show_sensor = visibility.sensor
+        owner.trail_freq = options.trail.frequency
 
-        if self.shape != "map":
-            self.plot_object(ax, state, vertices, **self.plot_kwargs)
+        if owner.shape != "map":
+            self.plot_object(ax, state, vertices, _options=options)
 
-        if self.show_goal:
-            goal_state = state if initial else self.goal
-            goal_vertices = vertices if initial else self.goal_vertices
-            self.plot_goal(ax, goal_state, goal_vertices, **self.plot_kwargs)
+        if visibility.goal:
+            goal_state = state if initial else owner.goal
+            goal_vertices = vertices if initial else owner.goal_vertices
+            self.plot_goal(ax, goal_state, goal_vertices, _options=options)
 
-        if show_text:
-            self.plot_text(ax, state, **self.plot_kwargs)
+        if visibility.text:
+            self.plot_text(ax, state, _options=options)
 
-        if show_arrow:
-            current_velocity = self.velocity_xy if np.any(state) else np.zeros((2, 1))
-            arrow_theta = 0.0 if initial else self.heading
+        if visibility.arrow:
+            current_velocity = owner.velocity_xy if np.any(state) else np.zeros((2, 1))
+            arrow_theta = 0.0 if initial else owner.heading
             self.plot_arrow(
-                ax, state, current_velocity, arrow_theta, **self.plot_kwargs
+                ax,
+                state,
+                current_velocity,
+                arrow_theta,
+                _options=options,
             )
 
-        if show_trajectory:
-            trajectory_data = self.trajectory if np.any(state) else []
-            self.plot_trajectory(ax, trajectory_data, **self.plot_kwargs)
+        if visibility.trajectory:
+            trajectory_data = owner.trajectory if np.any(state) else []
+            self.plot_trajectory(ax, trajectory_data, _options=options)
 
         if (
-            self.show_trail
-            and self._world_param.count % self.trail_freq == 0
-            and self._world_param.count > 0
+            visibility.trail
+            and owner._world_param.count % options.trail.frequency == 0
+            and owner._world_param.count > 0
         ):
-            self.plot_trail(ax, state, self.vertices, **self.plot_kwargs)
+            self.plot_trail(ax, state, owner.vertices, _options=options)
 
-        if self.show_sensor:
-            for sensor in self.sensors:
-                sensor.plot(ax, state, **self.plot_kwargs)
+        if visibility.sensor:
+            sensor_options = {**owner.plot_kwargs, **kwargs}
+            for sensor in owner.sensors:
+                sensor.plot(ax, state, **sensor_options)
 
-        if show_fov:
-            self.plot_fov(ax, **self.plot_kwargs)
+        if visibility.fov:
+            self.plot_fov(ax, _options=options)
 
         return owner.plot_attr_list
 
     def step(self, **kwargs: Any) -> None:
         """Update existing artists from the owner's current state."""
-        state = self.state
+        owner = self.owner
+        options = self.options.with_overrides(kwargs)
+        state = owner.state
         x = float(state[0, 0])
         y = float(state[1, 0])
         heading = float(state[2, 0])
 
-        self._update_object_patch(kwargs)
-        self._update_object_line(x, y, heading, kwargs)
+        self._update_object_patch(options.object)
+        self._update_object_line(x, y, heading, options.object)
         self._update_object_image(heading)
-        self._update_goal_patch(kwargs)
-        self._update_arrow_patch(x, y, kwargs)
-        self._update_trajectory(kwargs)
-        self._update_fov_patch(x, y, heading, kwargs)
-        self._update_text(x, y, kwargs)
-        self._update_goal_text(kwargs)
+        self._update_goal_patch(options.goal)
+        self._update_arrow_patch(x, y, options.arrow)
+        self._update_trajectory(options.trajectory)
+        self._update_fov_patch(x, y, heading, options.fov)
+        self._update_text(x, y, options.text)
+        self._update_goal_text(options.text)
 
-        if self.show_trail and self._world_param.count % self.trail_freq == 0:
-            self.plot_trail(self.ax, state, self.original_vertices, **self.plot_kwargs)
+        if (
+            options.visibility.trail
+            and owner._world_param.count % options.trail.frequency == 0
+        ):
+            self.plot_trail(owner.ax, state, owner.original_vertices, _options=options)
 
-        if self.show_sensor:
-            for sensor in self.sensors:
+        if options.visibility.sensor:
+            for sensor in owner.sensors:
                 sensor.step_plot()
 
     def _artist(self, name: str) -> Any | None:
         """Return an artist stored on the owner, if it has been created."""
-        return getattr(self._owner, name, None)
+        return getattr(self.owner, name, None)
 
-    def _update_object_patch(self, kwargs: dict[str, Any]) -> None:
+    def _update_object_patch(self, style: PatchStyle) -> None:
         element = self._artist("object_patch")
         if element is None:
             return
 
         set_patch_property(
             element,
-            self.ax,
-            state=self.state,
-            color=kwargs.get("obj_color", self.color),
-            alpha=kwargs.get("obj_alpha"),
-            zorder=kwargs.get("obj_zorder"),
-            linestyle=kwargs.get("obj_linestyle"),
+            self.owner.ax,
+            state=self.owner.state,
+            color=style.color,
+            alpha=style.alpha,
+            zorder=style.zorder,
+            linestyle=style.linestyle,
         )
 
     def _update_object_line(
@@ -189,7 +461,7 @@ class ObjectPlot:
         x: float,
         y: float,
         heading: float,
-        kwargs: dict[str, Any],
+        style: PatchStyle,
     ) -> None:
         element = self._artist("object_line")
         if element is None:
@@ -198,81 +470,77 @@ class ObjectPlot:
         cos_heading = np.cos(heading)
         sin_heading = np.sin(heading)
         rotation = np.array([[cos_heading, -sin_heading], [sin_heading, cos_heading]])
-        vertices = rotation @ self.vertices + np.array([[x], [y]])
+        vertices = rotation @ self.owner.vertices + np.array([[x], [y]])
         element.set_data(vertices[0, :], vertices[1, :])
 
-        if "obj_linestyle" in kwargs:
-            element.set_linestyle(kwargs["obj_linestyle"])
-        if "obj_color" in kwargs:
-            element.set_color(kwargs["obj_color"])
-        if "obj_alpha" in kwargs:
-            element.set_alpha(kwargs["obj_alpha"])
-        if "obj_zorder" in kwargs:
-            element.set_zorder(kwargs["obj_zorder"])
+        element.set_linestyle(style.linestyle)
+        element.set_color(style.color)
+        element.set_alpha(style.alpha)
+        element.set_zorder(style.zorder)
 
     def _update_object_image(self, heading: float) -> None:
         element = self._artist("object_img")
-        if element is None or isinstance(self.ax, Axes3D):
+        if element is None or isinstance(self.owner.ax, Axes3D):
             return
 
-        start_x = float(self.vertices[0, 0])
-        start_y = float(self.vertices[1, 0])
+        start_x = float(self.owner.vertices[0, 0])
+        start_y = float(self.owner.vertices[1, 0])
         element.set_extent(
             [
                 start_x,
-                start_x + self.length,
+                start_x + self.owner.length,
                 start_y,
-                start_y + self.width,
+                start_y + self.owner.width,
             ]
         )
         transform = (
             mtransforms.Affine2D().rotate_around(start_x, start_y, heading)
-            + self.ax.transData
+            + self.owner.ax.transData
         )
         element.set_transform(transform)
 
-    def _update_goal_patch(self, kwargs: dict[str, Any]) -> None:
+    def _update_goal_patch(self, style: PatchStyle) -> None:
         element = self._artist("goal_patch")
         if element is None:
             return
 
-        if self.goal is None:
+        if self.owner.goal is None:
             element.set_visible(False)
             return
 
         element.set_visible(True)
         goal_state = (
-            self.goal
-            if self.goal.shape[0] > 2
-            else np.pad(self.goal, (0, 1), "constant", constant_values=0)
+            self.owner.goal
+            if self.owner.goal.shape[0] > 2
+            else np.pad(self.owner.goal, (0, 1), "constant", constant_values=0)
         )
         set_patch_property(
             element,
-            self.ax,
+            self.owner.ax,
             state=goal_state,
-            color=kwargs.get("goal_color"),
-            alpha=kwargs.get("goal_alpha"),
-            zorder=kwargs.get("goal_zorder"),
+            color=style.color,
+            alpha=style.alpha,
+            zorder=style.zorder,
         )
 
     def _update_arrow_patch(
         self,
         x: float,
         y: float,
-        kwargs: dict[str, Any],
+        style: ArrowStyle,
     ) -> None:
         element = self._artist("arrow_patch")
         if not isinstance(element, Arrow):
             return
 
-        arrow_state = np.array([[x], [y], [self.heading]])
+        arrow_state = np.array([[x], [y], [self.owner.heading]])
         set_patch_property(
             element,
-            self.ax,
+            self.owner.ax,
             state=arrow_state,
-            color=kwargs.get("arrow_color"),
-            alpha=kwargs.get("arrow_alpha"),
-            zorder=kwargs.get("arrow_zorder"),
+            color=style.color,
+            alpha=style.alpha,
+            zorder=style.zorder,
         )
 
     def _update_fov_patch(
@@ -280,138 +548,129 @@ class ObjectPlot:
         x: float,
         y: float,
         heading: float,
-        kwargs: dict[str, Any],
+        style: FovStyle,
     ) -> None:
         element = self._artist("fov_patch")
         if not isinstance(element, Wedge | Circle):
             return
 
-        direction = heading if self.state_dim >= 3 else 0.0
+        direction = heading if self.owner.state_dim >= 3 else 0.0
         set_patch_property(
             element,
-            self.ax,
+            self.owner.ax,
             state=np.array([[x], [y], [direction]]),
-            facecolor=kwargs.get("fov_color"),
-            edgecolor=kwargs.get("fov_edge_color"),
-            alpha=kwargs.get("fov_alpha"),
-            zorder=kwargs.get("fov_zorder"),
+            facecolor=style.color,
+            edgecolor=style.edge_color,
+            alpha=style.alpha,
+            zorder=style.zorder,
         )
 
-    def _update_trajectory(self, kwargs: dict[str, Any]) -> None:
+    def _update_trajectory(self, style: LineStyle) -> None:
         """Update a trajectory line and its runtime style properties."""
         element = self._artist("trajectory_line")
         if not isinstance(element, list) or not element:
             return
 
         line = element[0]
-        trajectory = self.trajectory[-self.keep_traj_length :]
+        trajectory = self.owner.trajectory[-style.keep_length :]
         x_list = [state[0, 0] for state in trajectory]
         y_list = [state[1, 0] for state in trajectory]
 
-        if isinstance(self.ax, Axes3D):
+        if isinstance(self.owner.ax, Axes3D):
             line.set_data_3d(x_list, y_list, [0] * len(x_list))
         else:
             line.set_data(x_list, y_list)
 
         ax = line.axes
         if ax is not None:
-            width = kwargs.get("traj_width", self.width)
-            line.set_linewidth(linewidth_from_data_units(width, ax, "y"))
+            line.set_linewidth(linewidth_from_data_units(style.width, ax, "y"))
 
-        if "traj_color" in kwargs:
-            line.set_color(kwargs["traj_color"])
-        if "traj_style" in kwargs:
-            line.set_linestyle(kwargs["traj_style"])
-        if "traj_alpha" in kwargs:
-            line.set_alpha(kwargs["traj_alpha"])
-        if "traj_zorder" in kwargs:
-            line.set_zorder(kwargs["traj_zorder"])
+        line.set_color(style.color)
+        line.set_linestyle(style.style)
+        line.set_alpha(style.alpha)
+        line.set_zorder(style.zorder)
 
-    def _update_text(self, x: float, y: float, kwargs: dict[str, Any]) -> None:
+    def _update_text(self, x: float, y: float, style: TextStyle) -> None:
         """Update the object label when it exists."""
-        if not hasattr(self, "_text"):
+        owner = self.owner
+        if not hasattr(owner, "_text"):
             return
 
-        text = self._text
-        default_position = [-self.radius - 0.1, self.radius + 0.1]
-        text_position = kwargs.get(
-            "text_position",
-            self.plot_kwargs.get("text_position", default_position),
-        )
-        text.set_position((x + text_position[0], y + text_position[1]))
-        text.set_text(self._get_text())
-        self._set_text_properties(text, kwargs)
+        text = owner._text
+        text.set_position((x + style.position[0], y + style.position[1]))
+        text.set_text(owner._get_text())
+        self._set_text_properties(text, style)
 
-    def _update_goal_text(self, kwargs: dict[str, Any]) -> None:
+    def _update_goal_text(self, style: TextStyle) -> None:
         """Update the goal label when the object has a goal."""
-        if self.goal is None or not hasattr(self, "_goal_text"):
+        owner = self.owner
+        if owner.goal is None or not hasattr(owner, "_goal_text"):
             return
 
-        default_position = [-self.radius - 0.1, self.radius + 0.1]
-        text_position = kwargs.get(
-            "text_position",
-            self.plot_kwargs.get("text_position", default_position),
-        )
-        goal_text = self._goal_text
+        goal_text = owner._goal_text
         goal_text.set_position(
             (
-                self.goal[0, 0] + text_position[0],
-                self.goal[1, 0] + text_position[1],
+                owner.goal[0, 0] + style.position[0],
+                owner.goal[1, 0] + style.position[1],
             )
         )
-        goal_text.set_text(self._get_goal_text())
-        self._set_text_properties(goal_text, kwargs)
+        goal_text.set_text(owner._get_goal_text())
+        self._set_text_properties(goal_text, style)
 
     @staticmethod
-    def _set_text_properties(text: Any, kwargs: dict[str, Any]) -> None:
-        """Apply supplied runtime properties to a Matplotlib text artist."""
-        if "text_color" in kwargs:
-            text.set_color(kwargs["text_color"])
-        if "text_size" in kwargs:
-            text.set_fontsize(kwargs["text_size"])
-        if "text_alpha" in kwargs:
-            text.set_alpha(kwargs["text_alpha"])
-        if "text_zorder" in kwargs:
-            text.set_zorder(kwargs["text_zorder"])
+    def _set_text_properties(text: Any, style: TextStyle) -> None:
+        """Apply resolved properties to a Matplotlib text artist."""
+        text.set_color(style.color)
+        text.set_fontsize(style.size)
+        text.set_alpha(style.alpha)
+        text.set_zorder(style.zorder)
 
     def plot_object(
         self,
         ax: Any,
         state: np.ndarray | None = None,
         vertices: np.ndarray | None = None,
+        _options: ObjectPlotOptions | None = None,
         **kwargs: Any,
     ) -> None:
         """Draw the object's geometry or configured description image."""
-        obj_linestyle = kwargs.get("obj_linestyle", "-")
-        obj_zorder = kwargs.get("obj_zorder", 3) if self.role == "robot" else 1
-        obj_color = kwargs.get("obj_color", self.color)
-        obj_alpha = kwargs.get("obj_alpha")
-        state = self.state if state is None else state
-        vertices = self.vertices if vertices is None else vertices
+        options = self.options.with_overrides(kwargs) if _options is None else _options
+        state = self.owner.state if state is None else state
+        vertices = self.owner.vertices if vertices is None else vertices
 
-        if self.description is None or isinstance(ax, Axes3D):
+        if self.owner.description is None or isinstance(ax, Axes3D):
             try:
-                if self.shape != "map":
-                    self._owner.object_patch = draw_patch(
+                if self.owner.shape != "map":
+                    self.owner.object_patch = draw_patch(
                         ax,
-                        shape=self.shape,
+                        shape=self.owner.shape,
                         state=state,
-                        radius=self.radius,
+                        radius=self.owner.radius,
                         center=(
-                            self.original_centroid if self.shape == "circle" else None
+                            self.owner.original_centroid
+                            if self.owner.shape == "circle"
+                            else None
                         ),
                         vertices=vertices,
-                        color=obj_color,
-                        alpha=obj_alpha,
-                        linestyle=obj_linestyle,
-                        zorder=obj_zorder,
+                        color=options.object.color,
+                        alpha=options.object.alpha,
+                        linestyle=options.object.linestyle,
+                        zorder=options.object.zorder,
                     )
-                    self.plot_patch_list.append(self.object_patch)
+                    self.owner.plot_patch_list.append(self.owner.object_patch)
             except Exception as exc:
-                self.logger.error(f"Error occurred while plotting object: {exc!s}")
+                self.owner.logger.error(
+                    f"Error occurred while plotting object: {exc!s}"
+                )
                 raise
         else:
-            self.plot_object_image(ax, state, vertices, self.description, **kwargs)
+            self.plot_object_image(
+                ax,
+                state,
+                vertices,
+                self.owner.description,
+                _options=options,
+            )
 
     def plot_object_image(
         self,
@@ -419,11 +678,14 @@ class ObjectPlot:
         state: np.ndarray | None = None,
         vertices: np.ndarray | None = None,
         description: str | None = None,
+        _options: ObjectPlotOptions | None = None,
         **kwargs: Any,
     ) -> None:
         """Draw an image description at the object's pose."""
         if vertices is None or state is None:
             return
+
+        options = self.options.with_overrides(kwargs) if _options is None else _options
 
         image_path = file_check(
             description,
@@ -435,18 +697,17 @@ class ObjectPlot:
         start_x = float(vertices[0, 0])
         start_y = float(vertices[1, 0])
         angle_degrees = 180 * float(state[2, 0]) / pi
-        obj_zorder = kwargs.get("obj_zorder", 2)
         image_data = image.imread(image_path)
 
         object_image = ax.imshow(
             image_data,
             extent=[
                 start_x,
-                start_x + self.length,
+                start_x + self.owner.length,
                 start_y,
-                start_y + self.width,
+                start_y + self.owner.width,
             ],
-            zorder=obj_zorder,
+            zorder=options.object.zorder,
         )
         transform = (
             mtransforms.Affine2D().rotate_deg_around(start_x, start_y, angle_degrees)
@@ -454,47 +715,48 @@ class ObjectPlot:
         )
         object_image.set_transform(transform)
 
-        self.plot_patch_list.append(object_image)
-        self._owner.object_img = object_image
+        self.owner.plot_patch_list.append(object_image)
+        self.owner.object_img = object_image
 
     def plot_trajectory(
         self,
         ax: Any,
         trajectory: list[Any] | None = None,
         keep_traj_length: int = 0,
+        _options: ObjectPlotOptions | None = None,
         **kwargs: Any,
     ) -> None:
         """Draw the object's trajectory."""
-        trajectory = self.trajectory if trajectory is None else trajectory
-        self._owner.keep_traj_length = keep_traj_length
+        if _options is None:
+            options = self.options.with_overrides(
+                {**kwargs, "keep_traj_length": keep_traj_length}
+            )
+        else:
+            options = _options
+        trajectory = self.owner.trajectory if trajectory is None else trajectory
+        self.owner.keep_traj_length = options.trajectory.keep_length
 
-        traj_color = kwargs.get("traj_color", self.color)
-        traj_style = kwargs.get("traj_style", "-")
-        traj_width = kwargs.get("traj_width", self.width)
-        traj_alpha = kwargs.get("traj_alpha", 0.5)
-        traj_zorder = kwargs.get("traj_zorder", 0)
-
-        kept_trajectory = trajectory[-self.keep_traj_length :]
+        kept_trajectory = trajectory[-options.trajectory.keep_length :]
         x_list = [state[0, 0] for state in kept_trajectory]
         y_list = [state[1, 0] for state in kept_trajectory]
 
-        linewidth = linewidth_from_data_units(traj_width, ax, "y")
+        linewidth = linewidth_from_data_units(options.trajectory.width, ax, "y")
         if isinstance(ax, Axes3D):
-            linewidth = traj_width * 10
+            linewidth = options.trajectory.width * 10
 
-        solid_capstyle = "round" if self.shape == "circle" else "butt"
-        self._owner.trajectory_line = ax.plot(
+        solid_capstyle = "round" if self.owner.shape == "circle" else "butt"
+        self.owner.trajectory_line = ax.plot(
             x_list,
             y_list,
-            color=traj_color,
-            linestyle=traj_style,
+            color=options.trajectory.color,
+            linestyle=options.trajectory.style,
             linewidth=linewidth,
             solid_joinstyle="round",
             solid_capstyle=solid_capstyle,
-            alpha=traj_alpha,
-            zorder=traj_zorder,
+            alpha=options.trajectory.alpha,
+            zorder=options.trajectory.zorder,
         )
-        self.plot_line_list.append(self.trajectory_line)
+        self.owner.plot_line_list.append(self.owner.trajectory_line)
 
     def plot_goal(
         self,
@@ -504,102 +766,102 @@ class ObjectPlot:
         goal_color: str | None = None,
         goal_zorder: int | None = 1,
         goal_alpha: float | None = 0.5,
+        _options: ObjectPlotOptions | None = None,
         **kwargs: Any,
     ) -> None:
         """Draw the object's goal geometry."""
         if goal_state is None:
             return
 
-        goal_color = self.color if goal_color is None else goal_color
-        self._owner.goal_patch = draw_patch(
+        if _options is None:
+            overrides = {
+                **kwargs,
+                "goal_zorder": goal_zorder,
+                "goal_alpha": goal_alpha,
+            }
+            if goal_color is not None:
+                overrides["goal_color"] = goal_color
+            options = self.options.with_overrides(overrides)
+        else:
+            options = _options
+
+        self.owner.goal_patch = draw_patch(
             ax,
-            shape=self.shape,
+            shape=self.owner.shape,
             state=goal_state,
-            radius=self.radius,
+            radius=self.owner.radius,
             vertices=vertices,
-            color=goal_color,
-            alpha=goal_alpha,
-            zorder=goal_zorder,
+            color=options.goal.color,
+            alpha=options.goal.alpha,
+            zorder=options.goal.zorder,
         )
-        self.plot_patch_list.append(self.goal_patch)
+        self.owner.plot_patch_list.append(self.owner.goal_patch)
 
     def plot_text(
         self,
         ax: Any,
         state: np.ndarray | None = None,
+        _options: ObjectPlotOptions | None = None,
         **kwargs: Any,
     ) -> None:
         """Draw the object label and optional goal label."""
-        state = self.state if state is None else state
-        text_color = kwargs.get("text_color", "k")
-        text_size = kwargs.get("text_size", 10)
-        text_position = kwargs.get(
-            "text_position", [-self.radius - 0.1, self.radius + 0.1]
-        )
-        text_zorder = kwargs.get("text_zorder", 2)
-        text_alpha = kwargs.get("text_alpha", 1)
+        options = self.options.with_overrides(kwargs) if _options is None else _options
+        state = self.owner.state if state is None else state
         x, y = state[0, 0], state[1, 0]
 
         if isinstance(ax, Axes3D):
-            self._owner._text = ax.text(
-                x + text_position[0],
-                y + text_position[1],
-                self.z,
-                self._get_text(),
-                fontsize=text_size,
-                color=text_color,
-                zorder=text_zorder,
-                alpha=text_alpha,
+            self.owner._text = ax.text(
+                x + options.text.position[0],
+                y + options.text.position[1],
+                self.owner.z,
+                self.owner._get_text(),
+                fontsize=options.text.size,
+                color=options.text.color,
+                zorder=options.text.zorder,
+                alpha=options.text.alpha,
             )
         else:
-            self._owner._text = ax.text(
-                x + text_position[0],
-                y + text_position[1],
-                self._get_text(),
-                fontsize=text_size,
-                color=text_color,
-                zorder=text_zorder,
-                alpha=text_alpha,
+            self.owner._text = ax.text(
+                x + options.text.position[0],
+                y + options.text.position[1],
+                self.owner._get_text(),
+                fontsize=options.text.size,
+                color=options.text.color,
+                zorder=options.text.zorder,
+                alpha=options.text.alpha,
             )
-        self.plot_text_list.append(self._text)
+        self.owner.plot_text_list.append(self.owner._text)
 
-        if self.show_goal and self.show_goal_text and self.goal is not None:
-            self._plot_goal_text(
-                ax,
-                text_position,
-                text_color,
-                text_size,
-                text_zorder,
-                text_alpha,
-            )
+        if (
+            getattr(self.owner, "show_goal", options.visibility.goal)
+            and getattr(self.owner, "show_goal_text", options.visibility.goal_text)
+            and self.owner.goal is not None
+        ):
+            self._plot_goal_text(ax, options.text)
 
     def _plot_goal_text(
         self,
         ax: Any,
-        text_position: list[float],
-        text_color: str,
-        text_size: int,
-        text_zorder: int,
-        text_alpha: float,
+        style: TextStyle,
     ) -> None:
         """Create the goal label for ``plot_text``."""
-        goal_x, goal_y = self.goal[0, 0], self.goal[1, 0]
+        goal_x, goal_y = self.owner.goal[0, 0], self.owner.goal[1, 0]
         args = [
-            goal_x + text_position[0],
-            goal_y + text_position[1],
+            goal_x + style.position[0],
+            goal_y + style.position[1],
         ]
         if isinstance(ax, Axes3D):
-            args.append(self.z)
+            args.append(self.owner.z)
 
-        self._owner._goal_text = ax.text(
+        self.owner._goal_text = ax.text(
             *args,
-            self._get_goal_text(),
-            fontsize=text_size,
-            color=text_color,
-            zorder=text_zorder,
-            alpha=text_alpha,
+            self.owner._get_goal_text(),
+            fontsize=style.size,
+            color=style.color,
+            zorder=style.zorder,
+            alpha=style.alpha,
         )
-        self.plot_text_list.append(self._goal_text)
+        self.owner.plot_text_list.append(self.owner._goal_text)
 
     def plot_arrow(
         self,
@@ -611,24 +873,36 @@ class ObjectPlot:
         arrow_width: float = 0.6,
         arrow_color: str | None = None,
         arrow_zorder: int = 3,
+        _options: ObjectPlotOptions | None = None,
         **kwargs: Any,
     ) -> None:
         """Draw an arrow indicating the object's velocity orientation."""
-        state = self.state if state is None else state
-        arrow_color = "gold" if arrow_color is None else arrow_color
+        if _options is None:
+            overrides = {
+                **kwargs,
+                "arrow_length": arrow_length,
+                "arrow_width": arrow_width,
+                "arrow_zorder": arrow_zorder,
+            }
+            if arrow_color is not None:
+                overrides["arrow_color"] = arrow_color
+            options = self.options.with_overrides(overrides)
+        else:
+            options = _options
+        state = self.owner.state if state is None else state
 
-        self._owner.arrow_patch = draw_patch(
+        self.owner.arrow_patch = draw_patch(
             ax,
             shape="arrow",
             state=state,
-            color=arrow_color,
-            alpha=kwargs.get("arrow_alpha"),
-            zorder=arrow_zorder,
-            arrow_length=arrow_length,
-            arrow_width=arrow_width,
+            color=options.arrow.color,
+            alpha=options.arrow.alpha,
+            zorder=options.arrow.zorder,
+            arrow_length=options.arrow.length,
+            arrow_width=options.arrow.width,
             theta=arrow_theta,
         )
-        self.plot_patch_list.append(self.arrow_patch)
+        self.owner.plot_patch_list.append(self.owner.arrow_patch)
 
     def plot_trail(
         self,
@@ -636,86 +910,95 @@ class ObjectPlot:
         state: np.ndarray | None = None,
         vertices: np.ndarray | None = None,
         keep_trail_length: int = 0,
+        _options: ObjectPlotOptions | None = None,
         **kwargs: Any,
     ) -> None:
         """Draw a historical outline of the object."""
-        vertices = self.original_vertices if vertices is None else vertices
-        trail_type = kwargs.get("trail_type", self.shape)
-        trail_edgecolor = kwargs.get("trail_edgecolor", self.color)
-        trail_linewidth = kwargs.get("trail_linewidth", 0.8)
-        trail_alpha = kwargs.get("trail_alpha", 0.7)
-        trail_fill = kwargs.get("trail_fill", False)
-        trail_color = kwargs.get("trail_color", self.color)
-        trail_zorder = kwargs.get("trail_zorder", 0)
+        if _options is None:
+            options = self.options.with_overrides(
+                {**kwargs, "keep_trail_length": keep_trail_length}
+            )
+        else:
+            options = _options
+        vertices = self.owner.original_vertices if vertices is None else vertices
 
         trail = draw_patch(
             ax,
-            shape=trail_type,
+            shape=options.trail.shape,
             state=state,
             vertices=vertices,
-            radius=self.radius,
-            center=(self.original_centroid if trail_type == "circle" else None),
-            width=self.length,
-            height=self.width,
-            edgecolor=trail_edgecolor,
-            facecolor=trail_color,
-            fill=trail_fill,
-            alpha=trail_alpha,
-            linewidth=trail_linewidth,
-            zorder=trail_zorder,
+            radius=self.owner.radius,
+            center=(
+                self.owner.original_centroid
+                if options.trail.shape == "circle"
+                else None
+            ),
+            width=self.owner.length,
+            height=self.owner.width,
+            edgecolor=options.trail.edge_color,
+            facecolor=options.trail.color,
+            fill=options.trail.fill,
+            alpha=options.trail.alpha,
+            linewidth=options.trail.line_width,
+            zorder=options.trail.zorder,
         )
-        self.plot_trail_list.append(trail)
+        self.owner.plot_trail_list.append(trail)
 
-        if len(self.plot_trail_list) > keep_trail_length and keep_trail_length > 0:
-            self.plot_trail_list.pop(0).remove()
+        if (
+            len(self.owner.plot_trail_list) > options.trail.keep_length
+            and options.trail.keep_length > 0
+        ):
+            self.owner.plot_trail_list.pop(0).remove()
 
-    def plot_fov(self, ax: Any, **kwargs: Any) -> None:
+    def plot_fov(
+        self,
+        ax: Any,
+        _options: ObjectPlotOptions | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Draw the object's configured field of view."""
-        if self.fov is None or self.fov_radius is None:
+        if self.owner.fov is None or self.owner.fov_radius is None:
             return
 
-        fov_color = kwargs.get("fov_color", "lightblue")
-        fov_edge_color = kwargs.get("fov_edge_color", "blue")
-        fov_zorder = kwargs.get("fov_zorder", 1)
-        fov_alpha = kwargs.get("fov_alpha", 0.5)
-        start_degree = -180 * self.fov / (2 * pi)
-        end_degree = 180 * self.fov / (2 * pi)
-        shape = "circle" if abs(self.fov - 2 * pi) < 0.01 else "wedge"
+        options = self.options.with_overrides(kwargs) if _options is None else _options
+        start_degree = -180 * self.owner.fov / (2 * pi)
+        end_degree = 180 * self.owner.fov / (2 * pi)
+        shape = "circle" if abs(self.owner.fov - 2 * pi) < 0.01 else "wedge"
 
-        self._owner.fov_patch = draw_patch(
+        self.owner.fov_patch = draw_patch(
             ax,
             shape=shape,
             state=np.zeros((3, 1)),
-            radius=self.fov_radius,
+            radius=self.owner.fov_radius,
             theta1=start_degree,
             theta2=end_degree,
-            facecolor=fov_color,
-            edgecolor=fov_edge_color,
-            alpha=fov_alpha,
-            zorder=fov_zorder,
+            facecolor=options.fov.color,
+            edgecolor=options.fov.edge_color,
+            alpha=options.fov.alpha,
+            zorder=options.fov.zorder,
         )
-        self.plot_patch_list.append(self.fov_patch)
+        self.owner.plot_patch_list.append(self.owner.fov_patch)
 
     def plot_uncertainty(self, ax: Any, **kwargs: Any) -> None:
         """Reserved for future uncertainty rendering."""
 
     def clear(self, all: bool = False) -> None:
         """Remove this object's artists, optionally including its trails."""
-        for patch in self.plot_patch_list:
+        for patch in self.owner.plot_patch_list:
             patch.remove()
-        for line in self.plot_line_list:
+        for line in self.owner.plot_line_list:
             line.pop(0).remove()
-        for text in self.plot_text_list:
+        for text in self.owner.plot_text_list:
             text.remove()
 
         if all:
-            for trail in self.plot_trail_list:
+            for trail in self.owner.plot_trail_list:
                 trail.remove()
-            self._owner.plot_trail_list = []
+            self.owner.plot_trail_list = []
 
-        self._owner.plot_patch_list = []
-        self._owner.plot_line_list = []
-        self._owner.plot_text_list = []
+        self.owner.plot_patch_list = []
+        self.owner.plot_line_list = []
+        self.owner.plot_text_list = []
 
-        for sensor in self.sensors:
+        for sensor in self.owner.sensors:
             sensor.plot_clear()

--- a/irsim/world/object_plot.py
+++ b/irsim/world/object_plot.py
@@ -541,7 +541,9 @@ class ObjectPlot:
         goal_state = (
             self.owner.goal
             if self.owner.goal.shape[0] > 2
-            else np.pad(self.owner.goal, (0, 1), "constant", constant_values=0)
+            else np.pad(
+                self.owner.goal, ((0, 1), (0, 0)), "constant", constant_values=0
+            )
         )
         set_patch_property(
             element,

--- a/irsim/world/object_plot.py
+++ b/irsim/world/object_plot.py
@@ -1,0 +1,675 @@
+"""Matplotlib rendering for :class:`irsim.world.object_base.ObjectBase`."""
+
+from __future__ import annotations
+
+from math import pi
+from typing import TYPE_CHECKING, Any
+
+import matplotlib.transforms as mtransforms
+import numpy as np
+from matplotlib import image
+from matplotlib.patches import Arrow, Circle, Wedge
+from mpl_toolkits.mplot3d import Axes3D
+
+from irsim.config.path_param import path_manager
+from irsim.env.env_plot import draw_patch, linewidth_from_data_units, set_patch_property
+from irsim.util.util import file_check
+
+if TYPE_CHECKING:
+    from irsim.world.object_base import ObjectBase
+
+
+class ObjectPlot:
+    """Render and update the Matplotlib artists for one simulation object.
+
+    Artist attributes intentionally remain on ``ObjectBase`` during this
+    refactor. This preserves the existing plotting API while moving rendering
+    behavior out of the simulation model.
+    """
+
+    def __init__(self, obj: ObjectBase) -> None:
+        object.__setattr__(self, "_object", obj)
+
+    def __getattr__(self, name: str) -> Any:
+        """Read object state and existing artist attributes transparently."""
+        return getattr(self._object, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Keep artist state on the object for backward compatibility."""
+        if name == "_object":
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._object, name, value)
+
+    def plot(
+        self,
+        ax: Any,
+        state: np.ndarray | None = None,
+        vertices: np.ndarray | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Plot the object on ``ax`` using optional state and vertices."""
+        state = self.state if state is None else state
+        vertices = self.vertices if vertices is None else vertices
+        self._plot(ax, state, vertices, **kwargs)
+
+    def init(self, ax: Any, **kwargs: Any) -> list[str]:
+        """Create the object's artists at its original state."""
+        if (
+            self.kf is not None
+            and not self.static
+            and "show_arrow" not in self.plot_kwargs
+            and "show_arrow" not in kwargs
+        ):
+            kwargs.setdefault("show_arrow", self.kf.show_arrow)
+
+        return self._plot(
+            ax,
+            self.original_state,
+            self.original_vertices,
+            initial=True,
+            **kwargs,
+        )
+
+    def _plot(
+        self,
+        ax: Any,
+        state: np.ndarray,
+        vertices: np.ndarray,
+        initial: bool = False,
+        **kwargs: Any,
+    ) -> list[str]:
+        """Create the configured artists for one object."""
+        self.plot_attr_list = [
+            "object_patch",
+            "object_line",
+            "object_img",
+            "goal_patch",
+            "_text",
+            "_goal_text",
+            "arrow_patch",
+            "trajectory_line",
+            "fov_patch",
+        ]
+
+        self.plot_kwargs.update(kwargs)
+        self.ax = ax
+
+        self.show_goal = self.plot_kwargs.get("show_goal", False)
+        self.show_goal_text = self.plot_kwargs.get("show_goal_text", False)
+        self.show_goals = self.plot_kwargs.get("show_goals", False)
+        show_text = self.plot_kwargs.get("show_text", False)
+        show_arrow = self.plot_kwargs.get("show_arrow", False)
+        show_trajectory = self.plot_kwargs.get("show_trajectory", False)
+        self.show_trail = self.plot_kwargs.get("show_trail", False)
+        self.show_sensor = self.plot_kwargs.get("show_sensor", True)
+        show_fov = self.plot_kwargs.get("show_fov", False)
+        self.trail_freq = self.plot_kwargs.get("trail_freq", 2)
+
+        if self.shape != "map":
+            self.plot_object(ax, state, vertices, **self.plot_kwargs)
+
+        if self.show_goal:
+            goal_state = state if initial else self.goal
+            goal_vertices = vertices if initial else self.goal_vertices
+            self.plot_goal(ax, goal_state, goal_vertices, **self.plot_kwargs)
+
+        if show_text:
+            self.plot_text(ax, state, **self.plot_kwargs)
+
+        if show_arrow:
+            current_velocity = self.velocity_xy if np.any(state) else np.zeros((2, 1))
+            arrow_theta = 0.0 if initial else self.heading
+            self.plot_arrow(
+                ax, state, current_velocity, arrow_theta, **self.plot_kwargs
+            )
+
+        if show_trajectory:
+            trajectory_data = self.trajectory if np.any(state) else []
+            self.plot_trajectory(ax, trajectory_data, **self.plot_kwargs)
+
+        if (
+            self.show_trail
+            and self._world_param.count % self.trail_freq == 0
+            and self._world_param.count > 0
+        ):
+            self.plot_trail(ax, state, self.vertices, **self.plot_kwargs)
+
+        if self.show_sensor:
+            for sensor in self.sensors:
+                sensor.plot(ax, state, **self.plot_kwargs)
+
+        if show_fov:
+            self.plot_fov(ax, **self.plot_kwargs)
+
+        return self.plot_attr_list
+
+    def step(self, **kwargs: Any) -> None:
+        """Update the existing artists from the object's current state."""
+        x = self.state[0, 0]
+        y = self.state[1, 0]
+        r_phi = self.state[2, 0]
+        r_phi_ang = 180 * r_phi / pi
+
+        for attr in self.plot_attr_list:
+            if not hasattr(self, attr):
+                continue
+
+            element = getattr(self, attr)
+            if attr == "object_patch":
+                obj_kwargs = {
+                    "color": kwargs.get("obj_color", self.color),
+                    "alpha": kwargs.get("obj_alpha"),
+                    "zorder": kwargs.get("obj_zorder"),
+                    "linestyle": kwargs.get("obj_linestyle"),
+                }
+                set_patch_property(element, self.ax, state=self.state, **obj_kwargs)
+
+            elif attr == "object_line":
+                vertices = self.vertices
+                cos_phi = np.cos(r_phi)
+                sin_phi = np.sin(r_phi)
+                rotation_matrix = np.array([[cos_phi, -sin_phi], [sin_phi, cos_phi]])
+                rotated_vertices = np.dot(vertices.T, rotation_matrix.T).T
+                translated_vertices = rotated_vertices + np.array([[x], [y]])
+                element.set_data(translated_vertices[0, :], translated_vertices[1, :])
+                if "obj_linestyle" in kwargs:
+                    element.set_linestyle(kwargs["obj_linestyle"])
+                if "obj_color" in kwargs:
+                    element.set_color(kwargs["obj_color"])
+                if "obj_alpha" in kwargs:
+                    element.set_alpha(kwargs["obj_alpha"])
+                if "obj_zorder" in kwargs:
+                    element.set_zorder(kwargs["obj_zorder"])
+
+            elif attr == "object_img":
+                start_x = self.vertices[0, 0]
+                start_y = self.vertices[1, 0]
+                if not isinstance(self.ax, Axes3D):
+                    element.set_extent(
+                        [
+                            start_x,
+                            start_x + self.length,
+                            start_y,
+                            start_y + self.width,
+                        ]
+                    )
+                    transform = (
+                        mtransforms.Affine2D().rotate_deg_around(
+                            start_x, start_y, r_phi_ang
+                        )
+                        + self.ax.transData
+                    )
+                    element.set_transform(transform)
+
+            elif attr == "goal_patch":
+                goal_kwargs = {
+                    "color": kwargs.get("goal_color"),
+                    "alpha": kwargs.get("goal_alpha"),
+                    "zorder": kwargs.get("goal_zorder"),
+                }
+                if self.goal is None:
+                    element.set_visible(False)
+                    continue
+                if not element.get_visible():
+                    element.set_visible(True)
+
+                goal_state = (
+                    self.goal
+                    if self.goal.shape[0] > 2
+                    else np.pad(self.goal, (0, 1), "constant", constant_values=0)
+                )
+                set_patch_property(element, self.ax, state=goal_state, **goal_kwargs)
+
+            elif attr == "arrow_patch" and isinstance(element, Arrow):
+                arrow_state = np.array([[x], [y], [self.heading]])
+                arrow_kwargs = {
+                    "color": kwargs.get("arrow_color"),
+                    "alpha": kwargs.get("arrow_alpha"),
+                    "zorder": kwargs.get("arrow_zorder"),
+                }
+                set_patch_property(element, self.ax, state=arrow_state, **arrow_kwargs)
+
+            elif attr == "trajectory_line":
+                self._step_trajectory(element, kwargs)
+
+            elif attr == "fov_patch" and isinstance(element, Wedge | Circle):
+                direction = r_phi if self.state_dim >= 3 else 0
+                fov_state = np.array([[x], [y], [direction]])
+                fov_kwargs = {
+                    "alpha": kwargs.get("fov_alpha"),
+                    "zorder": kwargs.get("fov_zorder"),
+                }
+                set_patch_property(element, self.ax, state=fov_state, **fov_kwargs)
+
+        self._step_text(x, y, kwargs)
+        self._step_goal_text(kwargs)
+
+        if self.show_trail and self._world_param.count % self.trail_freq == 0:
+            self.plot_trail(
+                self.ax, self.state, self.original_vertices, **self.plot_kwargs
+            )
+
+        if self.show_sensor:
+            for sensor in self.sensors:
+                sensor.step_plot()
+
+    def _step_trajectory(self, element: Any, kwargs: dict[str, Any]) -> None:
+        """Update a trajectory line and its runtime style properties."""
+        if not isinstance(element, list) or not element:
+            return
+
+        line = element[0]
+        trajectory = self.trajectory[-self.keep_traj_length :]
+        x_list = [state[0, 0] for state in trajectory]
+        y_list = [state[1, 0] for state in trajectory]
+
+        if isinstance(self.ax, Axes3D):
+            line.set_data_3d(x_list, y_list, [0] * len(x_list))
+        else:
+            line.set_data(x_list, y_list)
+
+        ax = line.axes
+        if ax is not None:
+            width = kwargs.get("traj_width", self.width)
+            line.set_linewidth(linewidth_from_data_units(width, ax, "y"))
+
+        if "traj_color" in kwargs:
+            line.set_color(kwargs["traj_color"])
+        if "traj_style" in kwargs:
+            line.set_linestyle(kwargs["traj_style"])
+        if "traj_alpha" in kwargs:
+            line.set_alpha(kwargs["traj_alpha"])
+        if "traj_zorder" in kwargs:
+            line.set_zorder(kwargs["traj_zorder"])
+
+    def _step_text(self, x: float, y: float, kwargs: dict[str, Any]) -> None:
+        """Update the object label when it exists."""
+        if not hasattr(self, "_text"):
+            return
+
+        text = self._text
+        default_position = [-self.radius - 0.1, self.radius + 0.1]
+        text_position = kwargs.get(
+            "text_position",
+            self.plot_kwargs.get("text_position", default_position),
+        )
+        text.set_position((x + text_position[0], y + text_position[1]))
+        text.set_text(self._get_text())
+        self._set_text_properties(text, kwargs)
+
+    def _step_goal_text(self, kwargs: dict[str, Any]) -> None:
+        """Update the goal label when the object has a goal."""
+        if self.goal is None or not hasattr(self, "_goal_text"):
+            return
+
+        default_position = [-self.radius - 0.1, self.radius + 0.1]
+        text_position = kwargs.get(
+            "text_position",
+            self.plot_kwargs.get("text_position", default_position),
+        )
+        goal_text = self._goal_text
+        goal_text.set_position(
+            (
+                self.goal[0, 0] + text_position[0],
+                self.goal[1, 0] + text_position[1],
+            )
+        )
+        goal_text.set_text(self._get_goal_text())
+        self._set_text_properties(goal_text, kwargs)
+
+    @staticmethod
+    def _set_text_properties(text: Any, kwargs: dict[str, Any]) -> None:
+        """Apply supplied runtime properties to a Matplotlib text artist."""
+        if "text_color" in kwargs:
+            text.set_color(kwargs["text_color"])
+        if "text_size" in kwargs:
+            text.set_fontsize(kwargs["text_size"])
+        if "text_alpha" in kwargs:
+            text.set_alpha(kwargs["text_alpha"])
+        if "text_zorder" in kwargs:
+            text.set_zorder(kwargs["text_zorder"])
+
+    def plot_object(
+        self,
+        ax: Any,
+        state: np.ndarray | None = None,
+        vertices: np.ndarray | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Draw the object's geometry or configured description image."""
+        obj_linestyle = kwargs.get("obj_linestyle", "-")
+        obj_zorder = kwargs.get("obj_zorder", 3) if self.role == "robot" else 1
+        state = self.state if state is None else state
+        vertices = self.vertices if vertices is None else vertices
+
+        if self.description is None or isinstance(ax, Axes3D):
+            try:
+                if self.shape != "map":
+                    self.object_patch = draw_patch(
+                        ax,
+                        shape=self.shape,
+                        state=state,
+                        radius=self.radius,
+                        center=(
+                            self.original_centroid if self.shape == "circle" else None
+                        ),
+                        vertices=vertices,
+                        color=self.color,
+                        linestyle=obj_linestyle,
+                        zorder=obj_zorder,
+                    )
+                    self.plot_patch_list.append(self.object_patch)
+            except Exception as exc:
+                self.logger.error(f"Error occurred while plotting object: {exc!s}")
+                raise
+        else:
+            self.plot_object_image(ax, state, vertices, self.description, **kwargs)
+
+    def plot_object_image(
+        self,
+        ax: Any,
+        state: np.ndarray | None = None,
+        vertices: np.ndarray | None = None,
+        description: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Draw an image description at the object's pose."""
+        if vertices is None or state is None:
+            return
+
+        image_path = file_check(
+            description,
+            root_path=path_manager.root_path + "/world/description/",
+        )
+        if image_path is None:
+            return
+
+        start_x = float(vertices[0, 0])
+        start_y = float(vertices[1, 0])
+        angle_degrees = 180 * float(state[2, 0]) / pi
+        obj_zorder = kwargs.get("obj_zorder", 2)
+        image_data = image.imread(image_path)
+
+        object_image = ax.imshow(
+            image_data,
+            extent=[
+                start_x,
+                start_x + self.length,
+                start_y,
+                start_y + self.width,
+            ],
+            zorder=obj_zorder,
+        )
+        transform = (
+            mtransforms.Affine2D().rotate_deg_around(start_x, start_y, angle_degrees)
+            + ax.transData
+        )
+        object_image.set_transform(transform)
+
+        self.plot_patch_list.append(object_image)
+        self.object_img = object_image
+
+    def plot_trajectory(
+        self,
+        ax: Any,
+        trajectory: list[Any] | None = None,
+        keep_traj_length: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        """Draw the object's trajectory."""
+        trajectory = self.trajectory if trajectory is None else trajectory
+        self.keep_traj_length = keep_traj_length
+
+        traj_color = kwargs.get("traj_color", self.color)
+        traj_style = kwargs.get("traj_style", "-")
+        traj_width = kwargs.get("traj_width", self.width)
+        traj_alpha = kwargs.get("traj_alpha", 0.5)
+        traj_zorder = kwargs.get("traj_zorder", 0)
+
+        kept_trajectory = trajectory[-self.keep_traj_length :]
+        x_list = [state[0, 0] for state in kept_trajectory]
+        y_list = [state[1, 0] for state in kept_trajectory]
+
+        linewidth = linewidth_from_data_units(traj_width, ax, "y")
+        if isinstance(ax, Axes3D):
+            linewidth = traj_width * 10
+
+        solid_capstyle = "round" if self.shape == "circle" else "butt"
+        self.trajectory_line = ax.plot(
+            x_list,
+            y_list,
+            color=traj_color,
+            linestyle=traj_style,
+            linewidth=linewidth,
+            solid_joinstyle="round",
+            solid_capstyle=solid_capstyle,
+            alpha=traj_alpha,
+            zorder=traj_zorder,
+        )
+        self.plot_line_list.append(self.trajectory_line)
+
+    def plot_goal(
+        self,
+        ax: Any,
+        goal_state: np.ndarray | None = None,
+        vertices: np.ndarray | None = None,
+        goal_color: str | None = None,
+        goal_zorder: int | None = 1,
+        goal_alpha: float | None = 0.5,
+        **kwargs: Any,
+    ) -> None:
+        """Draw the object's goal geometry."""
+        if goal_state is None:
+            return
+
+        goal_color = self.color if goal_color is None else goal_color
+        self.goal_patch = draw_patch(
+            ax,
+            shape=self.shape,
+            state=goal_state,
+            radius=self.radius,
+            vertices=vertices,
+            color=goal_color,
+            alpha=goal_alpha,
+            zorder=goal_zorder,
+        )
+        self.plot_patch_list.append(self.goal_patch)
+
+    def plot_text(
+        self,
+        ax: Any,
+        state: np.ndarray | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Draw the object label and optional goal label."""
+        state = self.state if state is None else state
+        text_color = kwargs.get("text_color", "k")
+        text_size = kwargs.get("text_size", 10)
+        text_position = kwargs.get(
+            "text_position", [-self.radius - 0.1, self.radius + 0.1]
+        )
+        text_zorder = kwargs.get("text_zorder", 2)
+        text_alpha = kwargs.get("text_alpha", 1)
+        x, y = state[0, 0], state[1, 0]
+
+        if isinstance(ax, Axes3D):
+            self._text = ax.text(
+                x + text_position[0],
+                y + text_position[1],
+                self.z,
+                self._get_text(),
+                fontsize=text_size,
+                color=text_color,
+                zorder=text_zorder,
+                alpha=text_alpha,
+            )
+        else:
+            self._text = ax.text(
+                x + text_position[0],
+                y + text_position[1],
+                self._get_text(),
+                fontsize=text_size,
+                color=text_color,
+                zorder=text_zorder,
+                alpha=text_alpha,
+            )
+        self.plot_text_list.append(self._text)
+
+        if self.show_goal and self.show_goal_text:
+            self._plot_goal_text(
+                ax,
+                text_position,
+                text_color,
+                text_size,
+                text_zorder,
+                text_alpha,
+            )
+
+    def _plot_goal_text(
+        self,
+        ax: Any,
+        text_position: list[float],
+        text_color: str,
+        text_size: int,
+        text_zorder: int,
+        text_alpha: float,
+    ) -> None:
+        """Create the goal label for ``plot_text``."""
+        goal_x, goal_y = self.goal[0, 0], self.goal[1, 0]
+        args = [
+            goal_x + text_position[0],
+            goal_y + text_position[1],
+        ]
+        if isinstance(ax, Axes3D):
+            args.append(self.z)
+
+        self._goal_text = ax.text(
+            *args,
+            self._get_goal_text(),
+            fontsize=text_size,
+            color=text_color,
+            zorder=text_zorder,
+            alpha=text_alpha,
+        )
+        self.plot_text_list.append(self._goal_text)
+
+    def plot_arrow(
+        self,
+        ax: Any,
+        state: np.ndarray | None = None,
+        velocity: np.ndarray | None = None,
+        arrow_theta: float | None = 0.0,
+        arrow_length: float = 0.4,
+        arrow_width: float = 0.6,
+        arrow_color: str | None = None,
+        arrow_zorder: int = 3,
+        **kwargs: Any,
+    ) -> None:
+        """Draw an arrow indicating the object's velocity orientation."""
+        state = self.state if state is None else state
+        if velocity is None:
+            velocity = self.velocity_xy
+        arrow_color = "gold" if arrow_color is None else arrow_color
+
+        self.arrow_patch = draw_patch(
+            ax,
+            shape="arrow",
+            state=state,
+            color=arrow_color,
+            zorder=arrow_zorder,
+            arrow_length=arrow_length,
+            arrow_width=arrow_width,
+            theta=arrow_theta,
+        )
+        self.plot_patch_list.append(self.arrow_patch)
+
+    def plot_trail(
+        self,
+        ax: Any,
+        state: np.ndarray | None = None,
+        vertices: np.ndarray | None = None,
+        keep_trail_length: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        """Draw a historical outline of the object."""
+        vertices = self.original_vertices if vertices is None else vertices
+        trail_type = kwargs.get("trail_type", self.shape)
+        trail_edgecolor = kwargs.get("trail_edgecolor", self.color)
+        trail_linewidth = kwargs.get("trail_linewidth", 0.8)
+        trail_alpha = kwargs.get("trail_alpha", 0.7)
+        trail_fill = kwargs.get("trail_fill", False)
+        trail_color = kwargs.get("trail_color", self.color)
+        trail_zorder = kwargs.get("trail_zorder", 0)
+
+        trail = draw_patch(
+            ax,
+            shape=trail_type,
+            state=state,
+            vertices=vertices,
+            radius=self.radius,
+            center=(self.original_centroid if trail_type == "circle" else None),
+            width=self.length,
+            height=self.width,
+            edgecolor=trail_edgecolor,
+            facecolor=trail_color,
+            fill=trail_fill,
+            alpha=trail_alpha,
+            linewidth=trail_linewidth,
+            zorder=trail_zorder,
+        )
+        self.plot_trail_list.append(trail)
+
+        if len(self.plot_trail_list) > keep_trail_length and keep_trail_length > 0:
+            self.plot_trail_list.pop(0).remove()
+
+    def plot_fov(self, ax: Any, **kwargs: Any) -> None:
+        """Draw the object's configured field of view."""
+        if self.fov is None or self.fov_radius is None:
+            return
+
+        fov_color = kwargs.get("fov_color", "lightblue")
+        fov_edge_color = kwargs.get("fov_edge_color", "blue")
+        fov_zorder = kwargs.get("fov_zorder", 1)
+        fov_alpha = kwargs.get("fov_alpha", 0.5)
+        start_degree = -180 * self.fov / (2 * pi)
+        end_degree = 180 * self.fov / (2 * pi)
+        shape = "circle" if abs(self.fov - 2 * pi) < 0.01 else "wedge"
+
+        self.fov_patch = draw_patch(
+            ax,
+            shape=shape,
+            state=np.zeros((3, 1)),
+            radius=self.fov_radius,
+            theta1=start_degree,
+            theta2=end_degree,
+            facecolor=fov_color,
+            edgecolor=fov_edge_color,
+            alpha=fov_alpha,
+            zorder=fov_zorder,
+        )
+        self.plot_patch_list.append(self.fov_patch)
+
+    def plot_uncertainty(self, ax: Any, **kwargs: Any) -> None:
+        """Reserved for future uncertainty rendering."""
+
+    def clear(self, all: bool = False) -> None:
+        """Remove this object's artists, optionally including its trails."""
+        for patch in self.plot_patch_list:
+            patch.remove()
+        for line in self.plot_line_list:
+            line.pop(0).remove()
+        for text in self.plot_text_list:
+            text.remove()
+
+        if all:
+            for trail in self.plot_trail_list:
+                trail.remove()
+            self.plot_trail_list = []
+
+        self.plot_patch_list = []
+        self.plot_line_list = []
+        self.plot_text_list = []
+
+        for sensor in self.sensors:
+            sensor.plot_clear()

--- a/irsim/world/object_plot.py
+++ b/irsim/world/object_plot.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from math import pi
 from typing import TYPE_CHECKING, Any
 
@@ -40,21 +40,29 @@ class VisibilityOptions:
 class PatchStyle:
     """Style shared by object and goal patches."""
 
-    color: Any  # Matplotlib-compatible color.
-    alpha: float | None  # Opacity; None keeps the artist default.
-    zorder: int | None  # Layer order; larger values render above.
-    linestyle: str | None = None  # Patch boundary style.
+    color: Any = "k"  # Matplotlib-compatible color.
+    alpha: float = 1.0  # Opacity from fully transparent to opaque.
+    zorder: int = 1  # Layer order; larger values render above.
+    linestyle: str = "-"  # Patch boundary style.
+    line_width: float = 1.0  # Boundary width in Matplotlib points.
+
+
+@dataclass(frozen=True, slots=True)
+class ImageStyle:
+    """Style specific to an object's description image."""
+
+    zorder: int = 2  # Preserve the legacy image layer default.
 
 
 @dataclass(frozen=True, slots=True)
 class LineStyle:
     """Style and history length for a trajectory line."""
 
-    color: Any  # Matplotlib-compatible line color.
-    style: str  # Line style, such as "-" or "--".
-    width: float  # Width in environment data units.
-    alpha: float | None  # Opacity; None keeps the artist default.
-    zorder: int | None  # Matplotlib layer order.
+    color: Any = "k"  # Matplotlib-compatible line color.
+    style: str = "-"  # Line style, such as "-" or "--".
+    width: float = 1.0  # Width in environment data units.
+    alpha: float = 0.5  # Line opacity.
+    zorder: int = 0  # Matplotlib layer order.
     keep_length: int = 0  # Recent states retained; 0 keeps all.
 
 
@@ -62,24 +70,24 @@ class LineStyle:
 class TextStyle:
     """Style and offset for object and goal labels."""
 
-    color: Any  # Matplotlib-compatible text color.
-    size: float  # Font size in points.
-    position: tuple[float, float]  # Label offset in data coordinates.
-    alpha: float | None  # Opacity; None keeps the artist default.
-    zorder: int | None  # Matplotlib layer order.
+    color: Any = "k"  # Matplotlib-compatible text color.
+    size: float = 10.0  # Font size in points.
+    position: tuple[float, float] = (0.0, 0.0)  # Label offset.
+    alpha: float = 1.0  # Text opacity.
+    zorder: int = 2  # Matplotlib layer order.
 
 
 @dataclass(frozen=True, slots=True)
 class TrailStyle:
     """Style, frequency, and retention policy for object trails."""
 
-    shape: str  # Geometry used for each snapshot.
-    edge_color: Any  # Matplotlib-compatible boundary color.
-    line_width: float  # Boundary width passed to Matplotlib.
-    alpha: float | None  # Snapshot opacity.
-    fill: bool  # Fill the snapshot interior when true.
-    color: Any  # Matplotlib-compatible interior color.
-    zorder: int | None  # Matplotlib layer order.
+    shape: str = "circle"  # Geometry used for each snapshot.
+    edge_color: Any = "k"  # Matplotlib-compatible boundary color.
+    line_width: float = 0.8  # Boundary width passed to Matplotlib.
+    alpha: float = 0.7  # Snapshot opacity.
+    fill: bool = False  # Fill the snapshot interior when true.
+    color: Any = "k"  # Matplotlib-compatible interior color.
+    zorder: int = 0  # Matplotlib layer order.
     frequency: int = 2  # Simulation steps between snapshots.
     keep_length: int = 0  # Maximum snapshots; 0 keeps all.
 
@@ -88,9 +96,9 @@ class TrailStyle:
 class ArrowStyle:
     """Style and dimensions for the velocity arrow."""
 
-    color: Any  # Matplotlib-compatible arrow color.
-    alpha: float | None  # Opacity; None keeps the artist default.
-    zorder: int | None  # Matplotlib layer order.
+    color: Any = "gold"  # Matplotlib-compatible arrow color.
+    alpha: float = 1.0  # Arrow opacity.
+    zorder: int = 3  # Matplotlib layer order.
     length: float = 0.4  # Length in environment data units.
     width: float = 0.6  # Arrow-head width in data units.
 
@@ -99,24 +107,25 @@ class ArrowStyle:
 class FovStyle:
     """Style for the field-of-view patch."""
 
-    color: Any  # Matplotlib-compatible interior color.
-    edge_color: Any  # Matplotlib-compatible boundary color.
-    alpha: float | None  # Region opacity.
-    zorder: int | None  # Matplotlib layer order.
+    color: Any = "lightblue"  # Matplotlib-compatible interior color.
+    edge_color: Any = "blue"  # Matplotlib-compatible boundary color.
+    alpha: float = 0.5  # Region opacity.
+    zorder: int = 1  # Matplotlib layer order.
 
 
 @dataclass(frozen=True, slots=True)
 class ObjectPlotOptions:
     """Complete immutable plotting configuration for one object."""
 
-    visibility: VisibilityOptions  # Component visibility switches.
-    object: PatchStyle  # Physical object patch style.
-    goal: PatchStyle  # Goal marker patch style.
-    trajectory: LineStyle  # Trajectory style and retention.
-    text: TextStyle  # Object and goal label style.
-    trail: TrailStyle  # Snapshot style and retention.
-    arrow: ArrowStyle  # Velocity-arrow style and dimensions.
-    fov: FovStyle  # Field-of-view region style.
+    visibility: VisibilityOptions = field(default_factory=VisibilityOptions)
+    object: PatchStyle = field(default_factory=PatchStyle)
+    image: ImageStyle = field(default_factory=ImageStyle)
+    goal: PatchStyle = field(default_factory=lambda: PatchStyle(alpha=0.5, zorder=1))
+    trajectory: LineStyle = field(default_factory=LineStyle)
+    text: TextStyle = field(default_factory=TextStyle)
+    trail: TrailStyle = field(default_factory=TrailStyle)
+    arrow: ArrowStyle = field(default_factory=ArrowStyle)
+    fov: FovStyle = field(default_factory=FovStyle)
 
     @classmethod
     def defaults(
@@ -130,28 +139,15 @@ class ObjectPlotOptions:
     ) -> ObjectPlotOptions:
         """Create owner-dependent plotting defaults."""
         return cls(
-            visibility=VisibilityOptions(),
-            object=PatchStyle(color, None, object_zorder, "-"),
-            goal=PatchStyle(color, 0.5, 1),
-            trajectory=LineStyle(color, "-", width, 0.5, 0),
-            text=TextStyle(
-                color="k",
-                size=10,
-                position=(-radius - 0.1, radius + 0.1),
-                alpha=1,
-                zorder=2,
-            ),
+            object=PatchStyle(color=color, zorder=object_zorder),
+            goal=PatchStyle(color=color, alpha=0.5, zorder=1),
+            trajectory=LineStyle(color=color, width=width),
+            text=TextStyle(position=(-radius - 0.1, radius + 0.1)),
             trail=TrailStyle(
                 shape=shape,
                 edge_color=color,
-                line_width=0.8,
-                alpha=0.7,
-                fill=False,
                 color=color,
-                zorder=0,
             ),
-            arrow=ArrowStyle("gold", None, 3),
-            fov=FovStyle("lightblue", "blue", 0.5, 1),
         )
 
     def with_overrides(self, values: Mapping[str, Any]) -> ObjectPlotOptions:
@@ -179,7 +175,13 @@ class ObjectPlotOptions:
                 "obj_alpha": "alpha",
                 "obj_zorder": "zorder",
                 "obj_linestyle": "linestyle",
+                "obj_linewidth": "line_width",
             },
+        )
+        image = _replace_fields(
+            self.image,
+            values,
+            {"obj_zorder": "zorder"},
         )
         goal = _replace_fields(
             self.goal,
@@ -256,6 +258,7 @@ class ObjectPlotOptions:
             self,
             visibility=visibility,
             object=object_style,
+            image=image,
             goal=goal,
             trajectory=trajectory,
             text=text,
@@ -301,14 +304,37 @@ class ObjectPlot:
     """
 
     def __init__(self, owner: ObjectBase) -> None:
-        self.owner: ObjectBase = owner
-        self.options = ObjectPlotOptions.defaults(
+        self._owner: ObjectBase = owner
+        self.options = self._resolve_options()
+
+    @property
+    def owner(self) -> ObjectBase:
+        """Return the owner through the explicit renderer interface."""
+        return self._owner
+
+    @owner.setter
+    def owner(self, value: ObjectBase) -> None:
+        """Keep explicit owner assignment synchronized with legacy ``_owner``."""
+        self._owner = value
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate legacy renderer attribute reads to the owning object."""
+        owner = object.__getattribute__(self, "_owner")
+        return getattr(owner, name)
+
+    def _resolve_options(
+        self, overrides: Mapping[str, Any] | None = None
+    ) -> ObjectPlotOptions:
+        """Resolve live owner defaults, stored configuration, and call overrides."""
+        owner = self.owner
+        options = ObjectPlotOptions.defaults(
             color=owner.color,
             width=owner.width,
             radius=owner.radius,
             shape=owner.shape,
             object_zorder=3 if owner.role == "robot" else 1,
         ).with_overrides(owner.plot_kwargs)
+        return options.with_overrides(overrides) if overrides else options
 
     def plot(
         self,
@@ -350,9 +376,9 @@ class ObjectPlot:
     ) -> list[str]:
         """Create the configured artists for one object."""
         owner = self.owner
-        options = self.options.with_overrides(kwargs)
-        if initial:
-            self.options = options
+        owner.plot_kwargs.update(kwargs)
+        options = self._resolve_options()
+        self.options = options
 
         owner.plot_attr_list = list(_PLOT_ATTRIBUTES)
         owner.ax = ax
@@ -411,7 +437,8 @@ class ObjectPlot:
     def step(self, **kwargs: Any) -> None:
         """Update existing artists from the owner's current state."""
         owner = self.owner
-        options = self.options.with_overrides(kwargs)
+        options = self._resolve_options(kwargs)
+        self.options = options
         state = owner.state
         x = float(state[0, 0])
         y = float(state[1, 0])
@@ -454,6 +481,7 @@ class ObjectPlot:
             alpha=style.alpha,
             zorder=style.zorder,
             linestyle=style.linestyle,
+            linewidth=style.line_width,
         )
 
     def _update_object_line(
@@ -477,6 +505,7 @@ class ObjectPlot:
         element.set_color(style.color)
         element.set_alpha(style.alpha)
         element.set_zorder(style.zorder)
+        element.set_linewidth(style.line_width)
 
     def _update_object_image(self, heading: float) -> None:
         element = self._artist("object_img")
@@ -634,7 +663,7 @@ class ObjectPlot:
         **kwargs: Any,
     ) -> None:
         """Draw the object's geometry or configured description image."""
-        options = self.options.with_overrides(kwargs) if _options is None else _options
+        options = self._resolve_options(kwargs) if _options is None else _options
         state = self.owner.state if state is None else state
         vertices = self.owner.vertices if vertices is None else vertices
 
@@ -657,6 +686,7 @@ class ObjectPlot:
                         linestyle=options.object.linestyle,
                         zorder=options.object.zorder,
                     )
+                    self.owner.object_patch.set_linewidth(options.object.line_width)
                     self.owner.plot_patch_list.append(self.owner.object_patch)
             except Exception as exc:
                 self.owner.logger.error(
@@ -669,7 +699,7 @@ class ObjectPlot:
                 state,
                 vertices,
                 self.owner.description,
-                _options=options,
+                **kwargs,
             )
 
     def plot_object_image(
@@ -678,14 +708,11 @@ class ObjectPlot:
         state: np.ndarray | None = None,
         vertices: np.ndarray | None = None,
         description: str | None = None,
-        _options: ObjectPlotOptions | None = None,
         **kwargs: Any,
     ) -> None:
         """Draw an image description at the object's pose."""
         if vertices is None or state is None:
             return
-
-        options = self.options.with_overrides(kwargs) if _options is None else _options
 
         image_path = file_check(
             description,
@@ -698,6 +725,7 @@ class ObjectPlot:
         start_y = float(vertices[1, 0])
         angle_degrees = 180 * float(state[2, 0]) / pi
         image_data = image.imread(image_path)
+        options = self._resolve_options(kwargs)
 
         object_image = ax.imshow(
             image_data,
@@ -707,7 +735,7 @@ class ObjectPlot:
                 start_y,
                 start_y + self.owner.width,
             ],
-            zorder=options.object.zorder,
+            zorder=options.image.zorder,
         )
         transform = (
             mtransforms.Affine2D().rotate_deg_around(start_x, start_y, angle_degrees)
@@ -728,7 +756,7 @@ class ObjectPlot:
     ) -> None:
         """Draw the object's trajectory."""
         if _options is None:
-            options = self.options.with_overrides(
+            options = self._resolve_options(
                 {**kwargs, "keep_traj_length": keep_traj_length}
             )
         else:
@@ -781,7 +809,7 @@ class ObjectPlot:
             }
             if goal_color is not None:
                 overrides["goal_color"] = goal_color
-            options = self.options.with_overrides(overrides)
+            options = self._resolve_options(overrides)
         else:
             options = _options
 
@@ -805,7 +833,7 @@ class ObjectPlot:
         **kwargs: Any,
     ) -> None:
         """Draw the object label and optional goal label."""
-        options = self.options.with_overrides(kwargs) if _options is None else _options
+        options = self._resolve_options(kwargs) if _options is None else _options
         state = self.owner.state if state is None else state
         x, y = state[0, 0], state[1, 0]
 
@@ -886,7 +914,7 @@ class ObjectPlot:
             }
             if arrow_color is not None:
                 overrides["arrow_color"] = arrow_color
-            options = self.options.with_overrides(overrides)
+            options = self._resolve_options(overrides)
         else:
             options = _options
         state = self.owner.state if state is None else state
@@ -915,7 +943,7 @@ class ObjectPlot:
     ) -> None:
         """Draw a historical outline of the object."""
         if _options is None:
-            options = self.options.with_overrides(
+            options = self._resolve_options(
                 {**kwargs, "keep_trail_length": keep_trail_length}
             )
         else:
@@ -960,7 +988,7 @@ class ObjectPlot:
         if self.owner.fov is None or self.owner.fov_radius is None:
             return
 
-        options = self.options.with_overrides(kwargs) if _options is None else _options
+        options = self._resolve_options(kwargs) if _options is None else _options
         start_degree = -180 * self.owner.fov / (2 * pi)
         end_degree = 180 * self.owner.fov / (2 * pi)
         shape = "circle" if abs(self.owner.fov - 2 * pi) < 0.01 else "wedge"

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -5,6 +5,7 @@ Covers 2D and 3D plotting, trajectory drawing, quiver drawing, and shape patches
 """
 
 import os
+from dataclasses import FrozenInstanceError
 from unittest.mock import Mock
 
 import matplotlib.pyplot as plt
@@ -17,6 +18,7 @@ import irsim.env.env_plot as env_plot_module
 from irsim.env.env_plot import EnvPlot, draw_patch
 from irsim.env.env_plot3d import EnvPlot3D
 from irsim.world.object_base import ObjectBase
+from irsim.world.object_plot import ObjectPlotOptions
 
 
 class TestEnvPlot2D:
@@ -386,7 +388,7 @@ class TestObjectPlot:
         env = env_factory("test_all_objects.yaml")
         robot = env.robot
 
-        assert robot._object_plot._owner is robot
+        assert robot._object_plot.owner is robot
         assert "object_patch" in vars(robot)
         assert "object_patch" not in vars(robot._object_plot)
 
@@ -411,6 +413,61 @@ class TestObjectPlot:
         np.testing.assert_allclose(
             obj.object_patch.get_facecolor(), to_rgba("magenta", alpha=0.25)
         )
+        plt.close(fig)
+
+    def test_plot_options_are_grouped_immutable_values(self):
+        obj = ObjectBase(
+            shape={"name": "circle", "radius": 0.2},
+            color="navy",
+            plot={
+                "show_goal": True,
+                "obj_alpha": 0.3,
+                "keep_traj_length": 12,
+                "text_position": [0.4, 0.6],
+                "keep_trail_length": 8,
+                "arrow_length": 0.9,
+                "fov_color": "cyan",
+            },
+        )
+
+        options = obj._object_plot.options
+
+        assert isinstance(options, ObjectPlotOptions)
+        assert options.visibility.goal
+        assert options.object.alpha == 0.3
+        assert options.goal.color == "navy"
+        assert options.trajectory.keep_length == 12
+        assert options.text.position == (0.4, 0.6)
+        assert options.trail.keep_length == 8
+        assert options.arrow.length == 0.9
+        assert options.fov.color == "cyan"
+        assert not hasattr(options, "__dict__")
+
+        with pytest.raises(FrozenInstanceError):
+            options.object.alpha = 0.8
+
+        overridden = options.with_overrides({"obj_alpha": 0.8})
+        assert options.object.alpha == 0.3
+        assert overridden.object.alpha == 0.8
+
+    def test_runtime_overrides_do_not_mutate_stored_plot_config(self):
+        stored_options = {"obj_color": "blue"}
+        obj = ObjectBase(
+            shape={"name": "circle", "radius": 0.2},
+            plot=stored_options,
+        )
+
+        fig, ax = plt.subplots()
+        obj._init_plot(ax, obj_color="magenta")
+
+        assert obj.plot_kwargs == stored_options
+        assert obj._object_plot.options.object.color == "magenta"
+
+        obj._step_plot(obj_color="red")
+        np.testing.assert_allclose(obj.object_patch.get_facecolor(), to_rgba("red"))
+
+        obj._step_plot()
+        np.testing.assert_allclose(obj.object_patch.get_facecolor(), to_rgba("magenta"))
         plt.close(fig)
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -578,6 +578,128 @@ class TestObjectPlot:
         np.testing.assert_allclose(obj.object_patch.get_facecolor(), to_rgba("purple"))
         plt.close(fig)
 
+    def test_legacy_plot_helpers_resolve_direct_call_options(self):
+        obj = ObjectBase(
+            shape={"name": "circle", "radius": 0.2},
+            state=[0.0, 0.0, 0.0],
+            goal=[1.0, 1.0, 0.0],
+            color="navy",
+        )
+        trajectory = [obj.state.copy(), np.array([[0.5], [0.25], [0.0]])]
+
+        fig, ax = plt.subplots()
+        obj._plot(ax, obj.state, obj.vertices)
+
+        obj.plot_trajectory(
+            ax,
+            trajectory,
+            keep_traj_length=1,
+            traj_color="red",
+            traj_style="--",
+            traj_alpha=0.4,
+            traj_zorder=6,
+        )
+        trajectory_line = obj.trajectory_line[0]
+        assert obj.keep_traj_length == 1
+        assert trajectory_line.get_color() == "red"
+        assert trajectory_line.get_linestyle() == "--"
+        assert trajectory_line.get_alpha() == 0.4
+        assert trajectory_line.get_zorder() == 6
+
+        obj.plot_goal(ax)
+        obj.plot_goal(
+            ax,
+            obj.goal,
+            obj.goal_vertices,
+            goal_color="green",
+            goal_zorder=7,
+            goal_alpha=0.3,
+        )
+        np.testing.assert_allclose(
+            obj.goal_patch.get_facecolor(), to_rgba("green", alpha=0.3)
+        )
+        assert obj.goal_patch.get_zorder() == 7
+
+        obj.plot_arrow(
+            ax,
+            obj.state,
+            arrow_theta=0.0,
+            arrow_length=0.7,
+            arrow_width=0.2,
+            arrow_color="orange",
+            arrow_zorder=8,
+            arrow_alpha=0.6,
+        )
+        np.testing.assert_allclose(
+            obj.arrow_patch.get_facecolor(), to_rgba("orange", alpha=0.6)
+        )
+        assert obj.arrow_patch.get_zorder() == 8
+
+        obj.plot_trail(
+            ax,
+            obj.state,
+            obj.original_vertices,
+            keep_trail_length=1,
+            trail_color="yellow",
+        )
+        first_trail = obj.plot_trail_list[0]
+        obj.plot_trail(
+            ax,
+            obj.state,
+            obj.original_vertices,
+            keep_trail_length=1,
+            trail_color="cyan",
+        )
+        assert len(obj.plot_trail_list) == 1
+        assert obj.plot_trail_list[0] is not first_trail
+        plt.close(fig)
+
+    def test_legacy_plot_helper_guard_paths(self):
+        obj = ObjectBase(shape={"name": "circle", "radius": 0.2})
+
+        fig, ax = plt.subplots()
+        obj.plot_object_image(ax)
+        obj.plot_object_image(
+            ax,
+            obj.state,
+            obj.vertices,
+            description="__missing_plot_image__.png",
+        )
+        obj.plot_fov(ax)
+        obj.plot_uncertainty(ax)
+
+        assert not hasattr(obj, "object_img")
+        assert not hasattr(obj, "fov_patch")
+        plt.close(fig)
+
+    def test_object_line_update_applies_geometry_and_style(self):
+        obj = ObjectBase(
+            shape={"name": "linestring", "vertices": [[-1.0, 0.0], [1.0, 0.0]]}
+        )
+        obj.object_line = Mock()
+        style = obj._object_plot._resolve_options(
+            {
+                "obj_color": "purple",
+                "obj_alpha": 0.4,
+                "obj_zorder": 9,
+                "obj_linestyle": "--",
+                "obj_linewidth": 2.5,
+            }
+        ).object
+
+        obj._object_plot._update_object_line(2.0, 3.0, np.pi / 2, style)
+
+        rotation = np.array([[0.0, -1.0], [1.0, 0.0]])
+        expected_vertices = rotation @ obj.vertices + np.array([[2.0], [3.0]])
+        x_data, y_data = obj.object_line.set_data.call_args.args
+        np.testing.assert_allclose(x_data, expected_vertices[0, :], atol=1e-12)
+        np.testing.assert_allclose(y_data, expected_vertices[1, :], atol=1e-12)
+        obj.object_line.set_linestyle.assert_called_once_with("--")
+        obj.object_line.set_color.assert_called_once_with("purple")
+        obj.object_line.set_alpha.assert_called_once_with(0.4)
+        obj.object_line.set_zorder.assert_called_once_with(9)
+        obj.object_line.set_linewidth.assert_called_once_with(2.5)
+
 
 class TestSaveFigure:
     """Tests for figure saving functionality."""

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -10,11 +10,13 @@ from unittest.mock import Mock
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from matplotlib.colors import to_rgba
 
 import irsim
 import irsim.env.env_plot as env_plot_module
 from irsim.env.env_plot import EnvPlot, draw_patch
 from irsim.env.env_plot3d import EnvPlot3D
+from irsim.world.object_base import ObjectBase
 
 
 class TestEnvPlot2D:
@@ -374,6 +376,41 @@ class TestGoalText:
 
         assert hasattr(robot, "_goal_text")
         assert robot._goal_text is not None
+        plt.close(fig)
+
+
+class TestObjectPlot:
+    """Tests for the object-owned renderer boundary."""
+
+    def test_artist_state_stays_on_owner(self, env_factory):
+        env = env_factory("test_all_objects.yaml")
+        robot = env.robot
+
+        assert robot._object_plot._owner is robot
+        assert "object_patch" in vars(robot)
+        assert "object_patch" not in vars(robot._object_plot)
+
+    def test_goal_text_is_optional_without_goal(self):
+        obj = ObjectBase(shape={"name": "circle", "radius": 0.2}, goal=None)
+        obj.show_goal = True
+        obj.show_goal_text = True
+
+        fig, ax = plt.subplots()
+        obj.plot_text(ax)
+
+        assert hasattr(obj, "_text")
+        assert not hasattr(obj, "_goal_text")
+        plt.close(fig)
+
+    def test_initial_object_style_uses_plot_overrides(self):
+        obj = ObjectBase(shape={"name": "circle", "radius": 0.2})
+
+        fig, ax = plt.subplots()
+        obj.plot_object(ax, obj_color="magenta", obj_alpha=0.25)
+
+        np.testing.assert_allclose(
+            obj.object_patch.get_facecolor(), to_rgba("magenta", alpha=0.25)
+        )
         plt.close(fig)
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -389,8 +389,29 @@ class TestObjectPlot:
         robot = env.robot
 
         assert robot._object_plot.owner is robot
+        assert robot._object_plot._owner is robot
         assert "object_patch" in vars(robot)
         assert "object_patch" not in vars(robot._object_plot)
+
+    def test_legacy_renderer_attributes_delegate_to_owner(self):
+        obj = ObjectBase(
+            shape={"name": "circle", "radius": 0.2},
+            color="navy",
+            plot={"show_goal": True},
+        )
+
+        assert obj._object_plot.color == "navy"
+        assert obj._object_plot.plot_kwargs == {"show_goal": True}
+
+    def test_owner_aliases_stay_synchronized(self):
+        first = ObjectBase(shape={"name": "circle", "radius": 0.2})
+        second = ObjectBase(shape={"name": "circle", "radius": 0.3})
+
+        first._object_plot.owner = second
+
+        assert first._object_plot.owner is second
+        assert first._object_plot._owner is second
+        assert first._object_plot.radius == second.radius
 
     def test_goal_text_is_optional_without_goal(self):
         obj = ObjectBase(shape={"name": "circle", "radius": 0.2}, goal=None)
@@ -408,10 +429,44 @@ class TestObjectPlot:
         obj = ObjectBase(shape={"name": "circle", "radius": 0.2})
 
         fig, ax = plt.subplots()
-        obj.plot_object(ax, obj_color="magenta", obj_alpha=0.25)
+        obj.plot_object(
+            ax,
+            obj_color="magenta",
+            obj_alpha=0.25,
+            obj_linewidth=2.5,
+        )
 
         np.testing.assert_allclose(
             obj.object_patch.get_facecolor(), to_rgba("magenta", alpha=0.25)
+        )
+        assert obj.object_patch.get_linewidth() == 2.5
+        plt.close(fig)
+
+    @pytest.mark.parametrize(
+        ("plot", "render_options", "expected_zorder"),
+        [
+            ({}, {}, 2),
+            ({"obj_zorder": 7}, {}, 7),
+            ({}, {"obj_zorder": 9}, 9),
+        ],
+    )
+    def test_object_image_preserves_legacy_zorder(
+        self, plot, render_options, expected_zorder
+    ):
+        obj = ObjectBase(
+            shape={"name": "rectangle", "length": 0.5, "width": 0.2},
+            role="robot",
+            description="diff_robot0.png",
+            plot=plot,
+        )
+
+        fig, ax = plt.subplots()
+        obj.plot_object(ax, **render_options)
+
+        assert obj.object_img.get_zorder() == expected_zorder
+        assert (
+            obj._object_plot._resolve_options(render_options).image.zorder
+            == expected_zorder
         )
         plt.close(fig)
 
@@ -435,6 +490,7 @@ class TestObjectPlot:
         assert isinstance(options, ObjectPlotOptions)
         assert options.visibility.goal
         assert options.object.alpha == 0.3
+        assert options.image.zorder == 2
         assert options.goal.color == "navy"
         assert options.trajectory.keep_length == 12
         assert options.text.position == (0.4, 0.6)
@@ -450,7 +506,22 @@ class TestObjectPlot:
         assert options.object.alpha == 0.3
         assert overridden.object.alpha == 0.8
 
-    def test_runtime_overrides_do_not_mutate_stored_plot_config(self):
+    def test_plot_dataclasses_have_fully_resolved_defaults(self):
+        options = ObjectPlotOptions()
+
+        assert options.object.alpha == 1.0
+        assert options.object.zorder == 1
+        assert options.object.linestyle == "-"
+        assert options.object.line_width == 1.0
+        assert options.image.zorder == 2
+        assert options.goal.alpha == 0.5
+        assert options.trajectory.alpha == 0.5
+        assert options.text.alpha == 1.0
+        assert options.trail.alpha == 0.7
+        assert options.arrow.alpha == 1.0
+        assert options.fov.alpha == 0.5
+
+    def test_initial_overrides_update_live_plot_config(self):
         stored_options = {"obj_color": "blue"}
         obj = ObjectBase(
             shape={"name": "circle", "radius": 0.2},
@@ -460,7 +531,8 @@ class TestObjectPlot:
         fig, ax = plt.subplots()
         obj._init_plot(ax, obj_color="magenta")
 
-        assert obj.plot_kwargs == stored_options
+        assert stored_options["obj_color"] == "magenta"
+        assert obj.plot_kwargs["obj_color"] == "magenta"
         assert obj._object_plot.options.object.color == "magenta"
 
         obj._step_plot(obj_color="red")
@@ -468,6 +540,42 @@ class TestObjectPlot:
 
         obj._step_plot()
         np.testing.assert_allclose(obj.object_patch.get_facecolor(), to_rgba("magenta"))
+        plt.close(fig)
+
+    def test_owner_defaults_are_resolved_at_render_time(self):
+        obj = ObjectBase(
+            shape={"name": "circle", "radius": 0.2},
+            color="blue",
+        )
+        obj.color = "red"
+
+        fig, ax = plt.subplots()
+        obj._init_plot(ax)
+
+        np.testing.assert_allclose(obj.object_patch.get_facecolor(), to_rgba("red"))
+        assert obj._object_plot.options.object.color == "red"
+
+        obj.color = "orange"
+        obj._step_plot()
+        np.testing.assert_allclose(obj.object_patch.get_facecolor(), to_rgba("orange"))
+        plt.close(fig)
+
+    def test_plot_config_changes_are_resolved_at_render_time(self):
+        obj = ObjectBase(
+            shape={"name": "circle", "radius": 0.2},
+            plot={"obj_color": "blue"},
+        )
+        obj.plot_kwargs["obj_color"] = "green"
+
+        fig, ax = plt.subplots()
+        obj._init_plot(ax)
+
+        np.testing.assert_allclose(obj.object_patch.get_facecolor(), to_rgba("green"))
+        assert obj._object_plot.options.object.color == "green"
+
+        obj.plot_kwargs["obj_color"] = "purple"
+        obj._step_plot()
+        np.testing.assert_allclose(obj.object_patch.get_facecolor(), to_rgba("purple"))
         plt.close(fig)
 
 


### PR DESCRIPTION
This PR moves object plotting from `ObjectBase` into a dedicated `ObjectPlot` class. It groups plotting settings into clear dataclasses while keeping the existing plotting API compatible. It preserves the option priority of per-call arguments, `object.plot_kwargs`, and object defaults. The runtime defaults now match the English and Chinese documentation, and the added tests cover the compatibility paths and plotting options. 