### PR TITLE
feat: add compound geometry

### DIFF
--- a/docs/locale/zh_CN/LC_MESSAGES/usage/configure_robots_obstacles.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/usage/configure_robots_obstacles.po
@@ -169,13 +169,14 @@ msgstr "`[v, φ]` —— 线速度与转向角"
 msgid "Cars, car-like robots"
 msgstr "汽车及车式机器人"
 
-#: ../../source/usage/configure_robots_obstacles.md:77
+#: ../../source/usage/configure_robots_obstacles.md:76
 msgid ""
 "**`shape`:** Specifies the physical shape and size of the robot. Name "
-"options include `'circle'`, `'rectangle'`, `'polygon'`, and `linestring`."
+"options include `'circle'`, `'rectangle'`, `'polygon'`, `'compound'`, and "
+"`linestring`."
 msgstr ""
 "**`shape`：** 指定机器人的物理形状与尺寸，可选 `'circle'`、`'rectangle'`、"
-"`'polygon'`、`linestring`。"
+"`'polygon'`、`'compound'`、`linestring`。"
 
 #: ../../source/usage/configure_robots_obstacles.md:78
 msgid "`circle`: A circular robot with a specified radius."
@@ -188,6 +189,10 @@ msgstr "`rectangle`：具有特定长宽的矩形机器人。"
 #: ../../source/usage/configure_robots_obstacles.md:80
 msgid "`polygon`: A polygonal robot."
 msgstr "`polygon`：多边形机器人。"
+
+#: ../../source/usage/configure_robots_obstacles.md:80
+msgid "`compound`: A rigid combination of circle, rectangle, or polygon parts."
+msgstr "`compound`：由圆形、矩形或多边形部件组成的刚性组合形状。"
 
 #: ../../source/usage/configure_robots_obstacles.md:81
 msgid "`linestring`: list of lines."
@@ -221,6 +226,23 @@ msgid ""
 msgstr ""
 "**`plot`**（可选）：设置机器人的可视化样式。参见 {py:meth}"
 "`~irsim.world.object_base.ObjectBase.plot`。"
+
+#: ../../source/usage/configure_robots_obstacles.md:88
+msgid ""
+"For a `compound` shape, the object's `state` moves the complete body. Each "
+"part's optional `pose: [x, y, theta]` is fixed relative to the object frame "
+"and defaults to `[0, 0, 0]`. All parts use the owning object's color. "
+"`show_trajectory` uses the same path-line renderer as other shapes. By "
+"default, its width is the compound's local-y extent and the line follows the "
+"midpoint of that extent, keeping the trajectory and body widths aligned. The "
+"line does not reproduce concave or disjoint footprint gaps; use `show_trail` "
+"for exact historical shape snapshots."
+msgstr ""
+"对于 `compound` 形状，对象的 `state` 驱动整个刚体运动。每个部件可选的 `pose: "
+"[x, y, theta]` 固定在对象坐标系中，默认值为 `[0, 0, 0]`。所有部件使用所属对象"
+"的颜色。`show_trajectory` 与其他形状一样使用路径线渲染。默认宽度为组合体在局部 "
+"y 方向上的范围，路径线沿该范围的中点移动，使轨迹宽度与本体宽度对齐。路径线不会"
+"还原凹形或分离足迹中的空白；如需精确的历史形状快照，请使用 `show_trail`。"
 
 #: ../../source/usage/configure_robots_obstacles.md:89
 msgid ""

--- a/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
@@ -862,10 +862,11 @@ msgstr "`shape`"
 msgid ""
 "Shape of the object. If omitted, IR-SIM creates a circle with radius `1`; an "
 "explicit `{name: circle}` uses radius `0.2`. Supported names: `circle`, "
-"`rectangle`, `polygon`, `linestring`."
+"`rectangle`, `polygon`, `linestring`, `compound`."
 msgstr ""
 "对象的几何形状。省略时，IR-SIM 创建半径为 `1` 的圆；显式指定 `{name: circle}"
-"` 时使用半径 `0.2`。支持 `circle`、`rectangle`、`polygon`、`linestring`。"
+"` 时使用半径 `0.2`。支持 `circle`、`rectangle`、`polygon`、`linestring`、"
+"`compound`。"
 
 #: ../../source/yaml_config/configuration.md:700
 msgid "`state`"
@@ -1713,6 +1714,10 @@ msgid "**`polygon`**: Custom shape (`vertices`, `is_convex`)"
 msgstr "**`polygon`** — 自定义多边形（`vertices`、`is_convex`）"
 
 #: ../../source/yaml_config/configuration.md:1021
+msgid "**`compound`**: Fixed collection of solid parts (`parts`, `pose`)"
+msgstr "**`compound`** — 固定实体部件的组合（`parts`、`pose`）"
+
+#: ../../source/yaml_config/configuration.md:1021
 msgid "**`linestring`**: Line segments (`vertices`)"
 msgstr "**`linestring`** — 线段（`vertices`）"
 
@@ -1830,6 +1835,56 @@ msgstr ""
 "`~irsim.lib.algorithm.generation.random_generate_polygon`。参数包括 `number "
 "`、`center_range `、`avg_radius_range `、`irregularity_range `、"
 "`spikeyness_range `、`num_vertices_range `。"
+
+#: ../../source/yaml_config/configuration.md:1076
+msgid ""
+"**`'compound'`**: Represents one rigid shape assembled from fixed solid "
+"parts."
+msgstr "**`'compound'`**：表示由固定实体部件组合而成的一个刚性形状。"
+
+#: ../../source/yaml_config/configuration.md:1077
+msgid ""
+"**`parts`** (`list`): Non-empty list of `circle`, `rectangle`, or `polygon` "
+"shape dictionaries."
+msgstr ""
+"**`parts`**（`list`）：由 `circle`、`rectangle` 或 `polygon` 形状字典组成的"
+"非空列表。"
+
+#: ../../source/yaml_config/configuration.md:1078
+msgid ""
+"**`pose`** (`list`): Optional `[x, y, theta]` pose of a part relative to the "
+"owning object's coordinate-frame origin. Default is `[0, 0, 0]`, and "
+"`theta` is in radians."
+msgstr ""
+"**`pose`**（`list`）：部件相对于所属对象坐标系原点的可选 `[x, y, theta]` "
+"位姿。默认值为 `[0, 0, 0]`，`theta` 使用弧度。"
+
+#: ../../source/yaml_config/configuration.md:1079
+msgid ""
+"The object's `state` moves the complete compound body; parts cannot move "
+"independently."
+msgstr "对象的 `state` 驱动整个组合刚体运动；各部件不能独立运动。"
+
+#: ../../source/yaml_config/configuration.md:1080
+msgid ""
+"All parts inherit the owning object's color. Overlapping parts are merged "
+"for collision detection and visualization, while gaps between disjoint "
+"parts remain collision-free."
+msgstr ""
+"所有部件继承所属对象的颜色。重叠部件会合并用于碰撞检测和可视化，而分离部件之间"
+"的空隙仍为无碰撞区域。"
+
+#: ../../source/yaml_config/configuration.md:1081
+msgid ""
+"`show_trajectory` uses the same path-line renderer as other shapes. By "
+"default, its width is the compound's local-y extent and the line follows the "
+"midpoint of that extent, keeping the trajectory and body widths aligned. The "
+"line does not reproduce concave or disjoint footprint gaps; use `show_trail` "
+"for exact historical shape snapshots."
+msgstr ""
+"`show_trajectory` 与其他形状一样使用路径线渲染。默认宽度为组合体在局部 y 方向"
+"上的范围，路径线沿该范围的中点移动，使轨迹宽度与本体宽度对齐。路径线不会还原"
+"凹形或分离足迹中的空白；如需精确的历史形状快照，请使用 `show_trail`。"
 
 #: ../../source/yaml_config/configuration.md:1075
 msgid ""

