### PR TITLE
perf(sensors): speed up 2D lidar ray casting

### DIFF
--- a/irsim/lib/algorithm/__init__.py
+++ b/irsim/lib/algorithm/__init__.py
@@ -6,6 +6,7 @@ This package contains:
 - rvo: Reciprocal Velocity Obstacle algorithm
 - social_force_model: Anisotropic Social Force Model (Moussaïd 2009)
 - generation: Polygon generation utilities
+- ray_casting_2d: Vectorized 2D ray casting for lidar sensors
 """
 
 from .generation import generate_polygon, random_generate_polygon
@@ -15,11 +16,13 @@ from .kinematics import (
     omni_angular_kinematics,
     omni_kinematics,
 )
+from .ray_casting_2d import cast_rays
 from .rvo import reciprocal_vel_obs
 from .social_force_model import social_force_model
 
 __all__ = [
     "ackermann_kinematics",
+    "cast_rays",
     "differential_kinematics",
     "generate_polygon",
     "omni_angular_kinematics",

--- a/irsim/lib/algorithm/ray_casting_2d.py
+++ b/irsim/lib/algorithm/ray_casting_2d.py
@@ -1,0 +1,369 @@
+"""Vectorized 2D ray casting against simulation objects.
+
+Shared by the lidar sensors (:class:`~irsim.world.sensors.lidar2d.Lidar2D` and
+:class:`~irsim.world.sensors.fmcw_lidar2d.FMCWLidar2D`). The high-level
+:func:`cast_rays` function selects nearby objects, flattens their boundaries,
+and returns the nearest object hit by every beam. The lower-level
+:func:`cast_ray_segments` function performs the vectorized numerical kernel.
+
+For a sensor origin in free space, this reproduces a GEOS ``difference`` scan
+to floating-point precision while avoiding the expensive overlay. FMCW exit
+hits also remain compatible when the origin is inside an obstacle.
+
+Typical use::
+
+    ranges, hit_objects, origin, directions = cast_rays(
+        lidar_geometry, objects, geometry_tree, sensor_id, range_max
+    )
+"""
+
+import numpy as np
+import shapely
+
+# Beam hits closer than this are treated as the origin itself (e.g. the sensor
+# sitting exactly on an obstacle edge) and ignored, matching GEOS's difference,
+# which drops such coincident intersections topologically.
+ORIGIN_EPS = 1e-9
+
+
+def _empty_scan(number: int, max_range: float) -> tuple[np.ndarray, np.ndarray]:
+    """Return the range and hit-index arrays for a scan with no hits."""
+    # dtype=float is important when max_range comes from YAML as an integer;
+    # otherwise later assignments would truncate fractional hit distances.
+    ranges = np.full(number, max_range, dtype=float)
+    hit_index = np.full(number, -1, dtype=int)
+    return ranges, hit_index
+
+
+def _nonparallel_hit_distances(
+    directions: np.ndarray,
+    segment_vectors: np.ndarray,
+    start_to_origin: np.ndarray,
+    max_range: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Calculate valid distances for every non-parallel ray/segment pair.
+
+    For each pair, solve
+
+    ``origin + ray_distance * direction``
+    ``= segment_start + segment_position * segment_vector``.
+
+    A valid hit is in front of the ray origin and between the two segment
+    endpoints. Invalid pairs are represented by infinity so that a later
+    minimum operation naturally ignores them.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray, np.ndarray]: The ``(segments, rays)``
+        distance matrix, its intersection denominator, and the per-segment
+        cross product used to identify collinear segments.
+    """
+    perpendicular_directions = np.column_stack((-directions[:, 1], directions[:, 0]))
+    with np.errstate(all="ignore"):
+        denominator = segment_vectors @ perpendicular_directions.T
+        segment_position = (start_to_origin @ perpendicular_directions.T) / denominator
+        line_cross = (
+            segment_vectors[:, 0] * start_to_origin[:, 1]
+            - segment_vectors[:, 1] * start_to_origin[:, 0]
+        )
+        ray_distance = line_cross[:, np.newaxis] / denominator
+
+    # Ignore intersections at the sensor origin. For example, a sensor on a
+    # grid-cell edge would otherwise report zero for every crossing beam.
+    valid_hit = (
+        (denominator != 0)
+        & (segment_position >= 0)
+        & (segment_position <= 1)
+        & (ray_distance > ORIGIN_EPS)
+        & (ray_distance <= max_range)
+    )
+    return np.where(valid_hit, ray_distance, np.inf), denominator, line_cross
+
+
+def _empty_collinear_hits() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return empty arrays matching :func:`_find_collinear_hits`."""
+    empty_index = np.empty(0, dtype=int)
+    return empty_index, empty_index.copy(), np.empty(0, dtype=float)
+
+
+def _find_collinear_hits(
+    origin: np.ndarray,
+    directions: np.ndarray,
+    seg_start: np.ndarray,
+    seg_end: np.ndarray,
+    denominator: np.ndarray,
+    line_cross: np.ndarray,
+    max_range: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Find hits where a ray overlaps a collinear segment.
+
+    Parallel pairs have a zero intersection denominator. Most are separate
+    lines and therefore misses. A pair is collinear only when the segment's
+    supporting line also passes through the ray origin. For such pairs, project
+    both endpoints onto the ray and return the nearest positive endpoint.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray, np.ndarray]: Matching segment indices,
+        ray indices, and hit distances. All arrays are one-dimensional.
+    """
+    collinear_segments = np.flatnonzero(np.abs(line_cross) <= ORIGIN_EPS)
+    if len(collinear_segments) == 0:
+        return _empty_collinear_hits()
+
+    local_segment_index, ray_index = np.nonzero(denominator[collinear_segments] == 0)
+    segment_index = collinear_segments[local_segment_index]
+    if len(segment_index) == 0:
+        return _empty_collinear_hits()
+
+    matching_directions = directions[ray_index]
+    start_distance = np.sum(
+        (seg_start[segment_index] - origin) * matching_directions, axis=1
+    )
+    end_distance = np.sum(
+        (seg_end[segment_index] - origin) * matching_directions,
+        axis=1,
+    )
+    overlap_start = np.minimum(start_distance, end_distance)
+    overlap_end = np.maximum(start_distance, end_distance)
+
+    # When an overlap begins at the sensor origin, ignore distance zero and use
+    # its other positive endpoint, matching the previous scanner behavior.
+    hit_distance = np.where(
+        overlap_start > ORIGIN_EPS,
+        overlap_start,
+        np.minimum(overlap_end, max_range),
+    )
+    valid_hit = (
+        (overlap_end > ORIGIN_EPS)
+        & (overlap_start <= max_range)
+        & (hit_distance <= max_range)
+    )
+    return (
+        segment_index[valid_hit],
+        ray_index[valid_hit],
+        hit_distance[valid_hit],
+    )
+
+
+def _nearest_hits(
+    hit_distances: np.ndarray, max_range: float
+) -> tuple[np.ndarray, np.ndarray]:
+    """Select the nearest segment for each ray from a distance matrix."""
+    number = hit_distances.shape[1]
+    ranges, hit_index = _empty_scan(number, max_range)
+
+    nearest_segment = np.argmin(hit_distances, axis=0)
+    nearest_distance = hit_distances[nearest_segment, np.arange(number)]
+    has_hit = np.isfinite(nearest_distance)
+    ranges[has_hit] = nearest_distance[has_hit]
+    hit_index[has_hit] = nearest_segment[has_hit]
+    return ranges, hit_index
+
+
+def boundary_segments(geometry):
+    """Flatten a geometry's boundary into ``(start, end)`` segment arrays.
+
+    Handles every obstacle geometry a lidar may encounter: polygons (with
+    holes), rectangles, circles (buffer polygons), linestrings, map segments,
+    and compound ``MultiPolygon`` / ``GeometryCollection`` shapes. Points and
+    empty geometries contribute no edges.
+
+    Polygonal parts are reduced to their ring linestrings with
+    :func:`shapely.boundary` (which covers the outer ring and any holes);
+    linestrings are used directly. Note ``shapely.boundary`` of a *linestring*
+    returns its endpoints, not its segments, so it must not be applied to line
+    obstacles.
+
+    Args:
+        geometry: Any Shapely geometry.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: ``(start, end)`` endpoint arrays, each of
+        shape ``(M, 2)`` (``(0, 2)`` when the geometry has no edges).
+    """
+    # Collect boundary linestrings: polygon rings via shapely.boundary, lines
+    # as-is. shapely.get_parts flattens Multi* / GeometryCollection one level.
+    lines = []
+    for part in shapely.get_parts(geometry):
+        if part.geom_type in ("Polygon", "MultiPolygon"):
+            lines.append(shapely.boundary(part))
+        elif part.geom_type in ("LineString", "LinearRing", "MultiLineString"):
+            lines.append(part)
+    if not lines:
+        empty = np.empty((0, 2))
+        return empty, empty
+
+    # Split every linestring into (start, end) segments in one vectorized pass.
+    # ``return_index`` tags each coordinate with its linestring, so masking on
+    # equal neighbours keeps segments from spanning two different linestrings.
+    parts = shapely.get_parts(lines)
+    coords, index = shapely.get_coordinates(parts, return_index=True)
+    if len(coords) < 2:
+        empty = np.empty((0, 2))
+        return empty, empty
+    same = index[:-1] == index[1:]
+    return coords[:-1][same], coords[1:][same]
+
+
+def _empty_segments() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return empty segment endpoints and their owning-object indices."""
+    empty = np.empty((0, 2))
+    return empty, empty.copy(), np.empty(0, dtype=int)
+
+
+def _gather_obstacle_edges(
+    lidar_geometry,
+    objects,
+    geometry_tree,
+    sensor_id: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Select nearby objects and flatten their boundaries into line segments.
+
+    ``objects`` and ``geometry_tree`` must use the same ordering because tree
+    query indices are also returned as segment-owner indices. Map objects keep
+    their own spatial query so only map lines touched by the scan are expanded.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray, np.ndarray]: Segment starts, segment ends,
+        and the owning object index for every segment, with shapes ``(M, 2)``,
+        ``(M, 2)``, and ``(M,)``.
+    """
+    if geometry_tree is None:
+        return _empty_segments()
+
+    starts, ends, owners = [], [], []
+    for object_index in geometry_tree.query(lidar_geometry):
+        obj = objects[object_index]
+        if obj._id == sensor_id or not obj._geometry_valid or obj.unobstructed:
+            continue
+
+        if obj.shape == "map":
+            hits = obj.geometry_tree.query(lidar_geometry, predicate="intersects")
+            geometries = [obj.linestrings[index] for index in hits]
+        elif lidar_geometry.intersects(obj._geometry):
+            geometries = [obj._geometry]
+        else:
+            continue
+
+        if geometries:
+            start, end = boundary_segments(geometries)
+            if len(start):
+                starts.append(start)
+                ends.append(end)
+                owners.append(np.full(len(start), object_index))
+
+    if not starts:
+        return _empty_segments()
+    return np.concatenate(starts), np.concatenate(ends), np.concatenate(owners)
+
+
+def _ray_parameters(lidar_geometry, max_range: float) -> tuple[np.ndarray, np.ndarray]:
+    """Extract the shared origin and unit directions from max-range beams."""
+    coordinates = shapely.get_coordinates(lidar_geometry)
+    origin = coordinates[0]
+    directions = (coordinates[1::2] - origin) / max_range
+    return origin, directions
+
+
+def cast_ray_segments(
+    origin: np.ndarray,
+    directions: np.ndarray,
+    seg_start: np.ndarray,
+    seg_end: np.ndarray,
+    max_range: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Nearest ray-segment hit distance and segment index per ray (vectorized).
+
+    Solves, for every ray ``origin + t * direction`` against every segment
+    ``seg_start + u * (seg_end - seg_start)``, the intersection in one broadcast
+    pass and keeps the nearest valid hit (``0 < t <= max_range``, ``0 <= u <=
+    1``) per ray. Collinear overlaps are handled separately because their
+    standard intersection denominator is zero.
+
+    Args:
+        origin (np.ndarray): Shared ray origin ``(2,)``.
+        directions (np.ndarray): Unit ray directions ``(N, 2)``.
+        seg_start (np.ndarray): Segment start points ``(M, 2)``.
+        seg_end (np.ndarray): Segment end points ``(M, 2)``.
+        max_range (float): Maximum ray length; misses return this.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: ``ranges`` ``(N,)`` clamped to
+        ``max_range``, and ``hit_index`` ``(N,)`` giving the index into the
+        segment arrays that each ray hit (``-1`` on a miss).
+    """
+    if len(seg_start) == 0:
+        return _empty_scan(len(directions), max_range)
+
+    segment_vectors = seg_end - seg_start
+    start_to_origin = origin - seg_start
+
+    # 1. Solve the ordinary ray/segment intersections in one vectorized pass.
+    hit_distances, denominator, line_cross = _nonparallel_hit_distances(
+        directions,
+        segment_vectors,
+        start_to_origin,
+        max_range,
+    )
+
+    # 2. Fill in overlapping pairs that the zero denominator cannot solve.
+    segment_index, ray_index, distance = _find_collinear_hits(
+        origin,
+        directions,
+        seg_start,
+        seg_end,
+        denominator,
+        line_cross,
+        max_range,
+    )
+    hit_distances[segment_index, ray_index] = distance
+
+    # 3. Select the closest segment independently for every beam.
+    return _nearest_hits(hit_distances, max_range)
+
+
+def cast_rays(
+    lidar_geometry,
+    objects,
+    geometry_tree,
+    sensor_id: int,
+    max_range: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Cast a 2D lidar geometry against all relevant simulation objects.
+
+    This is the sensor-facing ray-casting operation. It owns the complete
+    geometry pipeline: deriving ray parameters, querying nearby objects,
+    gathering their boundary segments, running the numerical kernel, and
+    mapping segment hits back to object indices.
+
+    Args:
+        lidar_geometry: Max-range beams in world coordinates as a Shapely
+            multiline geometry.
+        objects: Simulation objects in the same order as ``geometry_tree``.
+        geometry_tree: STRtree containing the object geometries, or ``None``.
+        sensor_id: Parent object ID; its own geometry is ignored.
+        max_range: Maximum ray length; misses return this value.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]: Ranges,
+        hit-object indices, origin, and directions.
+    """
+    shapely.prepare(lidar_geometry)
+    origin, directions = _ray_parameters(lidar_geometry, max_range)
+    segment_start, segment_end, segment_owner = _gather_obstacle_edges(
+        lidar_geometry,
+        objects,
+        geometry_tree,
+        sensor_id,
+    )
+    ranges, hit_segments = cast_ray_segments(
+        origin,
+        directions,
+        segment_start,
+        segment_end,
+        max_range,
+    )
+
+    hit_objects = np.full(len(directions), -1, dtype=int)
+    has_hit = hit_segments >= 0
+    hit_objects[has_hit] = segment_owner[hit_segments[has_hit]]
+    return ranges, hit_objects, origin, directions

--- a/irsim/lib/algorithm/ray_casting_2d.py
+++ b/irsim/lib/algorithm/ray_casting_2d.py
@@ -25,6 +25,11 @@ import shapely
 # which drops such coincident intersections topologically.
 ORIGIN_EPS = 1e-9
 
+# Limit the ray/segment matrix to a predictable size. Large point-based maps
+# can contribute tens of thousands of boundary segments; processing all of
+# them at once would make every temporary matrix scale with segments * beams.
+SEGMENT_CHUNK_SIZE = 1024
+
 
 def _empty_scan(number: int, max_range: float) -> tuple[np.ndarray, np.ndarray]:
     """Return the range and hit-index arrays for a scan with no hits."""
@@ -274,10 +279,11 @@ def cast_ray_segments(
     """Nearest ray-segment hit distance and segment index per ray (vectorized).
 
     Solves, for every ray ``origin + t * direction`` against every segment
-    ``seg_start + u * (seg_end - seg_start)``, the intersection in one broadcast
-    pass and keeps the nearest valid hit (``0 < t <= max_range``, ``0 <= u <=
-    1``) per ray. Collinear overlaps are handled separately because their
-    standard intersection denominator is zero.
+    ``seg_start + u * (seg_end - seg_start)``, the intersection in vectorized
+    segment blocks and keeps the nearest valid hit (``0 < t <= max_range``,
+    ``0 <= u <= 1``) per ray. Blocking bounds peak matrix memory by
+    ``SEGMENT_CHUNK_SIZE * number_of_rays``. Collinear overlaps are handled
+    separately because their standard intersection denominator is zero.
 
     Args:
         origin (np.ndarray): Shared ray origin ``(2,)``.
@@ -294,31 +300,43 @@ def cast_ray_segments(
     if len(seg_start) == 0:
         return _empty_scan(len(directions), max_range)
 
-    segment_vectors = seg_end - seg_start
-    start_to_origin = origin - seg_start
+    ranges, hit_index = _empty_scan(len(directions), max_range)
 
-    # 1. Solve the ordinary ray/segment intersections in one vectorized pass.
-    hit_distances, denominator, line_cross = _nonparallel_hit_distances(
-        directions,
-        segment_vectors,
-        start_to_origin,
-        max_range,
-    )
+    for chunk_start in range(0, len(seg_start), SEGMENT_CHUNK_SIZE):
+        chunk_end = min(chunk_start + SEGMENT_CHUNK_SIZE, len(seg_start))
+        chunk_segment_start = seg_start[chunk_start:chunk_end]
+        chunk_segment_end = seg_end[chunk_start:chunk_end]
+        segment_vectors = chunk_segment_end - chunk_segment_start
+        start_to_origin = origin - chunk_segment_start
 
-    # 2. Fill in overlapping pairs that the zero denominator cannot solve.
-    segment_index, ray_index, distance = _find_collinear_hits(
-        origin,
-        directions,
-        seg_start,
-        seg_end,
-        denominator,
-        line_cross,
-        max_range,
-    )
-    hit_distances[segment_index, ray_index] = distance
+        # 1. Solve ordinary intersections for this bounded segment block.
+        hit_distances, denominator, line_cross = _nonparallel_hit_distances(
+            directions,
+            segment_vectors,
+            start_to_origin,
+            max_range,
+        )
 
-    # 3. Select the closest segment independently for every beam.
-    return _nearest_hits(hit_distances, max_range)
+        # 2. Fill in overlapping pairs that the zero denominator cannot solve.
+        segment_index, ray_index, distance = _find_collinear_hits(
+            origin,
+            directions,
+            chunk_segment_start,
+            chunk_segment_end,
+            denominator,
+            line_cross,
+            max_range,
+        )
+        hit_distances[segment_index, ray_index] = distance
+
+        # 3. Merge this block's nearest hits into the per-beam result. A strict
+        # comparison preserves np.argmin's original first-segment tie behavior.
+        chunk_ranges, chunk_hit_index = _nearest_hits(hit_distances, max_range)
+        nearer = (chunk_hit_index >= 0) & ((hit_index < 0) | (chunk_ranges < ranges))
+        ranges[nearer] = chunk_ranges[nearer]
+        hit_index[nearer] = chunk_start + chunk_hit_index[nearer]
+
+    return ranges, hit_index
 
 
 def cast_rays(

--- a/irsim/lib/algorithm/ray_casting_2d.py
+++ b/irsim/lib/algorithm/ray_casting_2d.py
@@ -2,8 +2,8 @@
 
 Shared by the lidar sensors (:class:`~irsim.world.sensors.lidar2d.Lidar2D` and
 :class:`~irsim.world.sensors.fmcw_lidar2d.FMCWLidar2D`). The high-level
-:func:`cast_rays` function selects nearby objects, flattens their boundaries,
-and returns the nearest object hit by every beam. The lower-level
+:func:`cast_rays` function flattens already-detected object boundaries and
+returns the nearest object hit by every beam. The lower-level
 :func:`cast_ray_segments` function performs the vectorized numerical kernel.
 
 For a sensor origin in free space, this reproduces a GEOS ``difference`` scan
@@ -12,8 +12,8 @@ hits also remain compatible when the origin is inside an obstacle.
 
 Typical use::
 
-    ranges, hit_objects, origin, directions = cast_rays(
-        lidar_geometry, objects, geometry_tree, sensor_id, range_max
+    ranges, hit_object_indices, origin, directions = cast_rays(
+        lidar_geometry, detected_objects, range_max
     )
 """
 
@@ -217,30 +217,21 @@ def _empty_segments() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
 
 def _gather_obstacle_edges(
     lidar_geometry,
-    objects,
-    geometry_tree,
-    sensor_id: int,
+    detected_objects,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Select nearby objects and flatten their boundaries into line segments.
+    """Flatten detected-object boundaries into line segments.
 
-    ``objects`` and ``geometry_tree`` must use the same ordering because tree
-    query indices are also returned as segment-owner indices. Map objects keep
-    their own spatial query so only map lines touched by the scan are expanded.
+    The caller has already selected detectable scene objects. Map objects keep
+    their internal spatial query here so only map lines touched by the scan are
+    expanded. Owner indices refer to ``detected_objects``.
 
     Returns:
         tuple[np.ndarray, np.ndarray, np.ndarray]: Segment starts, segment ends,
         and the owning object index for every segment, with shapes ``(M, 2)``,
         ``(M, 2)``, and ``(M,)``.
     """
-    if geometry_tree is None:
-        return _empty_segments()
-
     starts, ends, owners = [], [], []
-    for object_index in geometry_tree.query(lidar_geometry):
-        obj = objects[object_index]
-        if obj._id == sensor_id or not obj._geometry_valid or obj.unobstructed:
-            continue
-
+    for object_index, obj in enumerate(detected_objects):
         if obj.shape == "map":
             hits = obj.geometry_tree.query(lidar_geometry, predicate="intersects")
             geometries = [obj.linestrings[index] for index in hits]
@@ -341,37 +332,31 @@ def cast_ray_segments(
 
 def cast_rays(
     lidar_geometry,
-    objects,
-    geometry_tree,
-    sensor_id: int,
+    detected_objects,
     max_range: float,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """Cast a 2D lidar geometry against all relevant simulation objects.
+    """Cast a 2D lidar geometry against already-detected objects.
 
-    This is the sensor-facing ray-casting operation. It owns the complete
-    geometry pipeline: deriving ray parameters, querying nearby objects,
-    gathering their boundary segments, running the numerical kernel, and
-    mapping segment hits back to object indices.
+    This geometry-only operation derives ray parameters, gathers boundary
+    segments from the supplied objects, runs the numerical kernel, and maps
+    segment hits back to indices in ``detected_objects``. Scene lookup remains
+    the sensor's responsibility.
 
     Args:
         lidar_geometry: Max-range beams in world coordinates as a Shapely
             multiline geometry.
-        objects: Simulation objects in the same order as ``geometry_tree``.
-        geometry_tree: STRtree containing the object geometries, or ``None``.
-        sensor_id: Parent object ID; its own geometry is ignored.
+        detected_objects: Objects selected by the sensor's scene query.
         max_range: Maximum ray length; misses return this value.
 
     Returns:
         tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]: Ranges,
-        hit-object indices, origin, and directions.
+        indices into ``detected_objects``, origin, and directions.
     """
     shapely.prepare(lidar_geometry)
     origin, directions = _ray_parameters(lidar_geometry, max_range)
     segment_start, segment_end, segment_owner = _gather_obstacle_edges(
         lidar_geometry,
-        objects,
-        geometry_tree,
-        sensor_id,
+        detected_objects,
     )
     ranges, hit_segments = cast_ray_segments(
         origin,
@@ -381,7 +366,7 @@ def cast_rays(
         max_range,
     )
 
-    hit_objects = np.full(len(directions), -1, dtype=int)
+    hit_object_indices = np.full(len(directions), -1, dtype=int)
     has_hit = hit_segments >= 0
-    hit_objects[has_hit] = segment_owner[hit_segments[has_hit]]
-    return ranges, hit_objects, origin, directions
+    hit_object_indices[has_hit] = segment_owner[hit_segments[has_hit]]
+    return ranges, hit_object_indices, origin, directions

--- a/irsim/world/sensors/fmcw_lidar2d.py
+++ b/irsim/world/sensors/fmcw_lidar2d.py
@@ -92,13 +92,10 @@ class FMCWLidar2D(Lidar2D):
         """
         self._state = state
         lidar_geometry = self._world_geometry(state)
-        env_param = self._env_param
-        objects = env_param.objects
-        ranges, hit_objects, origin, directions = cast_rays(
+        detected_objects = self._get_detected_objects(lidar_geometry)
+        ranges, hit_object_indices, origin, directions = cast_rays(
             lidar_geometry,
-            objects,
-            env_param.GeometryTree,
-            self.obj_id,
+            detected_objects,
             self.range_max,
         )
 
@@ -107,13 +104,19 @@ class FMCWLidar2D(Lidar2D):
         self.radial_velocity[:] = 0.0
         self._resolve_hits(
             ranges,
-            hit_objects,
+            hit_object_indices,
             directions,
-            objects,
+            detected_objects,
         )
         self._rebuild_scan_geometry(origin, directions)
 
-    def _resolve_hits(self, ranges, hit_objects, directions, objects):
+    def _resolve_hits(
+        self,
+        ranges,
+        hit_object_indices,
+        directions,
+        detected_objects,
+    ):
         """Apply range noise, validity, and radial velocity for each hit beam.
 
         Draws range noise then (for in-band beams) velocity noise in beam order,
@@ -121,7 +124,7 @@ class FMCWLidar2D(Lidar2D):
         the old noisy scan bit-for-bit. Ray casting stays vectorized; only this
         cheap arithmetic pass is per-beam, and only over beams that hit.
         """
-        for beam in np.nonzero(hit_objects >= 0)[0]:
+        for beam in np.nonzero(hit_object_indices >= 0)[0]:
             distance = ranges[beam]
             if self.noise:
                 distance += rng.normal(0, self.std)
@@ -131,7 +134,7 @@ class FMCWLidar2D(Lidar2D):
                 self.range_data[beam] = distance
                 self.valid[beam] = True
                 velocity = self._compute_radial_velocity(
-                    objects[hit_objects[beam]], directions[beam]
+                    detected_objects[hit_object_indices[beam]], directions[beam]
                 )
                 if self.velocity_noise_std > 0:
                     velocity += rng.normal(0, self.velocity_noise_std)

--- a/irsim/world/sensors/fmcw_lidar2d.py
+++ b/irsim/world/sensors/fmcw_lidar2d.py
@@ -5,10 +5,9 @@ from math import cos, sin
 import numpy as np
 from matplotlib.colors import to_rgb
 from mpl_toolkits.mplot3d import Axes3D
-from shapely.geometry import LineString, MultiLineString, Point
 
+from irsim.lib.algorithm.ray_casting_2d import cast_rays
 from irsim.util.random import rng
-from irsim.util.util import transform_point_with_state
 from irsim.world.sensors.lidar2d import Lidar2D
 
 
@@ -85,52 +84,58 @@ class FMCWLidar2D(Lidar2D):
         self.valid = np.zeros(self.number, dtype=bool)
 
     def step(self, state):
-        """Update ranges, validity flags, and radial velocities for every beam."""
-        self._state = state
-        self.lidar_origin = transform_point_with_state(self.offset, self._state)
+        """Update ranges, validity flags, and radial velocities for every beam.
 
-        origin_xy = np.array([self.lidar_origin[0, 0], self.lidar_origin[1, 0]])
-        sensor_theta = (
-            float(self.lidar_origin[2, 0]) if self.lidar_origin.shape[0] > 2 else 0.0
+        Beams are cast against obstacle boundary segments in one vectorized pass
+        (:func:`irsim.lib.algorithm.ray_casting_2d.cast_rays`), then each valid
+        beam's hit object supplies the Doppler (radial) velocity.
+        """
+        self._state = state
+        lidar_geometry = self._world_geometry(state)
+        env_param = self._env_param
+        objects = env_param.objects
+        ranges, hit_objects, origin, directions = cast_rays(
+            lidar_geometry,
+            objects,
+            env_param.GeometryTree,
+            self.obj_id,
+            self.range_max,
         )
 
         self.range_data[:] = self.range_max
-        self.radial_velocity[:] = 0.0
         self.valid[:] = False
+        self.radial_velocity[:] = 0.0
+        self._resolve_hits(
+            ranges,
+            hit_objects,
+            directions,
+            objects,
+        )
+        self._rebuild_scan_geometry(origin, directions)
 
-        segments = []
-        for index, beam_angle in enumerate(self.angle_list):
-            # Cast each beam independently so the sensor can keep the closest hit
-            # object and project that object's motion onto the beam direction.
-            world_angle = sensor_theta + beam_angle
-            direction = np.array([cos(world_angle), sin(world_angle)])
-            ray_end = origin_xy + self.range_max * direction
-            ray = LineString([tuple(origin_xy), tuple(ray_end)])
+    def _resolve_hits(self, ranges, hit_objects, directions, objects):
+        """Apply range noise, validity, and radial velocity for each hit beam.
 
-            hit_distance, hit_object = self._find_nearest_hit(ray, origin_xy)
-            if hit_distance is not None:
-                if self.noise:
-                    hit_distance += rng.normal(0, self.std)
-
-                # Treat noise-induced out-of-range measurements as invalid so
-                # ``valid`` stays consistent with ``range_data`` and downstream
-                # consumers (e.g. ``get_points``) cannot silently drop a beam
-                # that is still flagged as a hit.
-                if self.range_min <= hit_distance <= self.range_max:
-                    self.range_data[index] = hit_distance
-                    self.valid[index] = True
-
-                    radial_velocity = self._compute_radial_velocity(
-                        hit_object, direction
-                    )
-                    if self.velocity_noise_std > 0:
-                        radial_velocity += rng.normal(0, self.velocity_noise_std)
-                    self.radial_velocity[index] = radial_velocity
-
-            segment_end = origin_xy + self.range_data[index] * direction
-            segments.append([tuple(origin_xy), tuple(segment_end)])
-
-        self._geometry = MultiLineString(segments)
+        Draws range noise then (for in-band beams) velocity noise in beam order,
+        matching the previous per-beam implementation so a seeded run reproduces
+        the old noisy scan bit-for-bit. Ray casting stays vectorized; only this
+        cheap arithmetic pass is per-beam, and only over beams that hit.
+        """
+        for beam in np.nonzero(hit_objects >= 0)[0]:
+            distance = ranges[beam]
+            if self.noise:
+                distance += rng.normal(0, self.std)
+            # A hit counts only if its (possibly noisy) range stays in band, so
+            # range_data/valid stay consistent for get_points.
+            if self.range_min <= distance <= self.range_max:
+                self.range_data[beam] = distance
+                self.valid[beam] = True
+                velocity = self._compute_radial_velocity(
+                    objects[hit_objects[beam]], directions[beam]
+                )
+                if self.velocity_noise_std > 0:
+                    velocity += rng.normal(0, self.velocity_noise_std)
+                self.radial_velocity[beam] = velocity
 
     def _plot(self, ax, state, **kwargs):
         """Plot beams, then color them from radial velocity for visualization."""
@@ -143,92 +148,6 @@ class FMCWLidar2D(Lidar2D):
         super()._step_plot()
         self._apply_velocity_visuals()
         self._update_velocity_markers()
-
-    def _find_nearest_hit(self, ray: LineString, origin_xy: np.ndarray):
-        """Return the nearest intersected object and hit distance for one beam."""
-        object_tree = self._env_param.GeometryTree
-        objects = self._env_param.objects
-
-        if object_tree is None:
-            return None, None
-
-        origin_point = Point(*origin_xy)
-        best_distance = None
-        best_object = None
-
-        for geom_index in object_tree.query(ray):
-            obj = objects[geom_index]
-            if obj._id == self.obj_id or not obj._geometry_valid or obj.unobstructed:
-                continue
-
-            geometry = self._get_candidate_geometry(obj, ray)
-            if geometry is None:
-                continue
-
-            distance = self._nearest_intersection_distance(ray, geometry, origin_point)
-            if distance is None:
-                continue
-
-            if best_distance is None or distance < best_distance:
-                best_distance = distance
-                best_object = obj
-
-        return best_distance, best_object
-
-    def _get_candidate_geometry(self, obj, ray: LineString):
-        """Return the geometry subset that should be tested against a beam ray."""
-        if obj.shape == "map":
-            intersecting_indices = obj.geometry_tree.query(ray, predicate="intersects")
-            if len(intersecting_indices) == 0:
-                return None
-            return MultiLineString([obj.linestrings[i] for i in intersecting_indices])
-
-        if not ray.intersects(obj.geometry):
-            return None
-        return obj.geometry
-
-    def _nearest_intersection_distance(
-        self,
-        ray: LineString,
-        geometry,
-        origin_point: Point,
-    ) -> float | None:
-        """Return the closest intersection distance along a beam ray."""
-        intersection = ray.intersection(geometry)
-
-        best_distance = None
-        for point in self._iter_intersection_points(intersection):
-            distance = origin_point.distance(point)
-            if distance <= 1e-9 or distance > self.range_max + 1e-9:
-                continue
-            if best_distance is None or distance < best_distance:
-                best_distance = distance
-
-        return best_distance
-
-    def _iter_intersection_points(self, geometry):
-        """Yield representative points from a Shapely intersection result."""
-        if geometry.is_empty:
-            return
-
-        geom_type = geometry.geom_type
-        if geom_type == "Point":
-            yield geometry
-            return
-        if geom_type == "MultiPoint":
-            yield from geometry.geoms
-            return
-        if geom_type in {"LineString", "LinearRing"}:
-            for coord in geometry.coords:
-                yield Point(coord)
-            return
-        if geom_type == "MultiLineString":
-            for part in geometry.geoms:
-                yield from self._iter_intersection_points(part)
-            return
-        if geom_type == "GeometryCollection":
-            for part in geometry.geoms:
-                yield from self._iter_intersection_points(part)
 
     def _compute_radial_velocity(self, obj, direction: np.ndarray) -> float:
         """Project the target motion onto the beam direction."""

--- a/irsim/world/sensors/lidar2d.py
+++ b/irsim/world/sensors/lidar2d.py
@@ -7,8 +7,9 @@ import shapely
 from matplotlib.collections import LineCollection
 from mpl_toolkits.mplot3d import Axes3D
 from mpl_toolkits.mplot3d.art3d import Line3DCollection
-from shapely import MultiLineString, prepare
+from shapely import MultiLineString
 
+from irsim.lib.algorithm.ray_casting_2d import cast_rays
 from irsim.util.random import rng
 from irsim.util.util import (
     WrapTo2Pi,
@@ -146,35 +147,6 @@ class Lidar2D:
 
         return env_param
 
-    def _ensure_multi_linestring(self, geometry):
-        """
-        Ensure geometry is a MultiLineString, converting if necessary.
-
-        Args:
-            geometry: Shapely geometry object.
-
-        Returns:
-            MultiLineString: Geometry as MultiLineString.
-        """
-        if geometry.geom_type == "LineString":
-            return MultiLineString([geometry])
-        if geometry.geom_type == "MultiLineString":
-            return geometry
-        if geometry.is_empty:
-            return MultiLineString()
-        if geometry.geom_type == "GeometryCollection":
-            # Extract LineString components (and any lines from nested MultiLineStrings)
-            linestrings = []
-            for g in geometry.geoms:
-                if g.geom_type == "LineString":
-                    linestrings.append(g)
-                elif g.geom_type == "MultiLineString":
-                    linestrings.extend(list(g.geoms))
-            return MultiLineString(linestrings) if linestrings else MultiLineString()
-
-        # For unsupported geometry types (e.g., Point, Polygon), return an empty MultiLineString
-        return MultiLineString()
-
     def init_geometry(self, state):
         """
         Initialize the Lidar's scanning geometry.
@@ -203,139 +175,72 @@ class Lidar2D:
         self._geometry = geometry_transform(self._original_geometry, state)
         self._init_geometry = self._geometry
 
-    def step(self, state):
+    def step(self, state: np.ndarray) -> None:
         """
-        Update the Lidar's state and process intersections with environment objects.
+        Update the Lidar's state and compute per-beam ranges via ray casting.
+
+        Each beam is intersected analytically against the boundary segments of
+        nearby obstacles (polygons, linestrings, and map segments); the nearest
+        hit along the beam is its range. This reproduces the previous geometry
+        ``difference`` result to floating-point precision when the sensor origin
+        is in free space, while avoiding the expensive GEOS overlay.
 
         Args:
             state (np.ndarray): New state of the sensor.
         """
         self._state = state
 
-        self.lidar_origin = transform_point_with_state(self.offset, self._state)
-        new_geometry = geometry_transform(self._original_geometry, self._state)
-        prepare(new_geometry)
+        lidar_geometry = self._world_geometry(state)
+        env_param = self._env_param
+        objects = env_param.objects
+        ranges, hit_objects, origin, directions = cast_rays(
+            lidar_geometry,
+            objects,
+            env_param.GeometryTree,
+            self.obj_id,
+            self.range_max,
+        )
 
-        new_geometry, intersect_indices = self.laser_geometry_process(new_geometry)
-
-        if len(intersect_indices) == 0:
-            self._geometry = self._ensure_multi_linestring(new_geometry)
-            self.calculate_range()
-        else:
-            origin_pt = shapely.points(self.lidar_origin[0, 0], self.lidar_origin[1, 0])
-            parts = shapely.get_parts(new_geometry)
-            self._geometry = MultiLineString(
-                list(parts[shapely.intersects(parts, origin_pt)])
-            )
-            self.calculate_range_vel(intersect_indices)
-
-    def laser_geometry_process(self, lidar_geometry):
-        """
-        Find the intersected objects and return the intersected indices with the lidar geometry
-
-        Args:
-            lidar_geometry (shapely.geometry.MultiLineString): The geometry of the lidar.
-
-        Returns:
-            list: The indices of the intersected objects.
-        """
-
-        object_tree = self._env_param.GeometryTree
-        objects = self._env_param.objects
-        geometries = [obj._geometry for obj in objects]
-
-        # Guard against missing geometry index
-        if object_tree is None:
-            return lidar_geometry, []
-
-        potential_geometries_index = object_tree.query(lidar_geometry)
-
-        geometries_to_subtract = []
-        intersect_indices = []
-
-        for geom_index in potential_geometries_index:
-            geo = geometries[geom_index]
-            obj = objects[geom_index]
-
-            if obj._id == self.obj_id or not obj._geometry_valid or obj.unobstructed:
-                continue
-
-            if obj.shape == "map":
-                intersecting_indices = obj.geometry_tree.query(
-                    lidar_geometry, predicate="intersects"
-                )
-                if len(intersecting_indices) > 0:
-                    filtered_lines = [obj.linestrings[i] for i in intersecting_indices]
-                    geometries_to_subtract.extend(filtered_lines)
-                    intersect_indices.append(geom_index)
-
-            else:
-                if lidar_geometry.intersects(geo):
-                    geometries_to_subtract.append(geo)
-                    intersect_indices.append(geom_index)
-
-        if geometries_to_subtract:
-            # Subtract linestrings (e.g. the static map) and polygons (e.g. moving
-            # obstacles) as separate, merged groups. Putting both kinds into one
-            # GeometryCollection makes GEOS's difference 2-3x slower, so adding a
-            # single dynamic obstacle on top of a map stalls the lidar (issue #302).
-            polygons = []
-            lines = []
-            for g in geometries_to_subtract:
-                bucket = (
-                    polygons if g.geom_type in ("Polygon", "MultiPolygon") else lines
-                )
-                bucket.append(g)
-            for group in (lines, polygons):
-                if group:
-                    obstacle = group[0] if len(group) == 1 else shapely.union_all(group)
-                    lidar_geometry = lidar_geometry.difference(obstacle)
-            lidar_geometry = self._ensure_multi_linestring(lidar_geometry)
-
-        return lidar_geometry, intersect_indices
-
-    def calculate_range(self):
-        """
-        Calculate the range data from the current geometry.
-        """
-        # Reset all beams to the default maximum range to avoid stale values
-        self.range_data[:] = self.range_max
-
-        parts = shapely.get_parts(self._geometry)
-        lengths = shapely.length(parts)
         if self.noise:
-            self.range_data[: len(lengths)] = lengths + rng.normal(
-                0, self.std, len(lengths)
-            )
+            self.range_data[:] = ranges + rng.normal(0, self.std, self.number)
         else:
-            self.range_data[: len(lengths)] = lengths
+            self.range_data[:] = ranges
 
-    def calculate_range_vel(self, intersect_index):
-        """
-        Calculate the range data and velocities from intersected geometries.
-
-        Args:
-            intersect_index (list): List of intersected object indices.
-        """
-        parts = shapely.get_parts(self._geometry)
-        lengths = shapely.length(parts)
-        if self.noise:
-            self.range_data[: len(lengths)] = lengths + rng.normal(
-                0, self.std, len(lengths)
-            )
-        else:
-            self.range_data[: len(lengths)] = lengths
+        self._rebuild_scan_geometry(origin, directions)
 
         if self.has_velocity:
-            # Reset all beam velocities to avoid carrying over stale values
-            self.velocity[:] = 0.0
-            for index, (line, length) in enumerate(zip(parts, lengths, strict=True)):
-                if length < self.range_max - 0.02:
-                    for index_obj in intersect_index:
-                        obj = self._env_param.objects[index_obj]
-                        if obj.geometry.distance(line) < 0.1:
-                            self.velocity[:, index : index + 1] = obj.velocity_xy
-                            break
+            self._assign_velocities(hit_objects, objects)
+
+    def _world_geometry(self, state: np.ndarray) -> MultiLineString:
+        """Build the max-range beam geometry in world coordinates."""
+        self.lidar_origin = transform_point_with_state(self.offset, state)
+        return geometry_transform(self._original_geometry, state)
+
+    def _rebuild_scan_geometry(
+        self, origin: np.ndarray, directions: np.ndarray
+    ) -> None:
+        """Rebuild each clipped beam from its origin and measured range."""
+        endpoints = origin + self.range_data[:, None] * directions
+        origins = np.broadcast_to(origin, endpoints.shape)
+        beam_coordinates = np.stack([origins, endpoints], axis=1)
+        self._geometry = shapely.multilinestrings(
+            shapely.linestrings(beam_coordinates),
+        )
+
+    def _assign_velocities(
+        self,
+        hit_objects: np.ndarray,
+        objects,
+    ) -> None:
+        """Assign velocity when ray casting reports an actual object hit.
+
+        ``hit_objects`` distinguishes a hit from a max-range miss directly, so
+        no range margin is needed near ``range_max``.
+        """
+        self.velocity[:] = 0.0
+        for beam_index in np.flatnonzero(hit_objects >= 0):
+            object_velocity = objects[hit_objects[beam_index]].velocity_xy
+            self.velocity[:, beam_index : beam_index + 1] = object_velocity
 
     def get_scan(self):
         """

--- a/irsim/world/sensors/lidar2d.py
+++ b/irsim/world/sensors/lidar2d.py
@@ -191,13 +191,11 @@ class Lidar2D:
         self._state = state
 
         lidar_geometry = self._world_geometry(state)
-        env_param = self._env_param
-        objects = env_param.objects
-        ranges, hit_objects, origin, directions = cast_rays(
+        detected_objects = self._get_detected_objects(lidar_geometry)
+
+        ranges, hit_object_indices, origin, directions = cast_rays(
             lidar_geometry,
-            objects,
-            env_param.GeometryTree,
-            self.obj_id,
+            detected_objects,
             self.range_max,
         )
 
@@ -209,7 +207,28 @@ class Lidar2D:
         self._rebuild_scan_geometry(origin, directions)
 
         if self.has_velocity:
-            self._assign_velocities(hit_objects, objects)
+            self._assign_velocities(hit_object_indices, detected_objects)
+
+    def _get_detected_objects(self, lidar_geometry) -> list:
+        """Select objects that may produce a return for this lidar geometry.
+
+        This is the environment-facing broad-phase operation. It owns access to
+        the scene's complete object list and geometry tree, and filters objects
+        that sensors must ignore. Exact boundary intersections remain in the
+        geometry-only ray-casting operation.
+        """
+        objects = self._env_param.objects
+        geometry_tree = self._env_param.GeometryTree
+        if geometry_tree is None:
+            return []
+
+        detected_objects = []
+        for object_index in geometry_tree.query(lidar_geometry):
+            obj = objects[object_index]
+            if obj._id == self.obj_id or not obj._geometry_valid or obj.unobstructed:
+                continue
+            detected_objects.append(obj)
+        return detected_objects
 
     def _world_geometry(self, state: np.ndarray) -> MultiLineString:
         """Build the max-range beam geometry in world coordinates."""
@@ -234,17 +253,20 @@ class Lidar2D:
 
     def _assign_velocities(
         self,
-        hit_objects: np.ndarray,
-        objects,
+        hit_object_indices: np.ndarray,
+        detected_objects,
     ) -> None:
         """Assign velocity when ray casting reports an actual object hit.
 
-        ``hit_objects`` distinguishes a hit from a max-range miss directly, so
-        no range margin is needed near ``range_max``.
+        ``hit_object_indices`` refers to ``detected_objects`` and distinguishes
+        a hit from a max-range miss, so no range margin is needed near
+        ``range_max``.
         """
         self.velocity[:] = 0.0
-        for beam_index in np.flatnonzero(hit_objects >= 0):
-            object_velocity = objects[hit_objects[beam_index]].velocity_xy
+        for beam_index in np.flatnonzero(hit_object_indices >= 0):
+            object_velocity = detected_objects[
+                hit_object_indices[beam_index]
+            ].velocity_xy
             self.velocity[:, beam_index : beam_index + 1] = object_velocity
 
     def get_scan(self):

--- a/irsim/world/sensors/lidar2d.py
+++ b/irsim/world/sensors/lidar2d.py
@@ -213,8 +213,13 @@ class Lidar2D:
 
     def _world_geometry(self, state: np.ndarray) -> MultiLineString:
         """Build the max-range beam geometry in world coordinates."""
+        world_geometry = geometry_transform(self._original_geometry, state)
         self.lidar_origin = transform_point_with_state(self.offset, state)
-        return geometry_transform(self._original_geometry, state)
+        # Use the beam geometry's exact start coordinate. Computing the same
+        # point through a separate transform can differ by one floating-point
+        # step across platforms, which breaks exact GEOS origin predicates.
+        self.lidar_origin[:2, 0] = shapely.get_coordinates(world_geometry)[0]
+        return world_geometry
 
     def _rebuild_scan_geometry(
         self, origin: np.ndarray, directions: np.ndarray

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -4,6 +4,7 @@ import pytest
 import shapely
 from shapely import STRtree
 
+import irsim.lib.algorithm.ray_casting_2d as ray_casting_2d
 from irsim.lib.algorithm.ray_casting_2d import cast_ray_segments
 from irsim.lib.handler.geometry_handler import GeometryFactory
 from irsim.util.random import rng, set_seed
@@ -1089,6 +1090,54 @@ def test_cast_ray_segments_detects_collinear_segment():
 
     np.testing.assert_allclose(ranges, [2.0], atol=1e-12)
     np.testing.assert_array_equal(hit, [0])
+
+
+def test_cast_ray_segments_chunks_large_segment_sets(monkeypatch):
+    """Chunking bounds each matrix and preserves ranges and global hit indices."""
+    random = np.random.default_rng(20260817)
+    angles = np.linspace(-np.pi, np.pi, 181)
+    directions = np.column_stack((np.cos(angles), np.sin(angles)))
+    segment_start = random.uniform(-8.0, 8.0, size=(5000, 2))
+    segment_end = segment_start + random.uniform(-0.5, 0.5, size=(5000, 2))
+
+    monkeypatch.setattr(ray_casting_2d, "SEGMENT_CHUNK_SIZE", len(segment_start))
+    expected_ranges, expected_hits = cast_ray_segments(
+        np.zeros(2), directions, segment_start, segment_end, 10.0
+    )
+
+    block_sizes = []
+    original = ray_casting_2d._nonparallel_hit_distances
+
+    def track_block_size(directions, segment_vectors, start_to_origin, max_range):
+        block_sizes.append(len(segment_vectors))
+        return original(directions, segment_vectors, start_to_origin, max_range)
+
+    monkeypatch.setattr(ray_casting_2d, "SEGMENT_CHUNK_SIZE", 64)
+    monkeypatch.setattr(
+        ray_casting_2d,
+        "_nonparallel_hit_distances",
+        track_block_size,
+    )
+    ranges, hits = cast_ray_segments(
+        np.zeros(2), directions, segment_start, segment_end, 10.0
+    )
+
+    assert len(block_sizes) > 1
+    assert max(block_sizes) <= 64
+    np.testing.assert_array_equal(ranges, expected_ranges)
+    np.testing.assert_array_equal(hits, expected_hits)
+
+    # Two equal nearest walls straddle a chunk boundary. The original full
+    # argmin keeps the lower global segment index, and chunk merging must too.
+    tie_start = np.tile([4.0, -1.0], (65, 1))
+    tie_end = np.tile([4.0, 1.0], (65, 1))
+    tie_start[63:] = [1.0, -1.0]
+    tie_end[63:] = [1.0, 1.0]
+    tie_ranges, tie_hits = cast_ray_segments(
+        np.zeros(2), np.array([[1.0, 0.0]]), tie_start, tie_end, 10.0
+    )
+    np.testing.assert_array_equal(tie_ranges, [1.0])
+    np.testing.assert_array_equal(tie_hits, [63])
 
 
 def test_lidar_collinear_wall_matches_geos_difference():

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -5,7 +5,7 @@ import shapely
 from shapely import STRtree
 
 import irsim.lib.algorithm.ray_casting_2d as ray_casting_2d
-from irsim.lib.algorithm.ray_casting_2d import cast_ray_segments
+from irsim.lib.algorithm.ray_casting_2d import cast_ray_segments, cast_rays
 from irsim.lib.handler.geometry_handler import GeometryFactory
 from irsim.util.random import rng, set_seed
 from irsim.world.object_factory import ObjectFactory
@@ -1076,6 +1076,33 @@ def test_lidar_origin_uses_exact_world_geometry_coordinate(monkeypatch):
     geometry_origin = shapely.get_coordinates(world_geometry)[0]
 
     np.testing.assert_array_equal(lidar.lidar_origin[:2, 0], geometry_origin)
+
+
+def test_cast_rays_only_requires_detected_objects():
+    """The geometry algorithm does not require the environment or its STRtree."""
+    lidar = Lidar2D(
+        state=np.array([[0.0], [0.0], [0.0]]),
+        obj_id=1,
+        number=1,
+        angle_range=0.0,
+        range_max=5.0,
+    )
+    detected_object = _Obstacle(
+        2,
+        shapely.LineString([(2.0, -1.0), (2.0, 1.0)]),
+        shape="linestring",
+    )
+
+    ranges, hit_object_indices, origin, directions = cast_rays(
+        lidar._world_geometry(lidar.state),
+        [detected_object],
+        lidar.range_max,
+    )
+
+    np.testing.assert_allclose(ranges, [2.0], atol=1e-12)
+    np.testing.assert_array_equal(hit_object_indices, [0])
+    np.testing.assert_array_equal(origin, [0.0, 0.0])
+    np.testing.assert_array_equal(directions, [[1.0, 0.0]])
 
 
 def test_cast_ray_segments_detects_collinear_segment():

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -4,8 +4,9 @@ import pytest
 import shapely
 from shapely import STRtree
 
+from irsim.lib.algorithm.ray_casting_2d import cast_ray_segments
 from irsim.lib.handler.geometry_handler import GeometryFactory
-from irsim.util.random import set_seed
+from irsim.util.random import rng, set_seed
 from irsim.world.object_factory import ObjectFactory
 from irsim.world.sensors.fmcw_lidar2d import FMCWLidar2D
 from irsim.world.sensors.lidar2d import Lidar2D
@@ -79,6 +80,83 @@ class _DummyMapObject:
     @property
     def velocity_xy(self):
         return self._velocity_xy
+
+
+def _legacy_intersection_points(geometry):
+    """Yield the representative points used by the previous FMCW scanner."""
+    if geometry.is_empty:
+        return
+    if geometry.geom_type == "Point":
+        yield geometry
+    elif geometry.geom_type == "MultiPoint":
+        yield from geometry.geoms
+    elif geometry.geom_type in {"LineString", "LinearRing"}:
+        for coordinate in geometry.coords:
+            yield shapely.Point(coordinate)
+    elif geometry.geom_type in {"MultiLineString", "GeometryCollection"}:
+        for part in geometry.geoms:
+            yield from _legacy_intersection_points(part)
+
+
+def _legacy_fmcw_scan(sensor):
+    """Run the pre-vectorization per-beam FMCW measurement algorithm."""
+    origin = np.array([sensor.lidar_origin[0, 0], sensor.lidar_origin[1, 0]])
+    origin_point = shapely.Point(*origin)
+    sensor_theta = float(sensor.lidar_origin[2, 0])
+    objects = sensor._env_param.objects
+    tree = sensor._env_param.GeometryTree
+
+    ranges = np.full(sensor.number, sensor.range_max, dtype=float)
+    velocities = np.zeros(sensor.number)
+    valid = np.zeros(sensor.number, dtype=bool)
+    if tree is None:
+        return ranges, velocities, valid
+
+    for beam, beam_angle in enumerate(sensor.angle_list):
+        world_angle = sensor_theta + beam_angle
+        direction = np.array([np.cos(world_angle), np.sin(world_angle)])
+        ray = shapely.LineString([origin, origin + sensor.range_max * direction])
+        best_distance = None
+        best_object = None
+
+        for geom_index in tree.query(ray):
+            obj = objects[geom_index]
+            if obj._id == sensor.obj_id or not obj._geometry_valid or obj.unobstructed:
+                continue
+            if obj.shape == "map":
+                indices = obj.geometry_tree.query(ray, predicate="intersects")
+                if len(indices) == 0:
+                    continue
+                geometry = shapely.MultiLineString(
+                    [obj.linestrings[index] for index in indices]
+                )
+            else:
+                if not ray.intersects(obj.geometry):
+                    continue
+                geometry = obj.geometry
+
+            intersection = ray.intersection(geometry)
+            for point in _legacy_intersection_points(intersection):
+                distance = origin_point.distance(point)
+                if distance <= 1e-9 or distance > sensor.range_max + 1e-9:
+                    continue
+                if best_distance is None or distance < best_distance:
+                    best_distance = distance
+                    best_object = obj
+
+        if best_distance is None:
+            continue
+        if sensor.noise:
+            best_distance += rng.normal(0, sensor.std)
+        if sensor.range_min <= best_distance <= sensor.range_max:
+            ranges[beam] = best_distance
+            valid[beam] = True
+            velocity = sensor._compute_radial_velocity(best_object, direction)
+            if sensor.velocity_noise_std > 0:
+                velocity += rng.normal(0, sensor.velocity_noise_std)
+            velocities[beam] = velocity
+
+    return ranges, velocities, valid
 
 
 class TestFMCWLidar2D:
@@ -406,8 +484,8 @@ class TestFMCWLidar2D:
 
         assert invalidated_at_max > 0  # the failure mode is actually exercised
 
-    def test_find_nearest_hit_skips_invalid_candidates(self):
-        """``_find_nearest_hit`` must skip self, invalid, and unobstructed objects."""
+    def test_step_skips_invalid_candidates(self):
+        """A scan must skip self, invalid, and unobstructed objects."""
         circle = shapely.Point(2.0, 0.0).buffer(0.2)
         self_obj = _DummyObstacleObject(obj_id=1, geometry=circle)
         invalid_obj = _DummyObstacleObject(
@@ -490,42 +568,6 @@ class TestFMCWLidar2D:
         assert not sensor.valid[0]
         assert sensor.range_data[0] == pytest.approx(5.0, abs=1e-6)
 
-    def test_iter_intersection_points_handles_geometry_types(self):
-        """Helper should yield points for every Shapely geometry kind it knows."""
-        sensor = FMCWLidar2D(
-            state=np.array([[0.0], [0.0], [0.0]]),
-            obj_id=1,
-            number=1,
-            angle_range=0.0,
-            range_max=5.0,
-        )
-
-        empty = list(sensor._iter_intersection_points(shapely.Point()))
-        assert empty == []
-
-        single = list(sensor._iter_intersection_points(shapely.Point(1.0, 2.0)))
-        assert len(single) == 1
-        assert single[0].geom_type == "Point"
-
-        multipoint = shapely.MultiPoint([(0.0, 0.0), (1.0, 1.0)])
-        assert len(list(sensor._iter_intersection_points(multipoint))) == 2
-
-        line = shapely.LineString([(0.0, 0.0), (1.0, 0.0)])
-        assert len(list(sensor._iter_intersection_points(line))) == 2
-
-        ring = shapely.LinearRing([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)])
-        assert len(list(sensor._iter_intersection_points(ring))) == 4
-
-        multiline = shapely.MultiLineString(
-            [[(0.0, 0.0), (1.0, 0.0)], [(2.0, 0.0), (3.0, 0.0)]]
-        )
-        assert len(list(sensor._iter_intersection_points(multiline))) == 4
-
-        collection = shapely.GeometryCollection(
-            [shapely.Point(0.0, 0.0), shapely.Point(1.0, 1.0)]
-        )
-        assert len(list(sensor._iter_intersection_points(collection))) == 2
-
     def test_sensor_velocity_xy_falls_back_when_parent_missing(self):
         """``_sensor_velocity_xy`` should default to zeros without a parent."""
         sensor = FMCWLidar2D(
@@ -602,6 +644,226 @@ class TestFMCWLidar2D:
         assert not hasattr(sensor, "laser_LineCollection")
         assert not hasattr(sensor, "velocity_marker_plot")
 
+    def test_noise_is_seeded_reproducible(self):
+        """Seeded range + velocity noise must reproduce run-to-run.
+
+        The per-beam draw order (range noise, then velocity noise) is what keeps
+        a seeded FMCW scan reproducible; batching the draws would silently change
+        the noise sequence. Regression lock for that draw order.
+        """
+        from irsim.util.random import set_seed
+
+        obstacle = _DummyObstacleObject(
+            obj_id=2,
+            geometry=shapely.Point(2.0, 0.0).buffer(0.6),
+            velocity_xy=(1.0, -0.5),
+        )
+        env = _DummySensorEnvParam([obstacle], STRtree([obstacle.geometry]))
+
+        def run(noise):
+            set_seed(5)
+            sensor = FMCWLidar2D(
+                state=np.array([[0.0], [0.0], [0.0]]),
+                obj_id=1,
+                number=64,
+                angle_range=6.283185,
+                range_max=5.0,
+                noise=noise,
+                std=0.1,
+                velocity_noise_std=0.2,
+            )
+            sensor.parent = _DummySensorParent([0.3, 0.0], env)
+            sensor.step(sensor.state)
+            return sensor
+
+        a = run(True)
+        b = run(True)
+        np.testing.assert_array_equal(a.range_data, b.range_data)
+        np.testing.assert_array_equal(a.radial_velocity, b.radial_velocity)
+        np.testing.assert_array_equal(a.valid, b.valid)
+
+        # Noise actually perturbed the hits vs the clean scan.
+        clean = run(False)
+        hit = a.valid
+        assert hit.any()
+        assert np.any(a.range_data[hit] != clean.range_data[hit])
+
+    def test_scan_matches_legacy_fmcw_with_noise_map_and_motion(self):
+        """All FMCW measurement fields match the previous per-beam scanner."""
+        wall = shapely.LineString([(-2.0, -2.0), (-2.0, 2.0)])
+        map_obj = _DummyMapObject(obj_id=2, linestrings=[wall])
+        moving = _DummyObstacleObject(
+            obj_id=3,
+            geometry=shapely.Point(2.0, 0.0).buffer(0.6),
+            velocity_xy=(1.0, -0.5),
+        )
+        objects = [map_obj, moving]
+        env = _DummySensorEnvParam(objects, STRtree([obj.geometry for obj in objects]))
+        sensor = FMCWLidar2D(
+            state=np.array([[0.0], [0.0], [0.2]]),
+            obj_id=1,
+            number=64,
+            angle_range=6.283185,
+            range_min=0.1,
+            range_max=5.0,
+            offset=[0.2, -0.1, 0.15],
+            noise=True,
+            std=0.05,
+            velocity_noise_std=0.02,
+        )
+        sensor.parent = _DummySensorParent([0.3, 0.1], env)
+
+        set_seed(123)
+        expected_ranges, expected_velocity, expected_valid = _legacy_fmcw_scan(sensor)
+        set_seed(123)
+        sensor.step(sensor.state)
+        scan = sensor.get_scan()
+
+        np.testing.assert_array_equal(scan["valid"], expected_valid)
+        np.testing.assert_allclose(scan["ranges"], expected_ranges, atol=1e-12, rtol=0)
+        np.testing.assert_allclose(
+            scan["radial_velocity"], expected_velocity, atol=1e-12, rtol=0
+        )
+        assert tuple(scan) == (
+            "angle_min",
+            "angle_max",
+            "angle_increment",
+            "time_increment",
+            "scan_time",
+            "range_min",
+            "range_max",
+            "ranges",
+            "intensities",
+            "radial_velocity",
+            "valid",
+        )
+        assert scan["intensities"] is None
+
+    def test_collinear_wall_matches_legacy_fmcw(self):
+        """A beam aligned with a wall must hit its nearest overlapping endpoint."""
+        wall = shapely.LineString([(2.0, 0.0), (4.0, 0.0)])
+        obstacle = _DummyObstacleObject(
+            obj_id=2,
+            geometry=wall,
+            velocity_xy=(0.5, 0.0),
+            shape="linestring",
+        )
+        env = _DummySensorEnvParam([obstacle], STRtree([wall]))
+        sensor = FMCWLidar2D(
+            state=np.array([[0.0], [0.0], [0.0]]),
+            obj_id=1,
+            number=1,
+            angle_range=0.0,
+            range_max=5.0,
+        )
+        sensor.parent = _DummySensorParent([0.0, 0.0], env)
+
+        expected_ranges, expected_velocity, expected_valid = _legacy_fmcw_scan(sensor)
+        sensor.step(sensor.state)
+
+        np.testing.assert_array_equal(sensor.valid, expected_valid)
+        np.testing.assert_allclose(sensor.range_data, expected_ranges, atol=1e-12)
+        np.testing.assert_allclose(
+            sensor.radial_velocity, expected_velocity, atol=1e-12
+        )
+        assert sensor.range_data[0] == pytest.approx(2.0)
+
+    def test_scan_matches_legacy_fmcw_in_randomized_free_space(self):
+        """Random poses, offsets, shapes, motion, and noise match legacy GEOS."""
+        random = np.random.default_rng(20260817)
+
+        for scene in range(20):
+            state = np.array(
+                [
+                    [random.uniform(-2.0, 2.0)],
+                    [random.uniform(-2.0, 2.0)],
+                    [random.uniform(-np.pi, np.pi)],
+                ]
+            )
+            offset = [
+                random.uniform(-0.3, 0.3),
+                random.uniform(-0.3, 0.3),
+                random.uniform(-0.4, 0.4),
+            ]
+            number = int(random.choice([1, 31, 64, 181]))
+            angle_range = (
+                0.0 if number == 1 else float(random.choice([0.7, 3.14, 6.283185]))
+            )
+            sensor = FMCWLidar2D(
+                state=state,
+                obj_id=1,
+                number=number,
+                angle_range=angle_range,
+                range_min=0.05,
+                range_max=8.0,
+                offset=offset,
+                noise=scene % 2 == 0,
+                std=0.03,
+                velocity_noise_std=0.02,
+            )
+
+            origin = sensor.lidar_origin[:2, 0]
+            objects = []
+            for object_id in range(2, 10):
+                bearing = random.uniform(-np.pi, np.pi)
+                center = origin + random.uniform(1.2, 6.5) * np.array(
+                    [np.cos(bearing), np.sin(bearing)]
+                )
+                velocity = random.uniform(-0.8, 0.8, size=2)
+                if object_id % 2:
+                    geometry = shapely.Point(center).buffer(
+                        random.uniform(0.1, 0.55), quad_segs=8
+                    )
+                    shape = "circle"
+                else:
+                    tangent = np.array([-np.sin(bearing), np.cos(bearing)])
+                    half_length = random.uniform(0.15, 0.8)
+                    geometry = shapely.LineString(
+                        [center - half_length * tangent, center + half_length * tangent]
+                    )
+                    shape = "linestring"
+                objects.append(
+                    _DummyObstacleObject(
+                        object_id,
+                        geometry,
+                        velocity_xy=velocity,
+                        shape=shape,
+                    )
+                )
+
+            env = _DummySensorEnvParam(
+                objects,
+                STRtree([obj.geometry for obj in objects]),
+            )
+            sensor.parent = _DummySensorParent(random.uniform(-0.5, 0.5, size=2), env)
+
+            set_seed(1000 + scene)
+            expected_ranges, expected_velocity, expected_valid = _legacy_fmcw_scan(
+                sensor
+            )
+            set_seed(1000 + scene)
+            sensor.step(sensor.state)
+
+            np.testing.assert_array_equal(sensor.valid, expected_valid)
+            np.testing.assert_allclose(
+                sensor.range_data,
+                expected_ranges,
+                atol=1e-11,
+                rtol=0,
+            )
+            np.testing.assert_allclose(
+                sensor.radial_velocity,
+                expected_velocity,
+                atol=1e-12,
+                rtol=0,
+            )
+            np.testing.assert_allclose(
+                shapely.length(shapely.get_parts(sensor._geometry)),
+                sensor.range_data,
+                atol=1e-12,
+                rtol=0,
+            )
+
 
 # ---------------------------------------------------------------------------
 # Lidar2D grouped-difference scan (issue #302): linestrings and polygons are
@@ -645,16 +907,21 @@ class _MapObject:
 class _Obstacle:
     """Mimics a dynamic obstacle with a polygon geometry."""
 
-    def __init__(self, obj_id, geometry, shape="circle"):
+    def __init__(self, obj_id, geometry, shape="circle", velocity_xy=(0.0, 0.0)):
         self._id = obj_id
         self._geometry = geometry
         self._geometry_valid = True
         self.shape = shape
         self.unobstructed = False
+        self._velocity_xy = np.asarray(velocity_xy, dtype=float).reshape(2, 1)
 
     @property
     def geometry(self):
         return self._geometry
+
+    @property
+    def velocity_xy(self):
+        return self._velocity_xy
 
 
 def test_lidar_subtracts_map_lines_and_dynamic_polygon():
@@ -724,119 +991,414 @@ def test_lidar_detects_disjoint_compound_geometry():
     assert lidar.range_data[0] == pytest.approx(1.75, abs=1e-6)
 
 
+def test_lidar_single_beam_tof():
+    """A single-beam (1D ToF) lidar produces a valid MultiLineString scan.
+
+    PR #200 added number=1 (1D ToF) support and needed a MultiLineString
+    normalization workaround because the old GEOS ``difference`` returned a bare
+    LineString for one beam. The ray-cast path builds the scan geometry natively
+    as a MultiLineString, so the ToF case stays correct without that workaround.
+    """
+    obstacle = _Obstacle(2, shapely.box(2.0, -1.0, 2.5, 1.0), shape="rectangle")
+    env_param = _EnvParam([obstacle], STRtree([obstacle.geometry]))
+    tof = Lidar2D(
+        state=np.array([[0.0], [0.0], [0.0]]),
+        obj_id=1,
+        number=1,
+        angle_range=0.0,
+        range_max=5.0,
+    )
+    tof.parent = _Parent(env_param)
+    tof.step(tof.state)
+
+    assert tof.range_data.shape == (1,)
+    assert tof.range_data[0] == pytest.approx(2.0, abs=1e-6)
+    assert tof._geometry.geom_type == "MultiLineString"
+    assert len(shapely.get_parts(tof._geometry)) == 1
+    assert np.asarray(tof.get_scan()["ranges"]).shape == (1,)
+    assert tof.get_points().shape == (2, 1)
+
+
+def _geos_difference_ranges(lidar, obstacle_geometries):
+    """Reference range_data via the pre-ray-cast whole-geometry difference.
+
+    Reproduces the previous GEOS approach: subtract linestrings and polygons as
+    two merged groups, keep the origin-connected beam parts, and read their
+    lengths. Used to prove the ray-cast reproduces that result.
+    """
+    from irsim.util.util import geometry_transform
+
+    geom = geometry_transform(lidar._original_geometry, lidar._state)
+    lines, polygons = [], []
+    for g in obstacle_geometries:
+        bucket = polygons if g.geom_type in ("Polygon", "MultiPolygon") else lines
+        bucket.append(g)
+    for group in (lines, polygons):
+        if group:
+            obstacle = group[0] if len(group) == 1 else shapely.union_all(group)
+            geom = geom.difference(obstacle)
+    origin = shapely.points(lidar.lidar_origin[0, 0], lidar.lidar_origin[1, 0])
+    parts = shapely.get_parts(geom)
+    kept = parts[shapely.intersects(parts, origin)]
+    ranges = np.full(lidar.number, lidar.range_max, dtype=float)
+    lengths = shapely.length(kept)
+    ranges[: len(lengths)] = lengths
+    return ranges
+
+
+def test_cast_ray_segments_detects_collinear_segment():
+    """The analytic kernel must preserve GEOS collinear-overlap behavior."""
+    ranges, hit = cast_ray_segments(
+        origin=np.array([0.0, 0.0]),
+        directions=np.array([[1.0, 0.0]]),
+        seg_start=np.array([[2.0, 0.0]]),
+        seg_end=np.array([[4.0, 0.0]]),
+        max_range=5.0,
+    )
+
+    np.testing.assert_allclose(ranges, [2.0], atol=1e-12)
+    np.testing.assert_array_equal(hit, [0])
+
+
+def test_lidar_collinear_wall_matches_geos_difference():
+    """A beam running along a wall keeps the same range as the GEOS overlay."""
+    wall = shapely.LineString([(2.0, 0.0), (4.0, 0.0)])
+    obstacle = _Obstacle(2, wall, shape="linestring")
+    lidar = Lidar2D(
+        state=np.array([[0.0], [0.0], [0.0]]),
+        obj_id=1,
+        number=1,
+        angle_range=0.0,
+        range_max=5.0,
+    )
+    lidar.parent = _Parent(_EnvParam([obstacle], STRtree([wall])))
+
+    lidar.step(lidar.state)
+    expected = _geos_difference_ranges(lidar, [wall])
+
+    np.testing.assert_allclose(lidar.range_data, expected, atol=1e-12, rtol=0)
+    assert lidar.range_data[0] == pytest.approx(2.0)
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        [0.0, 0.0, 0.0],
+        [-0.5, 0.5, 0.3],
+        [0.25, -0.75, -0.4],
+    ],
+)
+def test_lidar_map_contours_match_geos_per_beam(state):
+    """Multi-segment map contours preserve every beam's legacy range index."""
+    contours = [
+        shapely.LineString([(2.0, -4.0), (2.0, 4.0), (4.0, 4.0)]),
+        shapely.LineString([(-4.0, -3.0), (-1.0, -3.0), (-1.0, 3.0), (-4.0, 3.0)]),
+        shapely.LineString([(4.0, -2.0), (5.0, 0.0), (4.0, 2.0)]),
+    ]
+    map_obj = _MapObject(2, contours)
+    lidar = Lidar2D(
+        state=np.c_[state],
+        obj_id=1,
+        number=181,
+        angle_range=6.283185,
+        range_max=8.0,
+    )
+    lidar.parent = _Parent(_EnvParam([map_obj], STRtree([map_obj.geometry])))
+
+    lidar.step(lidar.state)
+    expected = _geos_difference_ranges(lidar, contours)
+
+    np.testing.assert_allclose(lidar.range_data, expected, atol=1e-9, rtol=0)
+
+
+def test_lidar_scan_fields_velocity_and_geometry_are_beam_aligned():
+    """Ranges, velocity, metadata, and beam geometry describe the same scan."""
+    obstacle = _Obstacle(
+        2,
+        shapely.Point(2.0, 0.0).buffer(0.7),
+        velocity_xy=(0.4, -0.2),
+    )
+    lidar = Lidar2D(
+        state=np.array([[0.0], [0.0], [0.0]]),
+        obj_id=1,
+        number=91,
+        angle_range=3.14,
+        range_max=5.0,
+        has_velocity=True,
+    )
+    lidar.parent = _Parent(_EnvParam([obstacle], STRtree([obstacle.geometry])))
+
+    lidar.step(lidar.state)
+    scan = lidar.get_scan()
+    expected = _geos_difference_ranges(lidar, [obstacle.geometry])
+
+    np.testing.assert_allclose(scan["ranges"], expected, atol=1e-9, rtol=0)
+    assert tuple(scan) == (
+        "angle_min",
+        "angle_max",
+        "angle_increment",
+        "time_increment",
+        "scan_time",
+        "range_min",
+        "range_max",
+        "ranges",
+        "intensities",
+        "velocity",
+    )
+    assert scan["intensities"] is None
+    assert scan["angle_min"] == lidar.angle_min
+    assert scan["angle_max"] == lidar.angle_max
+    assert scan["angle_increment"] == lidar.angle_inc
+    assert scan["time_increment"] == lidar.time_inc
+    assert scan["scan_time"] == lidar.scan_time
+    assert scan["range_min"] == lidar.range_min
+    assert scan["range_max"] == lidar.range_max
+
+    hit = scan["ranges"] < lidar.range_max - 1e-9
+    np.testing.assert_allclose(
+        scan["velocity"][:, hit],
+        np.broadcast_to(obstacle.velocity_xy, (2, int(hit.sum()))),
+    )
+    np.testing.assert_array_equal(scan["velocity"][:, ~hit], 0.0)
+
+    parts = shapely.get_parts(lidar._geometry)
+    np.testing.assert_allclose(shapely.length(parts), scan["ranges"], atol=1e-12)
+    starts = shapely.get_coordinates(parts)[::2]
+    np.testing.assert_allclose(starts, np.zeros((lidar.number, 2)), atol=1e-12)
+
+
+def test_lidar_velocity_uses_explicit_hit_near_max_range():
+    """A real hit near range_max carries velocity instead of looking like a miss."""
+    wall = shapely.LineString([(4.99, -1.0), (4.99, 1.0)])
+    obstacle = _Obstacle(
+        2,
+        wall,
+        shape="linestring",
+        velocity_xy=(0.7, -0.2),
+    )
+    lidar = Lidar2D(
+        state=np.array([[0.0], [0.0], [0.0]]),
+        obj_id=1,
+        number=1,
+        angle_range=0.0,
+        range_max=5.0,
+        has_velocity=True,
+    )
+    lidar.parent = _Parent(_EnvParam([obstacle], STRtree([wall])))
+
+    lidar.step(lidar.state)
+
+    assert lidar.range_data[0] == pytest.approx(4.99, abs=1e-12)
+    np.testing.assert_allclose(lidar.velocity, obstacle.velocity_xy)
+
+
+def _raycast_case(kind):
+    """Build (obstacle objects, flat geometry list) for one obstacle type."""
+    if kind == "rectangle":
+        obs = _Obstacle(2, shapely.box(2.0, -1.0, 3.0, 1.0), shape="rectangle")
+        return [obs], [obs.geometry]
+    if kind == "circle":  # a circle is a buffer polygon
+        obs = _Obstacle(2, shapely.Point(3.0, 0.0).buffer(0.8))
+        return [obs], [obs.geometry]
+    if kind == "linestring":
+        obs = _Obstacle(
+            2, shapely.LineString([(3.0, -2.0), (3.0, 2.0)]), shape="linestring"
+        )
+        return [obs], [obs.geometry]
+    if kind == "polygon_with_hole":
+        shell = shapely.box(2.0, -1.5, 4.0, 1.5)
+        hole = shapely.box(2.7, -0.5, 3.3, 0.5)
+        obs = _Obstacle(2, shell.difference(hole), shape="polygon")
+        return [obs], [obs.geometry]
+    if kind == "map":  # grid-map style: many short linestrings
+        walls = [
+            shapely.LineString([(3.0, y), (3.0, y + 0.1)])
+            for y in np.arange(-1.0, 1.0, 0.1)
+        ]
+        return [_MapObject(2, walls)], list(walls)
+    if kind == "compound":  # disjoint MultiPolygon (issue #350)
+        compound = GeometryFactory.create_geometry(
+            "compound",
+            parts=[
+                {
+                    "name": "rectangle",
+                    "length": 0.5,
+                    "width": 1.0,
+                    "pose": [2.0, 0.0, 0.0],
+                },
+                {
+                    "name": "rectangle",
+                    "length": 0.5,
+                    "width": 1.0,
+                    "pose": [4.0, 0.0, 0.0],
+                },
+            ],
+        )
+        obs = _Obstacle(2, compound.geometry, shape="compound")
+        return [obs], [obs.geometry]
+    if kind == "mixed":  # map + dynamic polygon in one scan (issue #302 layout)
+        walls = [
+            shapely.LineString([(-3.0, y), (-3.0, y + 0.1)])
+            for y in np.arange(-1.0, 1.0, 0.1)
+        ]
+        circle = _Obstacle(3, shapely.Point(3.0, 0.0).buffer(0.7))
+        return [_MapObject(2, walls), circle], [*walls, circle.geometry]
+    raise ValueError(kind)
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "rectangle",
+        "circle",
+        "linestring",
+        "polygon_with_hole",
+        "map",
+        "compound",
+        "mixed",
+    ],
+)
+def test_lidar_raycast_matches_geos_difference(kind):
+    """Ray-cast range_data reproduces the GEOS difference for every obstacle type.
+
+    The sensor sits in free space so both approaches agree to floating-point
+    precision (the analytic ray-cast uses the same obstacle edges GEOS does).
+    """
+    objects, geometries = _raycast_case(kind)
+    env_param = _EnvParam(objects, STRtree([o.geometry for o in objects]))
+    lidar = Lidar2D(
+        state=np.array([[0.0], [0.0], [0.0]]),
+        obj_id=1,
+        number=180,
+        angle_range=6.283185,
+        range_max=8.0,
+    )
+    lidar.parent = _Parent(env_param)
+
+    lidar.step(lidar.state)
+    expected = _geos_difference_ranges(lidar, geometries)
+
+    # Beam order is part of the LaserScan contract: ranges[i] belongs to
+    # angle_min + i * angle_increment, so a permutation is not acceptable.
+    np.testing.assert_allclose(lidar.range_data, expected, atol=1e-9, rtol=0)
+    assert (lidar.range_data < lidar.range_max - 1e-6).any()  # obstacle was seen
+
+
+def test_lidar_raycast_matches_geos_in_randomized_free_space():
+    """Random poses, offsets, and mixed shapes retain every GEOS beam range."""
+    random = np.random.default_rng(20260816)
+
+    for _ in range(20):
+        state = np.array(
+            [
+                [random.uniform(-2.0, 2.0)],
+                [random.uniform(-2.0, 2.0)],
+                [random.uniform(-np.pi, np.pi)],
+            ]
+        )
+        offset = [
+            random.uniform(-0.3, 0.3),
+            random.uniform(-0.3, 0.3),
+            random.uniform(-0.4, 0.4),
+        ]
+        number = int(random.choice([1, 31, 90, 181]))
+        angle_range = (
+            0.0 if number == 1 else float(random.choice([0.7, 3.14, 6.283185]))
+        )
+        lidar = Lidar2D(
+            state=state,
+            obj_id=1,
+            number=number,
+            angle_range=angle_range,
+            range_max=8.0,
+            offset=offset,
+        )
+        origin = lidar.lidar_origin[:2, 0]
+        objects = []
+        geometries = []
+        for obj_id in range(2, 8):
+            bearing = random.uniform(-np.pi, np.pi)
+            distance = random.uniform(1.5, 6.0)
+            center = origin + distance * np.array([np.cos(bearing), np.sin(bearing)])
+            if obj_id % 3 == 0:
+                geometry = shapely.Point(center).buffer(
+                    random.uniform(0.15, 0.6), quad_segs=8
+                )
+                shape = "circle"
+            elif obj_id % 3 == 1:
+                tangent = np.array([-np.sin(bearing), np.cos(bearing)])
+                half_length = random.uniform(0.2, 0.8)
+                geometry = shapely.LineString(
+                    [center - half_length * tangent, center + half_length * tangent]
+                )
+                shape = "linestring"
+            else:
+                half_size = random.uniform(0.15, 0.5, size=2)
+                geometry = shapely.box(
+                    center[0] - half_size[0],
+                    center[1] - half_size[1],
+                    center[0] + half_size[0],
+                    center[1] + half_size[1],
+                )
+                shape = "rectangle"
+            geometries.append(geometry)
+            objects.append(_Obstacle(obj_id, geometry, shape=shape))
+
+        lidar.parent = _Parent(
+            _EnvParam(objects, STRtree([obj.geometry for obj in objects]))
+        )
+
+        lidar.step(lidar.state)
+        expected = _geos_difference_ranges(lidar, geometries)
+
+        np.testing.assert_allclose(lidar.range_data, expected, atol=1e-9, rtol=0)
+        np.testing.assert_allclose(
+            shapely.length(shapely.get_parts(lidar._geometry)),
+            expected,
+            atol=1e-9,
+            rtol=0,
+        )
+
+
 # ---------------------------------------------------------------------------
-# Lidar2D geometry normalization, noise, and pointcloud conversion
+# Lidar2D range noise and pointcloud conversion
 # ---------------------------------------------------------------------------
-
-
-class TestLidar2DEnsureMultiLineString:
-    """Tests for Lidar2D._ensure_multi_linestring normalization."""
-
-    @pytest.fixture
-    def lidar(self):
-        """Create a minimal Lidar2D instance for testing."""
-        state = np.array([[0.0], [0.0], [0.0]])
-        return Lidar2D(state=state, obj_id=1, number=10, range_max=5.0)
-
-    def test_linestring_input(self, lidar):
-        """A LineString is wrapped in a MultiLineString."""
-        line = shapely.LineString([(0, 0), (1, 1)])
-        result = lidar._ensure_multi_linestring(line)
-
-        assert isinstance(result, shapely.MultiLineString)
-        assert len(result.geoms) == 1
-        assert result.geoms[0].equals(line)
-
-    def test_multilinestring_input(self, lidar):
-        """A MultiLineString is returned unchanged."""
-        lines = shapely.MultiLineString([[(0, 0), (1, 1)], [(2, 2), (3, 3)]])
-        result = lidar._ensure_multi_linestring(lines)
-
-        assert result is lines
-        assert len(result.geoms) == 2
-
-    def test_empty_geometry(self, lidar):
-        """An empty geometry returns an empty MultiLineString."""
-        # An empty MultiPolygon hits the is_empty branch (an empty LineString
-        # would hit the LineString branch first).
-        result = lidar._ensure_multi_linestring(shapely.MultiPolygon())
-
-        assert isinstance(result, shapely.MultiLineString)
-        assert result.is_empty
-
-    def test_geometry_collection_with_linestrings(self, lidar):
-        """A GeometryCollection of LineStrings is flattened."""
-        line1 = shapely.LineString([(0, 0), (1, 1)])
-        line2 = shapely.LineString([(2, 2), (3, 3)])
-        result = lidar._ensure_multi_linestring(
-            shapely.GeometryCollection([line1, line2])
-        )
-
-        assert isinstance(result, shapely.MultiLineString)
-        assert len(result.geoms) == 2
-
-    def test_geometry_collection_with_nested_multilinestring(self, lidar):
-        """Nested MultiLineStrings inside a GeometryCollection are flattened."""
-        line1 = shapely.LineString([(0, 0), (1, 1)])
-        multi = shapely.MultiLineString([[(2, 2), (3, 3)], [(4, 4), (5, 5)]])
-        result = lidar._ensure_multi_linestring(
-            shapely.GeometryCollection([line1, multi])
-        )
-
-        assert isinstance(result, shapely.MultiLineString)
-        assert len(result.geoms) == 3  # 1 from line1 + 2 from multi
-
-    def test_geometry_collection_empty(self, lidar):
-        """An empty GeometryCollection returns an empty MultiLineString."""
-        result = lidar._ensure_multi_linestring(shapely.GeometryCollection())
-
-        assert isinstance(result, shapely.MultiLineString)
-        assert result.is_empty
-
-    def test_unsupported_point_geometry(self, lidar):
-        """A Point geometry returns an empty MultiLineString."""
-        result = lidar._ensure_multi_linestring(shapely.Point(1, 1))
-
-        assert isinstance(result, shapely.MultiLineString)
-        assert result.is_empty
-
-    def test_unsupported_polygon_geometry(self, lidar):
-        """A Polygon geometry returns an empty MultiLineString."""
-        polygon = shapely.Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
-        result = lidar._ensure_multi_linestring(polygon)
-
-        assert isinstance(result, shapely.MultiLineString)
-        assert result.is_empty
-
-    def test_geometry_collection_mixed_types(self, lidar):
-        """Mixed GeometryCollections keep only the line components."""
-        line = shapely.LineString([(0, 0), (1, 1)])
-        point = shapely.Point(5, 5)  # ignored
-        result = lidar._ensure_multi_linestring(
-            shapely.GeometryCollection([line, point])
-        )
-
-        assert isinstance(result, shapely.MultiLineString)
-        assert len(result.geoms) == 1
 
 
 class TestLidar2DNoise:
-    """Lidar2D range computation with measurement noise enabled."""
+    """Lidar2D range noise via the ray-cast step path."""
 
-    def test_lidar_with_noise(self):
-        """calculate_range with noise=True still produces range data."""
-        state = np.array([[0.0], [0.0], [0.0]])
-        lidar = Lidar2D(state=state, obj_id=1, number=10, range_max=5.0, noise=True)
-        assert lidar.noise is True
-        lidar.calculate_range()
-        assert lidar.range_data is not None
+    def test_step_noise_applied_and_reproducible(self):
+        """Seeded range noise perturbs the scan and reproduces run-to-run."""
+        from irsim.util.random import set_seed
 
-    def test_lidar_calculate_range_vel_with_noise(self):
-        """calculate_range_vel with noise=True still produces range data."""
-        state = np.array([[0.0], [0.0], [0.0]])
-        lidar = Lidar2D(state=state, obj_id=1, number=10, range_max=5.0, noise=True)
-        lidar.calculate_range_vel(intersect_index=[])
-        assert lidar.range_data is not None
+        obstacle = _Obstacle(2, shapely.box(2.0, -3.0, 2.5, 3.0), shape="rectangle")
+        env_param = _EnvParam([obstacle], STRtree([obstacle.geometry]))
+
+        def run(noise):
+            set_seed(9)
+            lidar = Lidar2D(
+                state=np.array([[0.0], [0.0], [0.0]]),
+                obj_id=1,
+                number=120,
+                angle_range=6.283185,
+                range_max=8.0,
+                noise=noise,
+                std=0.2,
+            )
+            lidar.parent = _Parent(env_param)
+            lidar.step(lidar.state)
+            return lidar.range_data.copy()
+
+        noisy_a = run(True)
+        noisy_b = run(True)
+        clean = run(False)
+        np.testing.assert_array_equal(noisy_a, noisy_b)  # seeded reproducible
+        set_seed(9)
+        expected = clean + rng.normal(0, 0.2, len(clean))
+        np.testing.assert_allclose(noisy_a, expected, atol=1e-12, rtol=0)
+        assert np.any(noisy_a != clean)  # noise actually changed the scan
+        assert np.all(np.isfinite(noisy_a))
 
 
 class TestLidar2DScanToPointcloud:

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1046,6 +1046,37 @@ def _geos_difference_ranges(lidar, obstacle_geometries):
     return ranges
 
 
+def test_lidar_origin_uses_exact_world_geometry_coordinate(monkeypatch):
+    """The reported origin and transformed beam start must be bit-identical."""
+    import irsim.world.sensors.lidar2d as lidar_module
+
+    point_transform = lidar_module.transform_point_with_state
+
+    def slightly_shifted_origin(point, state):
+        origin = point_transform(point, state)
+        origin[0, 0] = np.nextafter(origin[0, 0], np.inf)
+        return origin
+
+    monkeypatch.setattr(
+        lidar_module,
+        "transform_point_with_state",
+        slightly_shifted_origin,
+    )
+    lidar = Lidar2D(
+        state=np.array([[1.2], [-0.7], [0.9]]),
+        obj_id=1,
+        number=31,
+        angle_range=3.14,
+        range_max=5.0,
+        offset=[0.2, -0.1, 0.3],
+    )
+
+    world_geometry = lidar._world_geometry(lidar.state)
+    geometry_origin = shapely.get_coordinates(world_geometry)[0]
+
+    np.testing.assert_array_equal(lidar.lidar_origin[:2, 0], geometry_origin)
+
+
 def test_cast_ray_segments_detects_collinear_segment():
     """The analytic kernel must preserve GEOS collinear-overlap behavior."""
     ranges, hit = cast_ray_segments(

--- a/usage/06multi_objects_world/multi_objects_large.py
+++ b/usage/06multi_objects_world/multi_objects_large.py
@@ -7,8 +7,9 @@ env = irsim.make(save_ani=False, full=False)
 for _i in range(100):
     start_time = time.time()
     env.step()
-    env.render(0.01)
     end_time = time.time()
+
+    env.render(0.01)
     print(f"Time taken: {end_time - start_time} seconds")
 
     if env.done():

--- a/usage/10grid_map/grid_map_perlin.yaml
+++ b/usage/10grid_map/grid_map_perlin.yaml
@@ -7,7 +7,7 @@ world:
   sample_time: 0.1  # 10Hz for render and data extraction
   offset: [0, 0]  # world origin offset
   collision_mode: 'stop'  # 'stop', 'unobstructed'
-  control_mode: 'auto'  # 'keyboard', 'auto'
+  control_mode: 'keyboard'  # 'keyboard', 'auto'
   mdownsample: 1
   obstacle_map:
     name: perlin
@@ -20,10 +20,10 @@ world:
 
 robot:
   - kinematics: {name: 'diff'}  # differential drive robot
-    shape: {name: 'circle', radius: 0.3}
-    state: [2, 2, 0]  # initial state [x, y, theta]
-    goal: [16, 18, 0]  # goal position
-    vel_max: [3, 1]  # max linear and angular velocity
+    shape: {name: 'circle', radius: 0.1}
+    state: [5.3, 5.5, 0]  # initial state [x, y, theta] (free cell for seed 48)
+    goal: [15.5, 17.9, 0]  # goal position (free cell for seed 48)
+    vel_max: [1, 1]  # max linear and angular velocity
     behavior: {name: 'dash'}  # move toward goal directly
 
     plot:


### PR DESCRIPTION
## Summary

This PR replaces GEOS overlay operations with vectorized 2D ray casting.

The same ray-casting implementation is shared by `Lidar2D` and `FMCWLidar2D`.

It supports polygons, lines, maps, compound shapes, holes, and collinear walls.

## Performance

**Baseline** means the previous Shapely/GEOS sensor operations. `Lidar2D` uses a whole-geometry `difference`. `FMCWLidar2D` uses a Shapely `intersection` for each beam.

### Lidar2D

| Scene | Baseline | Current | Speedup | Max range error | Hits (B/C) |
|---|---:|---:|---:|---:|---:|
| Empty | 0.123 ms | 0.177 ms | 0.69x | `1.78e-15 m` | 0 / 0 |
| One polygon | 7.673 ms | 0.308 ms | 24.93x | `1.78e-15 m` | 10 / 10 |
| 50 polygons | 17.604 ms | 3.824 ms | 4.60x | `2.66e-15 m` | 331 / 331 |
| Map with 360 segments | 11.670 ms | 1.803 ms | 6.47x | `2.66e-15 m` | 360 / 360 |
| Map with 20 polygons | 24.693 ms | 3.276 ms | 7.54x | `2.66e-15 m` | 360 / 360 |

Non-empty synthetic scenes are about 4.6x to 24.9x faster.

Synthetic map scenes are about 6.5x to 7.5x faster.

An empty standard scan is about 45% slower. The absolute increase is about 0.054 ms.

### FMCWLidar2D

| Scene | Baseline | Current | Speedup | Max range error | Max Doppler error | Valid beams (B/C) |
|---|---:|---:|---:|---:|---:|---:|
| Empty | 3.336 ms | 0.182 ms | 18.37x | `0 m` | `0 m/s` | 0 / 0 |
| One polygon | 5.870 ms | 0.328 ms | 17.91x | `4.44e-16 m` | `0 m/s` | 10 / 10 |
| 50 polygons | 29.178 ms | 4.318 ms | 6.76x | `2.66e-15 m` | `2.78e-17 m/s` | 331 / 331 |
| Map with 360 segments | 15.651 ms | 2.322 ms | 6.74x | `2.66e-15 m` | `0 m/s` | 360 / 360 |
| Map with 20 polygons | 24.607 ms | 3.812 ms | 6.45x | `2.66e-15 m` | `5.55e-17 m/s` | 360 / 360 |

FMCW scans are about 6.5x to 18.4x faster in these cases.

## Accuracy

The range and Doppler columns show the maximum absolute difference from the baseline Shapely/GEOS output.

The hit and valid-beam counts match in every benchmark case.

The scan ranges remain aligned with the previous Shapely/GEOS implementation when the sensor origin is in free space.

The comparisons cover maps, polygons, holes, compound shapes, lines, collinear walls, sensor offsets, motion, and noise.