### PR TITLE
feat: add internal and external step modes

### DIFF
--- a/docs/locale/zh_CN/LC_MESSAGES/usage/make_environment.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/usage/make_environment.po
@@ -537,3 +537,35 @@ msgid ""
 msgstr ""
 "[多环境](multiple_environments.md) —— 以相互隔离的状态同时运行多个场景，适用"
 "于对比研究或强化学习训练。"
+
+#: ../../source/usage/make_environment.md:24
+msgid "**`step_mode`** (`\"internal\"` or `\"external\"`, optional): Overrides `world.step_mode` for this environment. If omitted, the YAML value is used."
+msgstr "**`step_mode`**（`\"internal\"` 或 `\"external\"`，可选）：覆盖当前环境的 `world.step_mode`；若省略，则使用 YAML 中的值。"
+
+#: ../../source/usage/make_environment.md:87
+msgid "**`step_mode`**: Determines who advances object states"
+msgstr "**`step_mode`**：决定由谁推进对象状态"
+
+#: ../../source/usage/make_environment.md:88
+msgid "`'internal'`: IR-SIM integrates states from actions or configured behaviors"
+msgstr "`'internal'`：IR-SIM 根据动作或已配置的行为积分更新状态"
+
+#: ../../source/usage/make_environment.md:89
+msgid "`'external'`: External code supplies states; IR-SIM synchronizes derived data"
+msgstr "`'external'`：外部代码提供状态，IR-SIM 同步派生数据"
+
+#: ../../source/usage/make_environment.md:161
+msgid "Internal and External Step Modes"
+msgstr "内部与外部步进模式"
+
+#: ../../source/usage/make_environment.md:163
+msgid "The default `internal` mode preserves the normal IR-SIM loop. Actions may be provided explicitly, or omitted so configured behaviors generate them:"
+msgstr "默认的 `internal` 模式保持 IR-SIM 的常规循环。可以显式提供动作，也可以省略动作，由已配置的行为生成动作："
+
+#: ../../source/usage/make_environment.md:171
+msgid "In `external` mode, another simulator or system owns the state update. Supply the new state and velocity first, then call `env.step()` without an action:"
+msgstr "在 `external` 模式下，状态由另一个仿真器或外部系统更新。请先提供新的状态和速度，再调用不带动作的 `env.step()`："
+
+#: ../../source/usage/make_environment.md:185
+msgid "The external step does not execute IR-SIM kinematics or behaviors. It refreshes all object geometries from one state snapshot, rebuilds the collision index, updates sensors and status, records trajectories, and advances the world clock. Passing `action` to `env.step()` in this mode raises `ValueError`, preventing accidental mixing of internal and external state advancement."
+msgstr "外部步进不会执行 IR-SIM 的运动学或行为逻辑。它基于同一状态快照刷新所有对象的几何信息、重建碰撞索引、更新传感器和状态、记录轨迹，并推进世界时钟。在此模式下向 `env.step()` 传入 `action` 会引发 `ValueError`，以防意外混用内部和外部状态推进方式。"

--- a/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
@@ -3070,3 +3070,35 @@ msgid ""
 msgstr ""
 "**绘图选项**：若 `plot` 位于对象配置内部，可为单个对象定制可视化；若位于对象"
 "配置的根级，则应用于所有对象。"