--- a/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
@@ -1824,18 +1824,6 @@ msgid ""
 "polygons. Default is `False`."
 msgstr "**`is_convex`**（`bool`）：是否生成一系列随机凸多边形，默认 `False`。"
 
-#: ../../source/yaml_config/configuration.md:1056
-msgid ""
-"parameters for random polygon generation, see {py:func}"
-"`~irsim.lib.algorithm.generation.random_generate_polygon` for more details. "
-"Parameters include `number `, `center_range `, `avg_radius_range `, "
-"`irregularity_range `, `spikeyness_range `, `num_vertices_range `."
-msgstr ""
-"随机多边形生成的参数，更多细节参见 {py:func}"
-"`~irsim.lib.algorithm.generation.random_generate_polygon`。参数包括 `number "
-"`、`center_range `、`avg_radius_range `、`irregularity_range `、"
-"`spikeyness_range `、`num_vertices_range `。"
-
 #: ../../source/yaml_config/configuration.md:1076
 msgid ""
 "**`'compound'`**: Represents one rigid shape assembled from fixed solid "
@@ -1858,33 +1846,6 @@ msgid ""
 msgstr ""
 "**`pose`**（`list`）：部件相对于所属对象坐标系原点的可选 `[x, y, theta]` "
 "位姿。默认值为 `[0, 0, 0]`，`theta` 使用弧度。"
-
-#: ../../source/yaml_config/configuration.md:1079
-msgid ""
-"The object's `state` moves the complete compound body; parts cannot move "
-"independently."
-msgstr "对象的 `state` 驱动整个组合刚体运动；各部件不能独立运动。"
-
-#: ../../source/yaml_config/configuration.md:1080
-msgid ""
-"All parts inherit the owning object's color. Overlapping parts are merged "
-"for collision detection and visualization, while gaps between disjoint "
-"parts remain collision-free."
-msgstr ""
-"所有部件继承所属对象的颜色。重叠部件会合并用于碰撞检测和可视化，而分离部件之间"
-"的空隙仍为无碰撞区域。"
-
-#: ../../source/yaml_config/configuration.md:1081
-msgid ""
-"`show_trajectory` uses the same path-line renderer as other shapes. By "
-"default, its width is the compound's local-y extent and the line follows the "
-"midpoint of that extent, keeping the trajectory and body widths aligned. The "
-"line does not reproduce concave or disjoint footprint gaps; use `show_trail` "
-"for exact historical shape snapshots."
-msgstr ""
-"`show_trajectory` 与其他形状一样使用路径线渲染。默认宽度为组合体在局部 y 方向"
-"上的范围，路径线沿该范围的中点移动，使轨迹宽度与本体宽度对齐。路径线不会还原"
-"凹形或分离足迹中的空白；如需精确的历史形状快照，请使用 `show_trail`。"
 
 #: ../../source/yaml_config/configuration.md:1075
 msgid ""
@@ -1910,18 +1871,6 @@ msgid ""
 "**`is_convex`** (`bool`): Whether to generate a series of random convex line "
 "strings (polygons). Default is `True`."
 msgstr "**`is_convex`**（`bool`）：是否生成随机凸线串（多边形），默认 `True`。"
-
-#: ../../source/yaml_config/configuration.md:1079
-msgid ""
-"parameters for random line string generation (polygon), see {py:func}"
-"`~irsim.lib.algorithm.generation.random_generate_polygon` for more details. "
-"Parameters include `number `, `center_range `, `avg_radius_range `, "
-"`irregularity_range `, `spikeyness_range `, `num_vertices_range `."
-msgstr ""
-"随机折线（多边形）生成的参数，更多细节参见 {py:func}"
-"`~irsim.lib.algorithm.generation.random_generate_polygon`。参数包括 `number "
-"`、`center_range `、`avg_radius_range `、`irregularity_range `、"
-"`spikeyness_range `、`num_vertices_range `。"
 
 #: ../../source/yaml_config/configuration.md:0
 msgid "**object behavior**"

--- a/docs/source/usage/configure_robots_obstacles.md
+++ b/docs/source/usage/configure_robots_obstacles.md
@@ -73,16 +73,19 @@ robot:
 | `omni_angular` | `[forward, lateral, yaw_rate]` - body-frame velocity + yaw | Holonomic robots with rotation | ✓ Yes |
 | `diff`     | `[v, ω]` - linear & angular velocity | Two-wheeled robots | ✓ Yes |
 | `acker`    | `[v, φ]` - linear velocity & steering angle | Cars, car-like robots | ✗ No |
-- **`shape`:** Specifies the physical shape and size of the robot. Name options include `'circle'`, `'rectangle'`, `'polygon'`, and `linestring`.
+- **`shape`:** Specifies the physical shape and size of the robot. Name options include `'circle'`, `'rectangle'`, `'polygon'`, `'compound'`, and `linestring`.
     - `circle`: A circular robot with a specified radius.
     - `rectangle`: A rectangular robot with specified length and width.
     - `polygon`: A polygonal robot.
+    - `compound`: A rigid combination of circle, rectangle, or polygon parts.
     - `linestring`: list of lines.
  
 - **`state`:** Defines the initial position and orientation of the robot in the environment.
 - **`goal`:** Specifies the target position and orientation for the robot.
 - **`behavior`:** Specifies how the robot generates velocity in `env.step()` when no external command is provided. If omitted, the robot remains static unless a velocity command is passed to `env.step(velocity)`.
 - **`plot`** (optional): Specifies the visualization settings for the robot. See {py:meth}`~irsim.world.object_base.ObjectBase.plot` for more details.