+
+#: ../../source/yaml_config/configuration.md:513
+msgid "`step_mode`"
+msgstr "`step_mode`"
+
+#: ../../source/yaml_config/configuration.md:513
+msgid "`\"internal\"`"
+msgstr "`\"internal\"`"
+
+#: ../../source/yaml_config/configuration.md:513
+msgid "State advancement mode. Support mode: `internal` or `external`"
+msgstr "状态推进模式，支持 `internal` 或 `external`"
+
+#: ../../source/yaml_config/configuration.md:587
+msgid "**`step_mode`** (`str`, default: `\"internal\"`)"
+msgstr "**`step_mode`**（`str`，默认：`\"internal\"`）"
+
+#: ../../source/yaml_config/configuration.md:588
+msgid "Defines who advances object states during `env.step()`:"
+msgstr "定义在 `env.step()` 期间由谁推进对象状态："
+
+#: ../../source/yaml_config/configuration.md:591
+msgid "`internal`: IR-SIM advances states through its kinematics using explicit actions, keyboard commands, group behaviors, or object behaviors."
+msgstr "`internal`：IR-SIM 使用显式动作、键盘命令、群组行为或对象行为，通过自身运动学推进状态。"
+
+#: ../../source/yaml_config/configuration.md:592
+msgid "`external`: An external system owns the state update. Set each object's state and velocity with `set_state()` and `set_velocity()`, then call `env.step()` without an action. IR-SIM synchronizes geometry and sensors, rebuilds collision data, updates status, and advances the world clock without running its kinematics or behaviors."
+msgstr "`external`：由外部系统负责更新状态。使用 `set_state()` 和 `set_velocity()` 设置每个对象的状态和速度，然后调用不带动作的 `env.step()`。IR-SIM 会同步几何信息和传感器、重建碰撞数据、更新状态并推进世界时钟，但不运行自身的运动学或行为逻辑。"
+
+#: ../../source/yaml_config/configuration.md:594
+msgid "`irsim.make(\"world.yaml\", step_mode=\"...\")` can override the YAML value for a particular run. The override remains active across `env.reload()` and `env.reset(random=True)`."
+msgstr "`irsim.make(\"world.yaml\", step_mode=\"...\")` 可以为特定运行覆盖 YAML 中的值；该覆盖在 `env.reload()` 和 `env.reset(random=True)` 后仍然有效。"

--- a/docs/source/usage/make_environment.md
+++ b/docs/source/usage/make_environment.md
@@ -20,6 +20,8 @@ The `make` function creates an environment from a configuration file. Supported 
 
 - **`world_name`** (str, optional): Path to the world YAML configuration file
 - **`projection`** (str, optional): Projection type ("3d" for 3D environment, None for 2D)
+- **`step_mode`** (`"internal"` or `"external"`, optional): Overrides
+  `world.step_mode` for this environment. If omitted, the YAML value is used.
 - **`display`** (bool): Whether to display the environment visualization (default: True)
 - **`save_ani`** (bool): Whether to save the simulation as an animation (default: False)
 - **`log_level`** (str): Logging level for the environment (default: "INFO")
@@ -43,6 +45,7 @@ world:
   step_time: 0.1  # simulation time step (seconds) - 10Hz
   sample_time: 0.1  # rendering frequency (seconds) - 10Hz
   offset: [0, 0] # the offset of the world origin [x, y]
+  step_mode: 'internal' # state advancement: 'internal' or 'external'
   control_mode: 'auto' # control mode: 'auto', 'keyboard'
   collision_mode: 'stop' # collision behavior: 'stop', 'unobstructed', 'unobstructed_obstacles'
   obstacle_map: null # path to obstacle map file (optional)
@@ -81,6 +84,9 @@ The configuration file defines the world and the robot that the main loop advanc
 - **`step_time`**: Controls simulation accuracy and speed (smaller = more accurate, slower)
 - **`sample_time`**: Controls rendering frequency (larger = faster simulation, less smooth visualization)
 - **`offset`**: Shifts the world coordinate system origin [x, y] in meters
+- **`step_mode`**: Determines who advances object states
+  - `'internal'`: IR-SIM integrates states from actions or configured behaviors
+  - `'external'`: External code supplies states; IR-SIM synchronizes derived data
 - **`control_mode`**: Determines how the simulation is controlled
   - `'auto'`: Automatic simulation execution
   - `'keyboard'`: Manual keyboard control
@@ -151,6 +157,36 @@ Update order
 
 The environment advances all objects first, then updates all sensors. This two-phase update ensures sensors read the latest world state consistently. If you step objects manually, either pass `sensor_step=True` to `ObjectBase.step(...)` or call `obj.sensor_step()` after updating states.
 ::::
+
+### Internal and External Step Modes
+
+The default `internal` mode preserves the normal IR-SIM loop. Actions may be
+provided explicitly, or omitted so configured behaviors generate them:
+
+```python
+env = irsim.make("config.yaml")
+env.step(action=[1.0, 0.0], action_id=0)
+```
+
+In `external` mode, another simulator or system owns the state update. Supply
+the new state and velocity first, then call `env.step()` without an action:
+
+```python
+env = irsim.make("config.yaml", step_mode="external")
+robot = env.robot
+
+while not env.done():
+    state, velocity = external_system.read_robot()
+    robot.set_state(state)
+    robot.set_velocity(velocity)
+    env.step()
+```
+
+The external step does not execute IR-SIM kinematics or behaviors. It refreshes
+all object geometries from one state snapshot, rebuilds the collision index,
+updates sensors and status, records trajectories, and advances the world clock.
+Passing `action` to `env.step()` in this mode raises `ValueError`, preventing
+accidental mixing of internal and external state advancement.
 
 ## Environment Control and Status
 