+
+For a `compound` shape, the object's `state` moves the complete body. Each part's optional `pose: [x, y, theta]` is fixed relative to the object frame and defaults to `[0, 0, 0]`. All parts use the owning object's color. `show_trajectory` uses the same path-line renderer as other shapes. By default, its width is the compound's local-y extent and the line follows the midpoint of that extent, keeping the trajectory and body widths aligned. The line does not reproduce concave or disjoint footprint gaps; use `show_trail` for exact historical shape snapshots.
 
 
 The example above explicitly sets `behavior: {name: 'dash'}` so the robot moves from its initial state toward its goal when `env.step()` is called without an input velocity.

--- a/docs/source/yaml_config/configuration.md
+++ b/docs/source/yaml_config/configuration.md
@@ -717,7 +717,7 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
 | `number`         | `int`                                            | `1`              | Number of objects to create.                                                                                       |
 | `distribution`   | `dict`                                           | `{name: manual}` | Defines how multiple objects are distributed. Support name: `manual`, `random`, `circle`                           |
 | `kinematics`     | `dict`                                           | `None`           | Kinematic model of the object. Supported names: `diff`, `acker`, `omni`, `omni_angular`. An object without kinematics is static. |
-| `shape`          | `dict`                                           | `None`           | Shape of the object. If omitted, IR-SIM creates a circle with radius `1`; an explicit `{name: circle}` uses radius `0.2`. Supported names: `circle`, `rectangle`, `polygon`, `linestring`. |
+| `shape`          | `dict`                                           | `None`           | Shape of the object. If omitted, IR-SIM creates a circle with radius `1`; an explicit `{name: circle}` uses radius `0.2`. Supported names: `circle`, `rectangle`, `polygon`, `linestring`, `compound`. |
 | `state`          | `list` of `float`                                | `[1, 1, 0]` for manual distribution | Initial state vector of the object.                                                                                |
 | `velocity`       | `list` of `float`                                | `[0] * action_dim` | Initial velocity vector. Length matches the kinematics action dimension (2 for `diff`/`omni`/`acker`, 3 for `omni_angular`). |
 | `goal`           | `list` of `float` or `list` of `list` of `float` | `[1, 9, 0]` for manual distribution | Goal state(s) vector.                                                                                              |
@@ -1018,6 +1018,7 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
 - **`circle`**: Round shape (`radius`, `center`)
 - **`rectangle`**: Rectangular shape (`length`, `width`, `wheelbase`)
 - **`polygon`**: Custom shape (`vertices`, `is_convex`)
+- **`compound`**: Fixed collection of solid parts (`parts`, `pose`)
 - **`linestring`**: Line segments (`vertices`)
 ```
 
@@ -1070,6 +1071,22 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
     # Example usage - random polygon
     shape:
       - {name: 'polygon', random_shape: true, center_range: [5, 10, 40, 30], avg_radius_range: [0.5, 2], irregularity_range: [0, 1], spikeyness_range: [0, 1], num_vertices_range: [4, 5]} 
+    ```
+
+  - **`'compound'`**: Represents one rigid shape assembled from fixed solid parts.
+    - **`parts`** (`list`): Non-empty list of `circle`, `rectangle`, or `polygon` shape dictionaries.
+    - **`pose`** (`list`): Optional `[x, y, theta]` pose of a part relative to the owning object's coordinate-frame origin. Default is `[0, 0, 0]`, and `theta` is in radians.
+    - The object's `state` moves the complete compound body; parts cannot move independently.
+    - All parts inherit the owning object's color. Overlapping parts are merged for collision detection and visualization, while gaps between disjoint parts remain collision-free.
+    - `show_trajectory` uses the same path-line renderer as other shapes. By default, its width is the compound's local-y extent and the line follows the midpoint of that extent, keeping the trajectory and body widths aligned. The line does not reproduce concave or disjoint footprint gaps; use `show_trail` for exact historical shape snapshots.
+
+    ```yaml
+    # Example usage - compound robot body
+    shape:
+      name: compound
+      parts:
+        - {name: rectangle, length: 0.8, width: 0.3}
+        - {name: rectangle, length: 0.3, width: 0.8, pose: [-0.25, 0, 0]}
     ```
   
   - **`'linestring'`**: Represents a line string shape defined by a list of vertices. Similar to a polygon but generates a line string.

--- a/docs/source/yaml_config/configuration.md
+++ b/docs/source/yaml_config/configuration.md
@@ -1054,7 +1054,6 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
     - **`vertices`** (`list`): List of vertices defining the polygon in the format `[[x1, y1], [x2, y2], ...]`, if not provided, a random polygon will be generated.
     - **`random_shape`** (`bool`): Whether to generate a series of random polygons. Default is `False`.
     - **`is_convex`** (`bool`): Whether to generate a series of random convex polygons. Default is `False`.
-    - parameters for random polygon generation, see {py:func}`~irsim.lib.algorithm.generation.random_generate_polygon` for more details. Parameters include `number `, `center_range `, `avg_radius_range `, `irregularity_range `, `spikeyness_range `, `num_vertices_range `.
       
     ```yaml
     # Example usage
@@ -1076,9 +1075,6 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
   - **`'compound'`**: Represents one rigid shape assembled from fixed solid parts.
     - **`parts`** (`list`): Non-empty list of `circle`, `rectangle`, or `polygon` shape dictionaries.
     - **`pose`** (`list`): Optional `[x, y, theta]` pose of a part relative to the owning object's coordinate-frame origin. Default is `[0, 0, 0]`, and `theta` is in radians.
-    - The object's `state` moves the complete compound body; parts cannot move independently.
-    - All parts inherit the owning object's color. Overlapping parts are merged for collision detection and visualization, while gaps between disjoint parts remain collision-free.
-    - `show_trajectory` uses the same path-line renderer as other shapes. By default, its width is the compound's local-y extent and the line follows the midpoint of that extent, keeping the trajectory and body widths aligned. The line does not reproduce concave or disjoint footprint gaps; use `show_trail` for exact historical shape snapshots.
 
     ```yaml
     # Example usage - compound robot body
@@ -1093,7 +1089,6 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
     - **`vertices`** (`list`): List of vertices defining the line string in the format `[[x1, y1], [x2, y2], ...]`.
     - **`random_shape`** (`bool`): Whether to generate a series of random line strings (polygon). Default is `False`.
     - **`is_convex`** (`bool`): Whether to generate a series of random convex line strings (polygons). Default is `True`.
-    - parameters for random line string generation (polygon), see {py:func}`~irsim.lib.algorithm.generation.random_generate_polygon` for more details. Parameters include `number `, `center_range `, `avg_radius_range `, `irregularity_range `, `spikeyness_range `, `num_vertices_range `.
 
     ```yaml
     # Example usage

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -19,8 +19,20 @@ import matplotlib.transforms as mtransforms
 import mpl_toolkits.mplot3d.art3d as art3d
 import numpy as np
 from matplotlib.lines import Line2D
-from matplotlib.patches import Arrow, Circle, Ellipse, Polygon, Rectangle, Wedge
+from matplotlib.patches import (
+    Arrow,
+    Circle,
+    Ellipse,
+    PathPatch,
+    Polygon,
+    Rectangle,
+    Wedge,
+)
+from matplotlib.path import Path
 from mpl_toolkits.mplot3d import Axes3D
+from shapely.geometry import MultiPolygon as ShapelyMultiPolygon
+from shapely.geometry import Polygon as ShapelyPolygon
+from shapely.geometry.polygon import orient
 
 from irsim.config.path_param import path_manager as pm
 from irsim.util.util import points_to_xy_list, traj_to_xy_list
@@ -767,6 +779,44 @@ def linewidth_from_data_units(
     return linewidth * (length / value_range)
 
 
+def geometry_to_path(geometry: Any) -> Path:
+    """Convert a Shapely polygonal geometry to a Matplotlib path.
+
+    Polygon interiors are preserved as oppositely oriented subpaths, allowing
+    one ``PathPatch`` to render Polygon and MultiPolygon geometries including
+    holes.
+
+    Args:
+        geometry: Shapely Polygon or MultiPolygon in local coordinates.
+
+    Returns:
+        matplotlib.path.Path: Compound path containing every polygon ring.
+
+    Raises:
+        ValueError: If the geometry is empty or not polygonal.
+    """
+    if isinstance(geometry, ShapelyPolygon):
+        polygons = [geometry]
+    elif isinstance(geometry, ShapelyMultiPolygon):
+        polygons = list(geometry.geoms)
+    else:
+        raise ValueError("compound rendering requires a Polygon or MultiPolygon")
+
+    paths = []
+    for polygon in polygons:
+        polygon = orient(polygon, sign=1.0)
+        for ring in (polygon.exterior, *polygon.interiors):
+            vertices = np.asarray(ring.coords, dtype=float)
+            codes = np.full(len(vertices), Path.LINETO, dtype=np.uint8)
+            codes[0] = Path.MOVETO
+            codes[-1] = Path.CLOSEPOLY
+            paths.append(Path(vertices, codes))
+
+    if not paths:
+        raise ValueError("compound rendering requires a non-empty geometry")
+    return Path.make_compound_path(*paths)
+
+
 def draw_patch(
     ax: Any,
     shape: str,
@@ -776,6 +826,7 @@ def draw_patch(
     color: str | None = None,
     zorder: int | None = None,
     linestyle: str | None = None,
+    geometry: Any | None = None,
     **kwargs: Any,
 ) -> Any:
     """
@@ -787,6 +838,7 @@ def draw_patch(
       offset); created in the body frame and transformed, matching the collision geometry
     - rectangle: prefer ``vertices`` (2xN) else use ``width``/``height`` with ``state`` transform
     - polygon: use ``vertices`` (2xN)
+    - compound: use a local-frame Shapely Polygon or MultiPolygon as ``geometry``
     - ellipse: use ``width``/``height`` with ``state`` transform
     - wedge: use ``radius`` and either ``theta1``/``theta2`` (deg) or ``fov`` (rad); transformed by ``state``
     - arrow: use ``state`` for position/orientation or provide ``theta``; supports ``arrow_length`` and ``arrow_width``
@@ -887,6 +939,25 @@ def draw_patch(
             created_element,
             ax,
             state=state,  # vertices are absolute
+            color=color,
+            facecolor=facecolor,
+            edgecolor=edgecolor,
+            alpha=alpha,
+            zorder=zorder,
+            linestyle=linestyle,
+            fill=fill,
+        )
+
+    # Compound Polygon / MultiPolygon
+    elif shape == "compound":
+        if geometry is None:
+            raise ValueError("compound requires a Polygon or MultiPolygon geometry")
+        patch = PathPatch(geometry_to_path(geometry))
+        created_element = ax.add_patch(patch)
+        set_patch_property(
+            created_element,
+            ax,
+            state=state,
             color=color,
             facecolor=facecolor,
             edgecolor=edgecolor,

--- a/irsim/lib/handler/geometry_handler.py
+++ b/irsim/lib/handler/geometry_handler.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import ClassVar
 
 import numpy as np
 import shapely as shp
@@ -92,6 +93,8 @@ class geometry_handler(ABC):
                 cone_type = "Rpositive"
             else:
                 G, h, cone_type = None, None, None
+        elif self.name == "compound":
+            G, h, cone_type, convex_flag = None, None, None, False
         else:
             G, h, cone_type, convex_flag = None, None, None, None
 
@@ -109,6 +112,8 @@ class geometry_handler(ABC):
             tuple: ``(G, h, cone_type, convex_flag)`` where unavailable
             constraints are returned as ``None`` values.
         """
+        G, h, cone_type, convex_flag = None, None, None, None
+
         if self.name == "polygon" or self.name == "rectangle":
             G, h, cone_type, convex_flag = self.get_polygon_Gh(kwargs.get("vertices"))
 
@@ -116,6 +121,9 @@ class geometry_handler(ABC):
             G, h, cone_type, convex_flag = self.get_circle_Gh(
                 kwargs.get("center"), kwargs.get("radius")
             )
+
+        elif self.name == "compound":
+            convex_flag = False
 
         return G, h, cone_type, convex_flag
 
@@ -370,6 +378,142 @@ class RectangleGeometry(geometry_handler):
         return Polygon(vertices)
 
 
+class CompoundGeometry(geometry_handler):
+    """Compound geometry assembled from fixed solid parts.
+
+    Each part is defined in the owning object's body frame. Its optional
+    ``pose`` is ``[x, y, theta]`` relative to that frame and defaults to the
+    identity pose. The exact collision geometry is the union of all transformed
+    parts, so overlapping parts do not introduce internal collision boundaries.
+    """
+
+    _SUPPORTED_PARTS: ClassVar[set[str]] = {"circle", "polygon", "rectangle"}
+
+    def __init__(self, name: str = "compound", **kwargs):
+        super().__init__(name, **kwargs)
+
+    def construct_original_geometry(self, parts: list[dict] | None = None, **kwargs):
+        """Construct a compound geometry in the owning object's body frame.
+
+        Args:
+            parts: Non-empty list of shape dictionaries. Each dictionary uses
+                the existing primitive shape parameters and may include a local
+                ``pose`` of ``[x, y, theta]``.
+            **kwargs: Reserved for future compound-level options.
+
+        Returns:
+            shapely.geometry.Polygon | shapely.geometry.MultiPolygon: Union of
+            all locally transformed part geometries.
+
+        Raises:
+            ValueError: If parts are missing, unsupported, empty, or have an
+                invalid pose.
+            TypeError: If a part is not a dictionary.
+        """
+        self.part_handlers = []
+        self.part_poses = []
+        self._original_part_geometries = []
+
+        for part_config, pose_array in self._validate_parts(parts):
+            handler = GeometryFactory.create_geometry(**part_config)
+            local_geometry = geometry_transform(
+                handler._original_geometry, pose_array.reshape(3, 1)
+            )
+
+            self.part_handlers.append(handler)
+            self.part_poses.append(pose_array)
+            self._original_part_geometries.append(local_geometry)
+
+        geometry = unary_union(self._original_part_geometries)
+        if geometry.is_empty or geometry.geom_type not in {"Polygon", "MultiPolygon"}:
+            raise ValueError(
+                "compound parts must produce a non-empty Polygon or MultiPolygon"
+            )
+
+        self.part_geometries = list(self._original_part_geometries)
+        return geometry
+
+    @classmethod
+    def _validate_parts(cls, parts: list[dict] | None) -> list[tuple[dict, np.ndarray]]:
+        """Validate and normalize compound part configurations."""
+        if not isinstance(parts, list) or not parts:
+            raise ValueError("compound shape requires a non-empty 'parts' list")
+
+        validated = []
+        for index, part in enumerate(parts):
+            if not isinstance(part, dict):
+                raise TypeError(f"compound parts[{index}] must be a dictionary")
+
+            part_config = part.copy()
+            if "color" in part_config:
+                raise ValueError(
+                    "compound parts do not support individual colors; "
+                    "set color on the owning object"
+                )
+
+            try:
+                pose = np.asarray(part_config.pop("pose", [0, 0, 0]), dtype=float)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"compound parts[{index}].pose must contain three numbers"
+                ) from exc
+            if pose.shape != (3,) or not np.all(np.isfinite(pose)):
+                raise ValueError(
+                    f"compound parts[{index}].pose must be finite [x, y, theta]"
+                )
+
+            name = part_config.get("name")
+            if not isinstance(name, str):
+                raise ValueError(f"compound parts[{index}] requires a shape name")
+            name = name.lower()
+            if name not in cls._SUPPORTED_PARTS:
+                supported = ", ".join(sorted(cls._SUPPORTED_PARTS))
+                raise ValueError(
+                    f"unsupported compound part '{name}' at parts[{index}]; "
+                    f"supported parts are: {supported}"
+                )
+
+            part_config["name"] = name
+            validated.append((part_config, pose))
+
+        return validated
+
+    def step(self, state):
+        """Transform the compound and its individual parts to ``state``."""
+        self.geometry = geometry_transform(self._original_geometry, state)
+        self.part_geometries = [
+            geometry_transform(geometry, state)
+            for geometry in self._original_part_geometries
+        ]
+        return self.geometry
+
+    @property
+    def vertices(self) -> None:
+        """A compound has no single exact vertex matrix."""
+        return None
+
+    @property
+    def original_vertices(self) -> None:
+        """A compound has no single exact original vertex matrix."""
+        return None
+
+    @property
+    def part_vertices(self) -> list[np.ndarray]:
+        """Current exterior vertices for each part as ``(2, N)`` arrays."""
+        return [
+            geometry.exterior.coords._coords.T[:, :-1]
+            for geometry in self.part_geometries
+        ]
+
+    @property
+    def original_part_vertices(self) -> list[np.ndarray]:
+        """Body-frame exterior vertices for each part as ``(2, N)`` arrays."""
+        return [
+            geometry.exterior.coords._coords.T[:, :-1]
+            for geometry in self._original_part_geometries
+        ]
+
+
 class LinestringGeometry(geometry_handler):
     """LineString geometry handler for wall or boundary segments."""
 
@@ -495,7 +639,7 @@ class GeometryFactory:
 
         Args:
             name: Shape name. Supported values are ``circle``, ``polygon``,
-                ``rectangle``, ``linestring``, and ``map``.
+                ``rectangle``, ``compound``, ``linestring``, and ``map``.
             **kwargs: Shape-specific parameters forwarded to the handler.
 
         Returns:
@@ -514,6 +658,9 @@ class GeometryFactory:
 
         if name == "rectangle":
             return RectangleGeometry(name, **kwargs)
+
+        if name == "compound":
+            return CompoundGeometry(name, **kwargs)
 
         if name == "linestring":
             return LinestringGeometry(name, **kwargs)

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -63,7 +63,7 @@ class ObstacleInfo:
     """Geometry and motion snapshot exposed for collision-aware behaviors."""
 
     center: np.ndarray
-    vertex: np.ndarray
+    vertex: np.ndarray | None
     velocity: np.ndarray
     radius: float
     G: np.ndarray
@@ -1131,7 +1131,7 @@ class ObjectBase:
         self,
         ax: Any,
         state: np.ndarray,
-        vertices: np.ndarray,
+        vertices: np.ndarray | None,
         initial: bool = False,
         **kwargs: Any,
     ) -> list[str]:
@@ -1598,7 +1598,7 @@ class ObjectBase:
         return np.c_[self._goal[0]]
 
     @property
-    def goal_vertices(self) -> np.ndarray:
+    def goal_vertices(self) -> np.ndarray | None:
         """
         Get the goal vertices of the object.
 
@@ -1697,25 +1697,42 @@ class ObjectBase:
         return self.collision_flag
 
     @property
-    def vertices(self) -> np.ndarray:
+    def vertices(self) -> np.ndarray | None:
         """
         Get the vertices of the object.
 
         Returns:
-            np.ndarray: The vertices of the object.
+            np.ndarray | None: The single-boundary vertices, or ``None`` for
+            compound geometry.
         """
 
         return self.gf.vertices
 
     @property
-    def original_vertices(self) -> np.ndarray:
+    def original_vertices(self) -> np.ndarray | None:
         """
         Get the original vertices of the object.
 
         Returns:
-            np.ndarray: The original vertices of the object before any transformations.
+            np.ndarray | None: Original single-boundary vertices, or ``None``
+            for compound geometry.
         """
         return self.gf.original_vertices
+
+    @property
+    def part_vertices(self) -> list[np.ndarray] | None:
+        """Return current vertices for each compound part.
+
+        Returns:
+            list[np.ndarray] | None: One ``(2, N)`` array per compound part,
+            or ``None`` for non-compound shapes.
+        """
+        return getattr(self.gf, "part_vertices", None)
+
+    @property
+    def original_part_vertices(self) -> list[np.ndarray] | None:
+        """Return body-frame vertices for each compound part."""
+        return getattr(self.gf, "original_part_vertices", None)
 
     @property
     def original_geometry(self) -> BaseGeometry:

--- a/irsim/world/object_plot.py
+++ b/irsim/world/object_plot.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
-from math import pi
+from math import cos, pi, sin
 from typing import TYPE_CHECKING, Any
 
 import matplotlib.transforms as mtransforms
@@ -14,7 +14,11 @@ from matplotlib.patches import Arrow, Circle, Wedge
 from mpl_toolkits.mplot3d import Axes3D
 
 from irsim.config.path_param import path_manager
-from irsim.env.env_plot import draw_patch, linewidth_from_data_units, set_patch_property
+from irsim.env.env_plot import (
+    draw_patch,
+    linewidth_from_data_units,
+    set_patch_property,
+)
 from irsim.util.util import file_check
 
 if TYPE_CHECKING:
@@ -358,6 +362,15 @@ class ObjectPlot:
         ):
             kwargs.setdefault("show_arrow", self.owner.kf.show_arrow)
 
+        if self.owner.shape == "compound":
+            return self.draw(
+                ax,
+                self.owner.state,
+                None,
+                initial=True,
+                **kwargs,
+            )
+
         return self.draw(
             ax,
             self.owner.original_state,
@@ -370,7 +383,7 @@ class ObjectPlot:
         self,
         ax: Any,
         state: np.ndarray,
-        vertices: np.ndarray,
+        vertices: np.ndarray | None,
         initial: bool = False,
         **kwargs: Any,
     ) -> list[str]:
@@ -604,8 +617,7 @@ class ObjectPlot:
 
         line = element[0]
         trajectory = self.owner.trajectory[-style.keep_length :]
-        x_list = [state[0, 0] for state in trajectory]
-        y_list = [state[1, 0] for state in trajectory]
+        x_list, y_list = self._trajectory_coordinates(trajectory)
 
         if isinstance(self.owner.ax, Axes3D):
             line.set_data_3d(x_list, y_list, [0] * len(x_list))
@@ -620,6 +632,28 @@ class ObjectPlot:
         line.set_linestyle(style.style)
         line.set_alpha(style.alpha)
         line.set_zorder(style.zorder)
+
+    def _trajectory_coordinates(
+        self, trajectory: list[Any]
+    ) -> tuple[list[float], list[float]]:
+        if self.owner.shape == "compound":
+            _, min_y, _, max_y = self.owner.original_geometry.bounds
+            center_y = (min_y + max_y) / 2
+            return (
+                [
+                    float(state[0, 0] - sin(float(state[2, 0])) * center_y)
+                    for state in trajectory
+                ],
+                [
+                    float(state[1, 0] + cos(float(state[2, 0])) * center_y)
+                    for state in trajectory
+                ],
+            )
+
+        return (
+            [float(state[0, 0]) for state in trajectory],
+            [float(state[1, 0]) for state in trajectory],
+        )
 
     def _update_text(self, x: float, y: float, style: TextStyle) -> None:
         """Update the object label when it exists."""
@@ -669,7 +703,11 @@ class ObjectPlot:
         state = self.owner.state if state is None else state
         vertices = self.owner.vertices if vertices is None else vertices
 
-        if self.owner.description is None or isinstance(ax, Axes3D):
+        if (
+            self.owner.shape == "compound"
+            or self.owner.description is None
+            or isinstance(ax, Axes3D)
+        ):
             try:
                 if self.owner.shape != "map":
                     self.owner.object_patch = draw_patch(
@@ -683,6 +721,11 @@ class ObjectPlot:
                             else None
                         ),
                         vertices=vertices,
+                        geometry=(
+                            self.owner.original_geometry
+                            if self.owner.shape == "compound"
+                            else None
+                        ),
                         color=options.object.color,
                         alpha=options.object.alpha,
                         linestyle=options.object.linestyle,
@@ -767,8 +810,7 @@ class ObjectPlot:
         self.owner.keep_traj_length = options.trajectory.keep_length
 
         kept_trajectory = trajectory[-options.trajectory.keep_length :]
-        x_list = [state[0, 0] for state in kept_trajectory]
-        y_list = [state[1, 0] for state in kept_trajectory]
+        x_list, y_list = self._trajectory_coordinates(kept_trajectory)
 
         linewidth = linewidth_from_data_units(options.trajectory.width, ax, "y")
         if isinstance(ax, Axes3D):
@@ -821,6 +863,9 @@ class ObjectPlot:
             state=goal_state,
             radius=self.owner.radius,
             vertices=vertices,
+            geometry=(
+                self.owner.original_geometry if self.owner.shape == "compound" else None
+            ),
             color=options.goal.color,
             alpha=options.goal.alpha,
             zorder=options.goal.zorder,
@@ -957,6 +1002,11 @@ class ObjectPlot:
             shape=options.trail.shape,
             state=state,
             vertices=vertices,
+            geometry=(
+                self.owner.original_geometry
+                if options.trail.shape == "compound"
+                else None
+            ),
             radius=self.owner.radius,
             center=(
                 self.owner.original_centroid

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -191,6 +191,16 @@ class TestCompoundGeometry:
                 r"finite \[x, y, theta\]",
             ),
             (
+                [{"name": "rectangle", "pose": [0, 0, "invalid"]}],
+                ValueError,
+                "pose must contain three numbers",
+            ),
+            (
+                [{"name": "circle", "radius": 0.0}],
+                ValueError,
+                "non-empty Polygon or MultiPolygon",
+            ),
+            (
                 [{"name": "rectangle", "color": "red"}],
                 ValueError,
                 "do not support individual colors",
@@ -230,6 +240,8 @@ class TestCompoundGeometry:
             shape={"name": "circle", "radius": 0.2}, state=[1.5, 0.0, 0.0]
         )
 
+        assert len(compound.part_vertices) == 2
+        assert len(compound.original_part_vertices) == 2
         assert not compound.check_collision(in_gap)
         assert compound.check_collision(on_part)
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -83,6 +83,157 @@ class TestGeometryStep:
         assert geometry is not None
 
 
+class TestCompoundGeometry:
+    """Tests for fixed primitive parts assembled into one object geometry."""
+
+    def test_disjoint_parts_create_exact_multipolygon(self):
+        compound = GeometryFactory.create_geometry(
+            "compound",
+            parts=[
+                {"name": "rectangle", "length": 1.0, "width": 1.0},
+                {
+                    "name": "rectangle",
+                    "length": 1.0,
+                    "width": 1.0,
+                    "pose": [2.0, 0.0, 0.0],
+                },
+            ],
+        )
+
+        assert compound.geometry.geom_type == "MultiPolygon"
+        assert compound.geometry.area == pytest.approx(2.0)
+        assert compound.geometry.bounds == pytest.approx((-0.5, -0.5, 2.5, 0.5))
+        assert compound.vertices is None
+        assert compound.original_vertices is None
+        assert len(compound.part_vertices) == 2
+        assert len(compound.original_part_vertices) == 2
+        assert compound.get_init_Gh() == (None, None, None, False)
+        assert compound.get_Gh() == (None, None, None, False)
+
+    def test_overlapping_parts_are_unioned_without_internal_area(self):
+        compound = GeometryFactory.create_geometry(
+            "compound",
+            parts=[
+                {"name": "rectangle", "length": 2.0, "width": 1.0},
+                {
+                    "name": "rectangle",
+                    "length": 2.0,
+                    "width": 1.0,
+                    "pose": [1.0, 0.0, 0.0],
+                },
+            ],
+        )
+
+        assert compound.geometry.geom_type == "Polygon"
+        assert compound.geometry.area == pytest.approx(3.0)
+
+    def test_part_pose_rotation_is_relative_to_body_frame(self):
+        compound = GeometryFactory.create_geometry(
+            "compound",
+            parts=[
+                {
+                    "name": "rectangle",
+                    "length": 2.0,
+                    "width": 1.0,
+                    "pose": [1.0, 0.0, np.pi / 2],
+                }
+            ],
+        )
+
+        assert compound.geometry.bounds == pytest.approx((0.5, -1.0, 1.5, 1.0))
+
+    def test_object_state_transforms_union_and_parts_together(self):
+        compound = GeometryFactory.create_geometry(
+            "compound",
+            parts=[
+                {"name": "rectangle", "length": 1.0, "width": 0.4},
+                {
+                    "name": "circle",
+                    "radius": 0.2,
+                    "pose": [1.0, 0.0, 0.0],
+                },
+            ],
+        )
+        original_distances = [
+            part.centroid.distance(compound.geometry.centroid)
+            for part in compound.part_geometries
+        ]
+
+        compound.step(np.array([[3.0], [4.0], [np.pi / 2]]))
+
+        transformed_distances = [
+            part.centroid.distance(compound.geometry.centroid)
+            for part in compound.part_geometries
+        ]
+        assert transformed_distances == pytest.approx(original_distances)
+        assert len(compound.part_vertices) == 2
+
+    @pytest.mark.parametrize(
+        ("parts", "error", "message"),
+        [
+            (None, ValueError, "non-empty 'parts'"),
+            ([], ValueError, "non-empty 'parts'"),
+            (["rectangle"], TypeError, r"parts\[0\] must be a dictionary"),
+            ([{"length": 1.0}], ValueError, "requires a shape name"),
+            (
+                [{"name": "linestring", "vertices": [[0, 0], [1, 0]]}],
+                ValueError,
+                "unsupported compound part",
+            ),
+            (
+                [{"name": "rectangle", "pose": [0, 0]}],
+                ValueError,
+                r"finite \[x, y, theta\]",
+            ),
+            (
+                [{"name": "rectangle", "pose": [0, 0, np.nan]}],
+                ValueError,
+                r"finite \[x, y, theta\]",
+            ),
+            (
+                [{"name": "rectangle", "color": "red"}],
+                ValueError,
+                "do not support individual colors",
+            ),
+        ],
+    )
+    def test_invalid_parts_are_rejected(self, parts, error, message):
+        with pytest.raises(error, match=message):
+            GeometryFactory.create_geometry("compound", parts=parts)
+
+    def test_collision_uses_exact_disjoint_geometry(self):
+        from irsim.world.object_base import ObjectBase
+
+        compound = ObjectBase(
+            shape={
+                "name": "compound",
+                "parts": [
+                    {
+                        "name": "rectangle",
+                        "length": 1.0,
+                        "width": 1.0,
+                        "pose": [-1.5, 0.0, 0.0],
+                    },
+                    {
+                        "name": "rectangle",
+                        "length": 1.0,
+                        "width": 1.0,
+                        "pose": [1.5, 0.0, 0.0],
+                    },
+                ],
+            }
+        )
+        in_gap = ObjectBase(
+            shape={"name": "circle", "radius": 0.2}, state=[0.0, 0.0, 0.0]
+        )
+        on_part = ObjectBase(
+            shape={"name": "circle", "radius": 0.2}, state=[1.5, 0.0, 0.0]
+        )
+
+        assert not compound.check_collision(in_gap)
+        assert compound.check_collision(on_part)
+
+
 class TestGeometryHandlerCoverage:
     """Additional tests to cover remaining lines in geometry_handler.py"""
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -13,8 +13,10 @@ from unittest.mock import Mock
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+import shapely
 import yaml
 from matplotlib.colors import to_rgba
+from matplotlib.lines import Line2D
 
 import irsim
 import irsim.env.env_plot as env_plot_module
@@ -278,6 +280,31 @@ class TestDrawPatch:
         )
         assert poly is not None
 
+    def test_draw_compound_multipolygon(self, ax_2d):
+        """Compound rendering keeps disjoint polygon components in one patch."""
+        geometry = shapely.union_all(
+            [
+                shapely.box(-0.5, -0.5, 0.5, 0.5),
+                shapely.box(1.5, -0.5, 2.5, 0.5),
+            ]
+        )
+        patch = draw_patch(
+            ax_2d,
+            "compound",
+            state=np.array([[1.0], [2.0], [0.0]]),
+            geometry=geometry,
+            color="teal",
+        )
+
+        assert patch is not None
+        assert len(patch.get_path().vertices) == 10
+
+    def test_draw_compound_requires_polygonal_geometry(self, ax_2d):
+        with pytest.raises(ValueError, match="compound requires"):
+            draw_patch(ax_2d, "compound")
+        with pytest.raises(ValueError, match="Polygon or MultiPolygon"):
+            draw_patch(ax_2d, "compound", geometry=shapely.Point(0, 0))
+
     def test_draw_ellipse(self, ax_2d):
         """Test drawing ellipse patch."""
         state = np.array([[0.0], [0.0], [0.0]])
@@ -447,6 +474,110 @@ class TestObjectPlot:
             obj.object_patch.get_facecolor(), to_rgba("magenta", alpha=0.25)
         )
         assert obj.object_patch.get_linewidth() == 2.5
+        plt.close(fig)
+
+    def test_compound_object_render_matches_collision_geometry(self):
+        obj = ObjectBase(
+            shape={
+                "name": "compound",
+                "parts": [
+                    {"name": "rectangle", "length": 1.0, "width": 0.4},
+                    {
+                        "name": "circle",
+                        "radius": 0.2,
+                        "pose": [1.0, 0.0, 0.0],
+                    },
+                ],
+            },
+            state=[2.0, 3.0, np.pi / 2],
+            color="teal",
+        )
+
+        fig, ax = plt.subplots()
+        obj._init_plot(ax)
+
+        display_vertices = obj.object_patch.get_transform().transform(
+            obj.object_patch.get_path().vertices
+        )
+        data_vertices = ax.transData.inverted().transform(display_vertices)
+        rendered_bounds = (
+            data_vertices[:, 0].min(),
+            data_vertices[:, 1].min(),
+            data_vertices[:, 0].max(),
+            data_vertices[:, 1].max(),
+        )
+
+        assert rendered_bounds == pytest.approx(obj.geometry.bounds, abs=1e-6)
+        np.testing.assert_allclose(obj.object_patch.get_facecolor(), to_rgba("teal"))
+        plt.close(fig)
+
+    def test_compound_goal_and_trail_use_original_geometry(self):
+        obj = ObjectBase(
+            shape={
+                "name": "compound",
+                "parts": [
+                    {"name": "rectangle", "length": 1.0, "width": 0.4},
+                    {
+                        "name": "rectangle",
+                        "length": 0.4,
+                        "width": 1.0,
+                        "pose": [0.3, 0.0, 0.0],
+                    },
+                ],
+            },
+            goal=[4.0, 5.0, 0.5],
+        )
+
+        fig, ax = plt.subplots()
+        obj.plot_goal(ax, obj.goal)
+        obj.plot_trail(ax, np.array([[1.0], [2.0], [0.25]]))
+
+        assert obj.goal_patch.get_path().vertices.size > 0
+        assert obj.plot_trail_list[-1].get_path().vertices.size > 0
+        plt.close(fig)
+
+    def test_compound_trajectory_aligns_with_geometry_width(self):
+        obj = ObjectBase(
+            shape={
+                "name": "compound",
+                "parts": [
+                    {"name": "rectangle", "length": 0.8, "width": 0.3},
+                    {
+                        "name": "rectangle",
+                        "length": 0.3,
+                        "width": 0.8,
+                        "pose": [-0.25, 0.3, 0.0],
+                    },
+                ],
+            },
+            state=[1.0, 0.0, 0.0],
+            plot={"show_trajectory": True},
+        )
+        obj.trajectory = [
+            np.array([[1.0], [0.0], [0.0]]),
+            np.array([[2.0], [0.0], [0.0]]),
+        ]
+
+        fig, ax = plt.subplots()
+        obj._init_plot(ax)
+
+        trajectory_line = obj.trajectory_line[0]
+        _, min_y, _, max_y = obj.original_geometry.bounds
+        center_y = (min_y + max_y) / 2
+        assert isinstance(trajectory_line, Line2D)
+        assert obj._object_plot.options.trajectory.width == pytest.approx(obj.width)
+        np.testing.assert_allclose(trajectory_line.get_xdata(), [1.0, 2.0])
+        np.testing.assert_allclose(trajectory_line.get_ydata(), [center_y, center_y])
+
+        obj.trajectory.append(np.array([[3.0], [0.0], [np.pi / 2]]))
+        obj._step_plot()
+
+        np.testing.assert_allclose(
+            trajectory_line.get_xdata(), [1.0, 2.0, 3.0 - center_y]
+        )
+        np.testing.assert_allclose(
+            trajectory_line.get_ydata(), [center_y, center_y, 0.0], atol=1e-15
+        )
         plt.close(fig)
 
     @pytest.mark.parametrize(

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -304,6 +304,8 @@ class TestDrawPatch:
             draw_patch(ax_2d, "compound")
         with pytest.raises(ValueError, match="Polygon or MultiPolygon"):
             draw_patch(ax_2d, "compound", geometry=shapely.Point(0, 0))
+        with pytest.raises(ValueError, match="non-empty geometry"):
+            draw_patch(ax_2d, "compound", geometry=shapely.MultiPolygon())
 
     def test_draw_ellipse(self, ax_2d):
         """Test drawing ellipse patch."""

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -4,6 +4,7 @@ import pytest
 import shapely
 from shapely import STRtree
 
+from irsim.lib.handler.geometry_handler import GeometryFactory
 from irsim.util.random import set_seed
 from irsim.world.object_factory import ObjectFactory
 from irsim.world.sensors.fmcw_lidar2d import FMCWLidar2D
@@ -686,6 +687,41 @@ def test_lidar_subtracts_map_lines_and_dynamic_polygon():
     assert len(blocked) >= 2
     assert ranges.min() == pytest.approx(1.5, abs=0.3)  # circle -> polygon group
     assert blocked.max() == pytest.approx(3.0, abs=0.3)  # wall   -> line group
+
+
+def test_lidar_detects_disjoint_compound_geometry():
+    """A MultiPolygon compound is treated as one obstacle without filling gaps."""
+    compound = GeometryFactory.create_geometry(
+        "compound",
+        parts=[
+            {
+                "name": "rectangle",
+                "length": 0.5,
+                "width": 1.0,
+                "pose": [2.0, 0.0, 0.0],
+            },
+            {
+                "name": "rectangle",
+                "length": 0.5,
+                "width": 1.0,
+                "pose": [4.0, 0.0, 0.0],
+            },
+        ],
+    )
+    obstacle = _Obstacle(2, compound.geometry, shape="compound")
+    env_param = _EnvParam([obstacle], STRtree([obstacle.geometry]))
+    lidar = Lidar2D(
+        state=np.array([[0.0], [0.0], [0.0]]),
+        obj_id=1,
+        number=1,
+        angle_range=0.0,
+        range_max=6.0,
+    )
+    lidar.parent = _Parent(env_param)
+
+    lidar.step(lidar.state)
+
+    assert lidar.range_data[0] == pytest.approx(1.75, abs=1e-6)
 
 
 # ---------------------------------------------------------------------------

--- a/usage/02robot_world/robot_compound_world.yaml
+++ b/usage/02robot_world/robot_compound_world.yaml
@@ -1,0 +1,20 @@
+world:
+  height: 10
+  width: 10
+  step_time: 0.1
+  sample_time: 0.1
+  offset: [0, 0]
+
+robot:
+  kinematics: {name: diff}
+  shape:
+    name: compound
+    parts:
+      - {name: rectangle, length: 0.8, width: 0.3}
+      - {name: rectangle, length: 0.3, width: 0.8, pose: [-0.25, 0.3, 0]}
+  behavior: {name: dash}
+  state: [1, 1, 0]
+  goal: [9, 9, 0]
+  color: g
+  plot:
+    show_trajectory: true

--- a/usage/02robot_world/robot_world.py
+++ b/usage/02robot_world/robot_world.py
@@ -4,6 +4,7 @@ import irsim
 
 # env = irsim.make("robot_world.yaml")
 # env = irsim.make("robot_omni_world.yaml")
+# env = irsim.make("robot_compound_world.yaml")
 env = irsim.make("robot_omni_angular_world.yaml")
 
 # env = irsim.make('car_world.yaml')


### PR DESCRIPTION
## Summary

Add compound geometry built from fixed circle, rectangle, and polygon parts. Collision, LiDAR, rendering, goals, trails, examples, tests, and bilingual documentation use the combined shape.

A single primitive cannot accurately represent many rigid robots and obstacles. Compound geometry lets users model multi-part bodies without manually merging them into one polygon.

Closes #102.