--- a/docs/source/yaml_config/configuration.md
+++ b/docs/source/yaml_config/configuration.md
@@ -25,6 +25,7 @@ A complete IR-SIM scene is described by up to four top-level keys: `world`, `rob
   <div class="yt-leaf"><a class="yt-key" href="#p-w-step-time">step_time</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">0.1</span><span class="yt-desc">simulation step (s)</span></div>
   <div class="yt-leaf"><a class="yt-key" href="#p-w-sample-time">sample_time</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">step_time</span><span class="yt-desc">render / sample step (s)</span></div>
   <div class="yt-leaf"><a class="yt-key" href="#p-w-offset">offset</a><span class="yt-type yt-t-list"><b class="yt-pill">list</b></span><span class="yt-def">[0, 0]</span><span class="yt-desc">world origin offset [x, y]</span></div>
+  <div class="yt-leaf"><a class="yt-key" href="#p-w-step-mode">step_mode</a><span class="yt-type yt-t-str"><b class="yt-pill">str</b></span><span class="yt-def">"internal"</span><span class="yt-desc">internal | external</span></div>
   <div class="yt-leaf"><a class="yt-key" href="#p-w-control-mode">control_mode</a><span class="yt-type yt-t-str"><b class="yt-pill">str</b></span><span class="yt-def">"auto"</span><span class="yt-desc">auto | keyboard</span></div>
   <div class="yt-leaf"><a class="yt-key" href="#p-w-collision-mode">collision_mode</a><span class="yt-type yt-t-str"><b class="yt-pill">str</b></span><span class="yt-def">"stop"</span><span class="yt-desc">stop | unobstructed | unobstructed_obstacles</span></div>
   <div class="yt-leaf"><a class="yt-key" href="#p-w-status">status</a><span class="yt-type yt-t-str"><b class="yt-pill">str</b></span><span class="yt-def">"None"</span><span class="yt-desc">initial display label</span></div>
@@ -473,6 +474,7 @@ world:
   step_time: 0.1  # 10Hz calculate each step
   sample_time: 0.1  # 10 Hz for render and data extraction 
   offset: [0, 0] # the offset of the world on x and y 
+  step_mode: 'internal'  # 'internal' or 'external'
   collision_mode: 'stop'  # 'stop', 'unobstructed', 'unobstructed_obstacles'
   plot:
     show_title: true
@@ -536,6 +538,7 @@ This section outlines the configuration parameters available for the `world` sec
 | `step_time`      | `float`           | `0.1`       | Time interval between simulation steps (in seconds)                                                        |
 | `sample_time`    | `float`           | `step_time` | Time interval between samples for rendering and data extraction (in seconds). Defaults to `step_time` if not specified. |
 | `offset`         | `list` of `float` | `[0, 0]`    | Offset for the world's position in `[x, y]` coordinates                                                    |
+| `step_mode`      | `str`             | `"internal"` | State advancement mode. Support mode: `internal` or `external`                                          |
 | `control_mode`   | `str`             | `"auto"`    | Control mode of the simulation. Support mode: `auto` or `keyboard`                                         |
 | `collision_mode` | `str`             | `"stop"`    | Collision handling mode (Support: `"stop"`, `"unobstructed"`, `"unobstructed_obstacles"`)                  |
 | `status`         | `str`             | `"None"`    | Initial display label; replaced by the runtime status after the first completed step |
@@ -579,6 +582,16 @@ This section outlines the configuration parameters available for the `world` sec
 
 (world-mode)=
 ::::{dropdown} **world mode**
+
+(p-w-step-mode)=
+**`step_mode`** (`str`, default: `"internal"`)
+: Defines who advances object states during `env.step()`:
+
+  **Options:**
+  - `internal`: IR-SIM advances states through its kinematics using explicit actions, keyboard commands, group behaviors, or object behaviors.
+  - `external`: An external system owns the state update. Set each object's state and velocity with `set_state()` and `set_velocity()`, then call `env.step()` without an action. IR-SIM synchronizes geometry and sensors, rebuilds collision data, updates status, and advances the world clock without running its kinematics or behaviors.
+
+  `irsim.make("world.yaml", step_mode="...")` can override the YAML value for a particular run. The override remains active across `env.reload()` and `env.reset(random=True)`.
 
 (p-w-control-mode)=
 **`control_mode`** (`str`, default: `"auto"`)
@@ -687,6 +700,7 @@ world:
   step_time: 0.1                      # Time interval between steps (10 Hz)
   sample_time: 0.1                    # Time interval for rendering and data extraction (10 Hz)
   offset: [0, 0]                      # Positional offset of the world on the x and y axes
+  step_mode: 'internal'               # State advancement mode ('internal' or 'external')
   control_mode: 'keyboard'            # Control mode ('auto' or 'keyboard')
   collision_mode: 'stop'              # Collision handling mode ('stop', 'unobstructed', 'unobstructed_obstacles')
   obstacle_map: "path/to/map.png"     # Path to the obstacle map image file

--- a/irsim/__init__.py
+++ b/irsim/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from collections.abc import Callable
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from irsim.env import EnvBase, EnvBase3D
 
@@ -58,7 +58,10 @@ _env_factory = _EnvFactory()
 
 
 def make(
-    world_name: str | None = None, projection: str | None = None, **kwargs: Any
+    world_name: str | None = None,
+    projection: str | None = None,
+    step_mode: Literal["internal", "external"] | None = None,
+    **kwargs: Any,
 ) -> EnvBase:
     """
     Create an environment by the given world file and projection.
@@ -73,6 +76,11 @@ def make(
         projection (str, optional): The projection type of the environment.
             Default is None for 2D environment. If set to "3d", creates a 3D
             plot environment.
+        step_mode ({"internal", "external"}, optional): Override the
+            ``world.step_mode`` value from YAML. ``internal`` lets IR-SIM
+            integrate object states. ``external`` expects callers to update
+            object states before each :py:meth:`.EnvBase.step` call. If None,
+            the YAML value is used (defaulting to ``internal``).
         **kwargs: Additional keyword arguments passed to :py:class:`.EnvBase`
             or :py:class:`.EnvBase3D`. Common options include:
 
@@ -95,5 +103,9 @@ def make(
         >>>
         >>> # Create environment with additional options
         >>> env = make("world.yaml", display=True, save_ani=False)
+        >>> # Override the YAML state-advancement mode
+        >>> env = make("world.yaml", step_mode="external")
     """
+    if step_mode is not None:
+        kwargs["step_mode"] = step_mode
     return _env_factory.create(world_name=world_name, projection=projection, **kwargs)

--- a/irsim/config/world_param.py
+++ b/irsim/config/world_param.py
@@ -3,6 +3,8 @@ World parameters.
 
 Attributes:
     time: time elapse of the simulation
+    step_mode: 'internal' (IR-SIM advances object states) or 'external'
+        (an external system supplies object states)
     control_mode: 'auto' (robot controlled automatically) or 'keyboard' (robot controlled by keyboard)
     collision_mode: 'stop' (default, all objects stop on collision), 'unobstructed' (no collision check),
         or 'unobstructed_obstacles' (only obstacles pass through each other)
@@ -21,6 +23,8 @@ class WorldParam:
 
     Attributes:
         time: Elapsed simulation time.
+        step_mode: ``internal`` when IR-SIM advances object states or
+            ``external`` when an external system supplies object states.
         control_mode: ``auto`` for automatic control or ``keyboard`` for manual control.
         collision_mode: Collision handling mode.
         step_time: Simulation time step.
@@ -28,6 +32,7 @@ class WorldParam:
     """
 
     time: float = 0.0
+    step_mode: str = "internal"
     control_mode: str = "auto"
     collision_mode: str = "stop"
     step_time: float = 0.1

--- a/irsim/env/env_base.py
+++ b/irsim/env/env_base.py
@@ -375,7 +375,7 @@ class EnvBase:
         """
         for obj in self.objects:
             obj.refresh(sensor_step=False)
-            if record_trajectory and not obj.static:
+            if record_trajectory and not obj.static and not obj.stop_flag:
                 obj.trajectory.append(obj.state.copy())
         self.build_tree()
 

--- a/irsim/env/env_base.py
+++ b/irsim/env/env_base.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import importlib
 from collections import Counter
-from typing import Any
+from typing import Any, Literal
 
 import matplotlib
 import numpy as np
@@ -105,6 +105,11 @@ class EnvBase:
         seed (int, optional): Seed for the random number generator. Default is None.
             If None, the seed will be set to a random value, which will make the simulation non-reproducible.
             If a fixed seed is provided, the random simulation scenario will be reproducible.
+        step_mode ({"internal", "external"}, optional): Override the mode from
+            ``world.step_mode`` in YAML. ``internal`` runs the normal IR-SIM
+            kinematics step. ``external`` expects callers to update object
+            states and velocities before calling :meth:`step`. Default is None,
+            which uses the YAML value (or ``internal`` when omitted there).
 
     Attributes:
         display (bool): Whether to display the environment visualization.
@@ -149,6 +154,7 @@ class EnvBase:
         log_file: str | None = None,
         log_level: str = "INFO",
         seed: int | None = None,
+        step_mode: Literal["internal", "external"] | None = None,
     ) -> None:
         # Reset object ID counter so each environment starts from 0
         ObjectBase.reset_id_iter()
@@ -181,6 +187,7 @@ class EnvBase:
                 world_name,
                 env_param_instance=self._env_param,
                 world_param_instance=self._world_param,
+                step_mode=step_mode,
             )
         except Exception as e:
             self.logger.critical(f"YAML Configuration load failed: {e}")
@@ -321,11 +328,20 @@ class EnvBase:
         ) or self.pause_flag:
             return
 
-        # assign the keyboard and group action to the action list in a priority order
-        action = self._assign_keyboard_action(action)
-        action = self._assign_group_action(action)
+        if self.step_mode == "external":
+            if any(item is not None for item in action):
+                raise ValueError(
+                    "env.step(action=...) is unavailable when step_mode='external'. "
+                    "Update object states with set_state()/set_velocity(), then call "
+                    "env.step() without an action."
+                )
+            self._objects_refresh(record_trajectory=True)
+        else:
+            # assign keyboard and group actions in priority order
+            action = self._assign_keyboard_action(action)
+            action = self._assign_group_action(action)
+            self._objects_step(action, sensor_step=False)
 
-        self._objects_step(action, sensor_step=False)
         self._objects_sensor_step()
         self._world.step(self.objects)
         self._status_step()
@@ -345,6 +361,22 @@ class EnvBase:
             for obj, action in zip(self.objects, action, strict=True)
         ]
 
+        self.build_tree()
+
+    def _objects_refresh(self, record_trajectory: bool = False) -> None:
+        """Synchronize geometry with externally supplied object states.
+
+        Geometry for every object is refreshed before rebuilding the spatial
+        index, so the subsequent sensor phase observes one consistent state
+        snapshot.
+
+        Args:
+            record_trajectory: Append dynamic-object states to their trajectories.
+        """
+        for obj in self.objects:
+            obj.refresh(sensor_step=False)
+            if record_trajectory and not obj.static:
+                obj.trajectory.append(obj.state.copy())
         self.build_tree()
 
     def _objects_sensor_step(self) -> None:
@@ -796,9 +828,8 @@ class EnvBase:
         views (geometry, sensors, collisions) brought up to date.
         """
 
-        for obj in self.objects:
-            obj.refresh()
-        self.build_tree()
+        self._objects_refresh()
+        self._objects_sensor_step()
         self._status_step()
 
     def reset_plot(self) -> None:
@@ -1369,13 +1400,18 @@ class EnvBase:
         return self._world.step_time
 
     @property
+    def step_mode(self) -> str:
+        """Get the active state-advancement mode."""
+        return self._world_param.step_mode
+
+    @property
     def world_param(self):
         """
         Get the world parameters of the simulation.
 
         Returns:
             WorldParam: World parameters including time, control_mode,
-                collision_mode, step_time, and count.
+                collision_mode, step_mode, step_time, and count.
         """
         return self._world_param
 

--- a/irsim/env/env_base3d.py
+++ b/irsim/env/env_base3d.py
@@ -28,7 +28,11 @@ class EnvBase3D(EnvBase):
 
         object_factory = ObjectFactory()
 
-        self._world = World3D(world_name, **self.env_config.parse["world"])
+        self._world = World3D(
+            world_name,
+            world_param_instance=self._world_param,
+            **self.env_config.parse["world"],
+        )
 
         ObjectBase.id_iter = itertools.count()
 

--- a/irsim/env/env_config.py
+++ b/irsim/env/env_config.py
@@ -34,10 +34,12 @@ class EnvConfig:
         world_name: str | None,
         env_param_instance: EnvParam | None = None,
         world_param_instance: WorldParam | None = None,
+        step_mode: str | None = None,
     ) -> None:
         self.object_factory = ObjectFactory()
         self._env_param = env_param_instance
         self._world_param = world_param_instance
+        self._step_mode = step_mode
         self.load_yaml(world_name)
 
     def load_yaml(self, world_name: str | None = None) -> None:
@@ -87,9 +89,8 @@ class EnvConfig:
                 f"{self.world_name} YAML File not found!, using default world config as alternative."
             )
 
-    def _world_kwargs(self) -> dict[str, Any]:
-        """World constructor kwargs from the ``world`` section."""
-        return dict(self.parse["world"])
+        if self._step_mode is not None:
+            self._kwargs_parse["world"]["step_mode"] = self._step_mode
 
     def initialize_objects(self) -> Any:
         """Construct world, objects and plot from the current parsed config.
@@ -105,7 +106,7 @@ class EnvConfig:
         world = World(
             self.world_name,
             world_param_instance=self._world_param,
-            **self._world_kwargs(),
+            **self.parse["world"],
         )
         self.object_factory.world = world
 
@@ -166,7 +167,7 @@ class EnvConfig:
         world = World(
             self.world_name,
             world_param_instance=self._world_param,
-            **self._world_kwargs(),
+            **self.parse["world"],
         )
         self.object_factory.world = world
 

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -1274,16 +1274,23 @@ class ObjectBase:
         self.trajectory = []
         self._invalidate_reactive_cache()
 
-    def refresh(self):
+    def refresh(self, sensor_step: bool = True):
         """
         Refresh state-derived attributes (geometry and sensors) without
         advancing the simulation. Used after ``reset`` so geometry/sensor
         readings reflect the current state without running a kinematic
         step (which would clobber ``_velocity`` and add noise drift).
+
+        Args:
+            sensor_step: Whether to update attached sensors immediately.
+                Environments pass ``False`` while refreshing all object
+                geometries, rebuild the spatial index, then update all sensors
+                from the same state snapshot.
         """
         self._geometry = self.gf.step(self.state)
         self._geometry_valid = shapely.is_valid(self._geometry)
-        self.sensor_step()
+        if sensor_step:
+            self.sensor_step()
         self._invalidate_reactive_cache()
 
     def _invalidate_reactive_cache(self) -> None:

--- a/irsim/world/world.py
+++ b/irsim/world/world.py
@@ -27,6 +27,7 @@ class World:
         step_time (float): Time interval between steps.
         sample_time (float): Time interval between samples.
         offset (list): Offset for the world's position.
+        step_mode (str): State advancement mode ('internal' or 'external').
         control_mode (str): Control mode ('auto' or 'keyboard').
         collision_mode (str): Collision mode ('stop',  , 'unobstructed').
         obstacle_map: ``None``, image path (str), grid ndarray, or generator spec dict.
@@ -42,6 +43,7 @@ class World:
         "step_time",
         "sample_time",
         "offset",
+        "step_mode",
         "control_mode",
         "collision_mode",
         "obstacle_map",
@@ -60,6 +62,7 @@ class World:
         step_time: float = 0.1,
         sample_time: float | None = None,
         offset: list[float] | None = None,
+        step_mode: str = "internal",
         control_mode: str = "auto",
         collision_mode: str = "stop",
         obstacle_map: Any | None = None,
@@ -81,6 +84,9 @@ class World:
             step_time (float): Time interval between steps.
             sample_time (float): Time interval between samples.
             offset (list): Offset for the world's position.
+            step_mode (str): ``internal`` lets IR-SIM advance object states;
+                ``external`` expects callers to update states before each
+                environment step.
             control_mode (str): Control mode ('auto' or 'keyboard').
             collision_mode (str): Collision mode ('stop',  , 'unobstructed').
             obstacle_map: ``None``, image path (str), grid ndarray, or generator spec dict.
@@ -151,12 +157,28 @@ class World:
         self.status = status
 
         # mode
+        self.step_mode = self._validate_step_mode(step_mode)
+        self._wp.step_mode = self.step_mode
         self._wp.control_mode = control_mode
         self._wp.collision_mode = collision_mode
 
         check_unknown_kwargs(
             kwargs, self._VALID_PARAMS, context=" in 'world' config", logger=self.logger
         )
+
+    @staticmethod
+    def _validate_step_mode(step_mode: str) -> str:
+        """Normalize and validate the world state-advancement mode."""
+        if not isinstance(step_mode, str):
+            raise TypeError("step_mode must be a string: 'internal' or 'external'")
+
+        normalized = step_mode.strip().lower()
+        if normalized not in {"internal", "external"}:
+            raise ValueError(
+                f"Unsupported step_mode {step_mode!r}. "
+                "Supported modes are 'internal' and 'external'."
+            )
+        return normalized
 
     def step(self, objects: list[Any] | None = None) -> None:
         """

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -446,7 +446,7 @@ class TestSimulationLoop:
             "  width: 10\n"
             "  step_time: 0.1\n"
             "  step_mode: external\n"
-            "  collision_mode: unobstructed\n"
+            "  collision_mode: stop\n"
             "robot:\n"
             "  - kinematics: {name: diff}\n"
             "    shape: {name: circle, radius: 0.5}\n"
@@ -476,7 +476,13 @@ class TestSimulationLoop:
         np.testing.assert_allclose(robot.state[:, 0], [3, 3, 0])
         np.testing.assert_allclose(robot.velocity[:, 0], [0.4, 0.0])
         assert robot.collision is True
+        assert robot.stop_flag is True
         assert env.time == pytest.approx(0.2)
+        assert len(robot.trajectory) == 2
+
+        env.step()
+
+        assert env.time == pytest.approx(0.3)
         assert len(robot.trajectory) == 2
 
     def test_external_step_rejects_actions(self, env_factory):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -24,6 +24,7 @@ class TestEnvironmentCreation:
         env = env_factory("test_collision_world.yaml")
         assert env is not None
         assert env.robot is not None
+        assert env.step_mode == "internal"
 
     def test_make_with_full_flag(self, env_factory):
         """Test environment creation with full=True for complete setup."""
@@ -36,6 +37,49 @@ class TestEnvironmentCreation:
         """Test environment creation with different projections."""
         env = env_factory("test_multi_objects_world.yaml", projection=projection)
         assert env is not None
+
+    @pytest.mark.parametrize("projection", ["2d", "3d"])
+    def test_make_step_mode_overrides_yaml(self, env_factory, tmp_path, projection):
+        """make(step_mode=...) takes precedence for both projections."""
+        yaml_file = tmp_path / "external_step.yaml"
+        yaml_file.write_text(
+            "world:\n"
+            "  height: 10\n"
+            "  width: 10\n"
+            "  step_mode: external\n"
+            "robot:\n"
+            "  - kinematics: {name: diff}\n"
+            "    state: [1, 1, 0]\n"
+            "    goal: [9, 1, 0]\n"
+            "    behavior: {name: dash}\n"
+        )
+
+        env = env_factory(str(yaml_file), projection=projection, step_mode="internal")
+
+        assert env.step_mode == "internal"
+        assert env.world_param.step_mode == "internal"
+
+    def test_make_step_mode_override_survives_reload(self, env_factory, tmp_path):
+        """The runtime override remains active across reload and random reset."""
+        yaml_file = tmp_path / "internal_step.yaml"
+        yaml_file.write_text(
+            "world:\n"
+            "  height: 10\n"
+            "  width: 10\n"
+            "  step_mode: internal\n"
+            "robot:\n"
+            "  - kinematics: {name: diff}\n"
+            "    state: [1, 1, 0]\n"
+            "    goal: [9, 1, 0]\n"
+            "    behavior: {name: dash}\n"
+        )
+        env = env_factory(str(yaml_file), step_mode="external")
+
+        env.reload()
+        assert env.step_mode == "external"
+
+        env.reset(random=True)
+        assert env.step_mode == "external"
 
     def test_invalid_projection_raises(self):
         """Test that invalid projection raises ValueError."""
@@ -283,6 +327,7 @@ class TestEnvironmentProperties:
         assert wp is not None
         assert hasattr(wp, "control_mode")
         assert hasattr(wp, "collision_mode")
+        assert hasattr(wp, "step_mode")
         assert hasattr(wp, "step_time")
         assert hasattr(wp, "count")
         assert wp.step_time > 0
@@ -391,6 +436,55 @@ class TestSimulationLoop:
         action_list = [[1, 0], [2, 0]]
         action_id = 1
         env.step(action_list, action_id)
+
+    def test_external_step_synchronizes_supplied_state(self, env_factory, tmp_path):
+        """External mode refreshes supplied states without running behaviors."""
+        yaml_file = tmp_path / "external_step.yaml"
+        yaml_file.write_text(
+            "world:\n"
+            "  height: 10\n"
+            "  width: 10\n"
+            "  step_time: 0.1\n"
+            "  step_mode: external\n"
+            "  collision_mode: unobstructed\n"
+            "robot:\n"
+            "  - kinematics: {name: diff}\n"
+            "    shape: {name: circle, radius: 0.5}\n"
+            "    state: [1, 1, 0]\n"
+            "    goal: [9, 1, 0]\n"
+            "    behavior: {name: dash}\n"
+            "obstacle:\n"
+            "  - shape: {name: circle, radius: 0.5}\n"
+            "    state: [3, 3, 0]\n"
+        )
+        env = env_factory(str(yaml_file))
+        robot = env.robot
+        initial_state = robot.state.copy()
+
+        with patch.object(robot, "step", wraps=robot.step) as robot_step:
+            env.step()
+
+        robot_step.assert_not_called()
+        np.testing.assert_allclose(robot.state, initial_state)
+        assert env.time == pytest.approx(0.1)
+        assert len(robot.trajectory) == 1
+
+        robot.set_state([3, 3, 0])
+        robot.set_velocity([0.4, 0.0])
+        env.step()
+
+        np.testing.assert_allclose(robot.state[:, 0], [3, 3, 0])
+        np.testing.assert_allclose(robot.velocity[:, 0], [0.4, 0.0])
+        assert robot.collision is True
+        assert env.time == pytest.approx(0.2)
+        assert len(robot.trajectory) == 2
+
+    def test_external_step_rejects_actions(self, env_factory):
+        """External state mode cannot also run IR-SIM action integration."""
+        env = env_factory("test_collision_world.yaml", step_mode="external")
+
+        with pytest.raises(ValueError, match="step_mode='external'"):
+            env.step(np.array([1.0, 0.0]))
 
     def test_objects_step(self, env_factory):
         """Test internal _objects_step method."""

--- a/tests/test_world_map.py
+++ b/tests/test_world_map.py
@@ -1781,6 +1781,18 @@ class TestWorldUnknownKwargs:
         w = World(name="test")
         assert w.logger is w._env_param.logger
 
+    def test_world_step_mode_default_and_normalization(self):
+        """World defaults to internal stepping and normalizes explicit values."""
+        assert World(name="default").step_mode == "internal"
+        assert World(name="external", step_mode=" EXTERNAL ").step_mode == "external"
+
+    def test_world_invalid_step_mode_raises(self):
+        """World rejects unknown or non-string step modes."""
+        with pytest.raises(ValueError, match="Unsupported step_mode"):
+            World(name="invalid", step_mode="automatic")
+        with pytest.raises(TypeError, match="step_mode must be a string"):
+            World(name="invalid", step_mode=1)
+
 
 class TestWorld3D:
     """World3D depth and offset handling."""


### PR DESCRIPTION
## Motivation

IR-SIM currently owns the state update performed by `env.step()`. This works for built-in behaviors and actions, but an external simulator or middleware may already provide the next object states. Running IR-SIM kinematics again would update those states twice.

This PR adds an explicit state-ownership switch while keeping rendering and other simulation effects consistent in both modes.

## Step modes

### `internal` (default)

Preserves the existing behavior. IR-SIM obtains actions from explicit inputs, keyboard control, group behaviors, or object behaviors, then advances states through its kinematics.

### `external`

The caller updates object states and velocities before calling `env.step()`:

```python
env = irsim.make("world.yaml", step_mode="external")

robot.set_state(state)
robot.set_velocity(velocity)
env.step()
```

IR-SIM does not run behaviors or kinematics in this mode. It still:

- refreshes all object geometry from the same state snapshot;
- rebuilds the collision index before updating sensors;
- updates sensors, collision and arrival status;
- records trajectories for the same rendering and animation behavior;
- advances the world clock.

Passing an action to `env.step()` in external mode raises `ValueError` to prevent mixing the two state-update paths.

## Configuration

The mode can be configured in YAML:

```yaml
world:
  step_mode: internal  # internal or external
```

`irsim.make(..., step_mode=...)` overrides the YAML value for a particular environment. The override applies to both 2D and 3D environments and remains active after reload or randomized reset.

Existing scenarios remain backward compatible because the default is `internal`.