### PR TITLE
refactor: remove duplicated logic and dead code

### DIFF
--- a/irsim/env/env_base.py
+++ b/irsim/env/env_base.py
@@ -11,6 +11,7 @@ Author: Ruihua Han
 
 from __future__ import annotations
 
+import contextlib
 import importlib
 from typing import Any, Literal, cast
 
@@ -40,12 +41,8 @@ from irsim.world import ObjectBase, ObjectFactory
 
 from .env_logger import EnvLogger
 
-try:
+with contextlib.suppress(ImportError):  # KeyboardControl needs pynput or an MPL backend
     from irsim.gui.keyboard_control import KeyboardControl
-
-    keyboard_module = True
-except ImportError:
-    keyboard_module = False
 
 # Define backend preferences for different operating systems
 BACKEND_PREFERENCES = {
@@ -72,8 +69,7 @@ def _set_matplotlib_backend(backend_list: list[str]) -> bool:
 
 
 # Get the current operating system from env_param and set backend
-backends = BACKEND_PREFERENCES.get(env_param.platform_name, ["Agg"])
-backend_set = _set_matplotlib_backend(backends)
+_set_matplotlib_backend(BACKEND_PREFERENCES.get(env_param.platform_name, ["Agg"]))
 
 
 class EnvBase:
@@ -169,9 +165,7 @@ class EnvBase:
         self._env_param = EnvParam()
         self._world_param = WorldParam()
         self._path_manager = PathManager()
-        env_param.bind(self._env_param)
-        world_param.bind(self._world_param)
-        path_param.bind(self._path_manager)
+        self._bind_config()
 
         # init env setting
         self.display = display

--- a/irsim/env/env_config.py
+++ b/irsim/env/env_config.py
@@ -108,56 +108,12 @@ class EnvConfig:
               during in-place reloads.
         """
 
-        world = World(
-            self.world_name,
-            world_param_instance=self._world_param,
-            **self.parse["world"],
-        )
-        self.object_factory.world = world
+        world, objects, robots, obstacles, maps, groups = self._build_scene()
 
-        robot_collection = self.object_factory.create_from_parse(
-            self.parse["robot"], "robot"
-        )
-        obstacle_collection = self.object_factory.create_from_parse(
-            self.parse["obstacle"],
-            "obstacle",
-            group_start_index=(
-                max((obj.group for obj in robot_collection), default=-1) + 1
-            ),
-        )
-        map_collection = self.object_factory.create_from_map(
-            world.obstacle_positions,
-            world.reso,
-            grid_map=world.grid_map,
-            world_offset=world.offset,
-        )
-
-        objects = robot_collection + obstacle_collection + map_collection
-
-        objects.sort(key=attrgetter("id"))
-
-        # Initialize groups (unique and inclusive)
-        group_ids = sorted({obj.group for obj in objects})
-        object_groups = [
-            ObjectGroup([obj for obj in objects if obj.group == gid], gid)
-            for gid in group_ids
-        ]
-
-        env_plot = EnvPlot(world, objects)
-
-        # cache for in-place reload
-        self._env_plot = env_plot
+        self._env_plot = EnvPlot(world, objects)
         self._objects = objects
 
-        return (
-            world,
-            objects,
-            self._env_plot,
-            robot_collection,
-            obstacle_collection,
-            map_collection,
-            object_groups,
-        )
+        return world, objects, self._env_plot, robots, obstacles, maps, groups
 
     def reload_objects(self) -> Any:
         """Rebuild world/objects and update the current figure in-place.
@@ -169,55 +125,15 @@ class EnvConfig:
             Tuple: ``(world, objects, env_plot, robot_collection, obstacle_collection, map_collection)``
         """
 
-        world = World(
-            self.world_name,
-            world_param_instance=self._world_param,
-            **self.parse["world"],
-        )
-        self.object_factory.world = world
+        world, objects, robots, obstacles, maps, groups = self._build_scene()
 
-        robot_collection = self.object_factory.create_from_parse(
-            self.parse["robot"], "robot"
-        )
-        obstacle_collection = self.object_factory.create_from_parse(
-            self.parse["obstacle"],
-            "obstacle",
-            group_start_index=(
-                max((obj.group for obj in robot_collection), default=-1) + 1
-            ),
-        )
-        map_collection = self.object_factory.create_from_map(
-            world.obstacle_positions,
-            world.reso,
-            grid_map=world.grid_map,
-            world_offset=world.offset,
-        )
-
-        objects = robot_collection + obstacle_collection + map_collection
-        objects.sort(key=attrgetter("id"))
-
-        group_ids = sorted({obj.group for obj in objects})
-        object_groups = [
-            ObjectGroup([obj for obj in objects if obj.group == gid], gid)
-            for gid in group_ids
-        ]
-
-        # env_plot = EnvPlot(world, objects, **world.plot_parse)
         self._env_plot.clear_components("all", self._objects)
         self._env_plot._init_plot(world, objects)
 
         # Refresh cached objects so subsequent reloads clear the right set
         self._objects = objects
 
-        return (
-            world,
-            objects,
-            self._env_plot,
-            robot_collection,
-            obstacle_collection,
-            map_collection,
-            object_groups,
-        )
+        return world, objects, self._env_plot, robots, obstacles, maps, groups
 
     def reload_yaml_objects(self, world_name) -> Any:
         """Reload YAML and update the scene using the existing figure.
@@ -233,22 +149,58 @@ class EnvConfig:
             Tuple: ``(world, objects, env_plot, robot_collection, obstacle_collection, map_collection)``
         """
 
-        reload_world_name = world_name if world_name is not None else self.world_name
-        self.load_yaml(reload_world_name)
-        (
-            world,
-            objects,
-            env_plot,
-            robot_collection,
-            obstacle_collection,
-            map_collection,
-            object_groups,
-        ) = self.reload_objects()
+        self.load_yaml(world_name if world_name is not None else self.world_name)
+
+        return self.reload_objects()
+
+    def _build_scene(self) -> Any:
+        """Create the world, its objects, and their groups from the parsed config.
+
+        Shared by :py:meth:`initialize_objects` and :py:meth:`reload_objects`,
+        which differ only in how the resulting scene is drawn.
+
+        Returns:
+            Tuple: ``(world, objects, robot_collection, obstacle_collection,
+            map_collection, object_groups)``
+        """
+
+        world = World(
+            self.world_name,
+            world_param_instance=self._world_param,
+            **self.parse["world"],
+        )
+        self.object_factory.world = world
+
+        robot_collection = self.object_factory.create_from_parse(
+            self.parse["robot"], "robot"
+        )
+        obstacle_collection = self.object_factory.create_from_parse(
+            self.parse["obstacle"],
+            "obstacle",
+            group_start_index=(
+                max((obj.group for obj in robot_collection), default=-1) + 1
+            ),
+        )
+        map_collection = self.object_factory.create_from_map(
+            world.obstacle_positions,
+            world.reso,
+            grid_map=world.grid_map,
+            world_offset=world.offset,
+        )
+
+        objects = robot_collection + obstacle_collection + map_collection
+        objects.sort(key=attrgetter("id"))
+
+        # Initialize groups (unique and inclusive)
+        group_ids = sorted({obj.group for obj in objects})
+        object_groups = [
+            ObjectGroup([obj for obj in objects if obj.group == gid], gid)
+            for gid in group_ids
+        ]
 
         return (
             world,
             objects,
-            env_plot,
             robot_collection,
             obstacle_collection,
             map_collection,

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -25,7 +25,6 @@ from matplotlib.patches import (
     Ellipse,
     PathPatch,
     Polygon,
-    Rectangle,
     Wedge,
 )
 from matplotlib.path import Path
@@ -847,7 +846,7 @@ def draw_patch(
 
     - circle: use ``state`` (x,y,theta), ``radius``, and optional ``center`` (body-frame
       offset); created in the body frame and transformed, matching the collision geometry
-    - rectangle: prefer ``vertices`` (2xN) else use ``width``/``height`` with ``state`` transform
+    - rectangle: use ``vertices`` (2xN), as for polygon
     - polygon: use ``vertices`` (2xN)
     - compound: use a local-frame Shapely Polygon or MultiPolygon as ``geometry``
     - ellipse: use ``width``/``height`` with ``state`` transform
@@ -929,33 +928,17 @@ def _circle_patch(radius: float | None = None, center: Any = None, **_: Any) -> 
     return Circle(xy, radius)
 
 
-def _rectangle_patch(
-    vertices: np.ndarray | None = None,
-    width: float | None = None,
-    height: float | None = None,
-    center: Any = None,
-    **_: Any,
-) -> Any:
-    """Build a rectangle from its vertices, or from width and height.
+def _rectangle_patch(vertices: np.ndarray | None = None, **_: Any) -> Polygon:
+    """Build a rectangle from its body-frame vertices.
 
-    ``center`` is the body-frame center of the box, as it is for a circle. It
-    defaults to the origin, which matches the collision geometry of a plain
-    rectangle; an Ackermann box, offset from the origin by half a wheelbase,
-    passes its own centroid so the two still coincide.
+    A rectangle is a four-vertex polygon, and ``RectangleGeometry`` already
+    carries the box placement - including the Ackermann offset that puts the
+    body origin on the rear axle - so the vertices are the whole description.
     """
-    if vertices is not None:
-        return Polygon(vertices.T)
+    if vertices is None:
+        raise ValueError("rectangle requires vertices (2xN)")
 
-    if width is None or height is None:
-        raise ValueError("rectangle requires either vertices or width/height")
-
-    if center is None:
-        cx, cy = 0.0, 0.0
-    else:
-        c = np.asarray(center, dtype=float).flatten()
-        cx, cy = float(c[0]), float(c[1])
-
-    return Rectangle((cx - width / 2.0, cy - height / 2.0), width, height)
+    return Polygon(vertices.T)
 
 
 def _polygon_patch(vertices: np.ndarray | None = None, **_: Any) -> Polygon:

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -232,11 +232,16 @@ class EnvPlot:
         if objects is None:
             objects = []
         if mode == "static":
-            [obj.plot(self.ax, **kwargs) for obj in objects if obj.static]
+            for obj in objects:
+                if obj.static:
+                    obj.plot(self.ax, **kwargs)
         elif mode == "dynamic":
-            [obj.plot(self.ax, **kwargs) for obj in objects if not obj.static]
+            for obj in objects:
+                if not obj.static:
+                    obj.plot(self.ax, **kwargs)
         elif mode == "all":
-            [obj.plot(self.ax, **kwargs) for obj in objects]
+            for obj in objects:
+                obj.plot(self.ax, **kwargs)
         else:
             self.logger.error("Error: Invalid draw mode")
 
@@ -252,29 +257,35 @@ class EnvPlot:
         """
         if objects is None:
             objects = []
-        if mode == "dynamic":
-            [obj.plot_clear() for obj in objects if not obj.static]
-            [line.pop(0).remove() for line in self.dyna_line_list]
-            [points.remove() for points in self.dyna_point_list]
-            [quiver.remove() for quiver in self.dyna_quiver_list]
 
-            self.dyna_line_list = []
-            self.dyna_point_list = []
-            self.dyna_quiver_list = []
+        if mode == "dynamic":
+            for obj in objects:
+                if not obj.static:
+                    obj.plot_clear()
+            self._clear_dynamic_artists()
 
         elif mode == "static":
-            [obj.plot_clear() for obj in objects if obj.static]
+            for obj in objects:
+                if obj.static:
+                    obj.plot_clear()
 
         elif mode == "all":
-            [obj.plot_clear(all=True) for obj in objects]
+            for obj in objects:
+                obj.plot_clear(all=True)
+            self._clear_dynamic_artists()
 
-            [line.pop(0).remove() for line in self.dyna_line_list]
-            [points.remove() for points in self.dyna_point_list]
-            [quiver.remove() for quiver in self.dyna_quiver_list]
+    def _clear_dynamic_artists(self) -> None:
+        """Remove the per-step lines, points, and quivers, then forget them."""
+        for line in self.dyna_line_list:
+            line.pop(0).remove()
+        for points in self.dyna_point_list:
+            points.remove()
+        for quiver in self.dyna_quiver_list:
+            quiver.remove()
 
-            self.dyna_line_list = []
-            self.dyna_point_list = []
-            self.dyna_quiver_list = []
+        self.dyna_line_list = []
+        self.dyna_point_list = []
+        self.dyna_quiver_list = []
 
     def draw_grid_map(self, grid_map: Any | None = None, **kwargs: Any) -> None:
         """

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -933,18 +933,29 @@ def _rectangle_patch(
     vertices: np.ndarray | None = None,
     width: float | None = None,
     height: float | None = None,
+    center: Any = None,
     **_: Any,
 ) -> Any:
-    """Build a rectangle from absolute vertices, or from width and height."""
+    """Build a rectangle from its vertices, or from width and height.
+
+    ``center`` is the body-frame center of the box, as it is for a circle. It
+    defaults to the origin, which matches the collision geometry of a plain
+    rectangle; an Ackermann box, offset from the origin by half a wheelbase,
+    passes its own centroid so the two still coincide.
+    """
     if vertices is not None:
         return Polygon(vertices.T)
 
     if width is None or height is None:
         raise ValueError("rectangle requires either vertices or width/height")
 
-    # Centered on the body-frame origin, like the collision geometry, so the
-    # state transform places it the same way.
-    return Rectangle((-width / 2.0, -height / 2.0), width, height)
+    if center is None:
+        cx, cy = 0.0, 0.0
+    else:
+        c = np.asarray(center, dtype=float).flatten()
+        cx, cy = float(c[0]), float(c[1])
+
+    return Rectangle((cx - width / 2.0, cy - height / 2.0), width, height)
 
 
 def _polygon_patch(vertices: np.ndarray | None = None, **_: Any) -> Polygon:

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -862,183 +862,22 @@ def draw_patch(
     Returns the created matplotlib artist (patch, line, or list from ax.plot).
     """
 
-    created_element = None
+    state = state if state is not None else np.zeros((3, 1))
 
     # Normalize some common styling kwargs
     facecolor = kwargs.pop("facecolor", None)
     edgecolor = kwargs.pop("edgecolor", None)
     alpha = kwargs.pop("alpha", None)
     fill = kwargs.pop("fill", None)
-    center = kwargs.pop("center", None)
 
-    state = state if state is not None else np.zeros((3, 1))
+    if shape in ("line", "linestring"):
+        # Lines are artists rather than patches, so they are styled directly.
+        return _draw_line(ax, vertices, color, alpha, zorder, linestyle, fill, kwargs)
 
-    # Circle
-    if shape == "circle":
-        if radius is None:
-            raise ValueError("circle requires radius")
-
-        use_radius = radius
-
-        if center is None:
-            xy = (0.0, 0.0)
-        else:
-            c = np.asarray(center, dtype=float).flatten()
-            xy = (c[0], c[1])
-        # Create at the body-frame center; translate/rotate with transform
-        patch = Circle(xy, use_radius)
-        created_element = ax.add_patch(patch)
-        set_patch_property(
-            created_element,
-            ax,
-            state=state,
-            color=color,
-            facecolor=facecolor,
-            edgecolor=edgecolor,
-            alpha=alpha,
-            zorder=zorder,
-            linestyle=linestyle,
-            fill=fill,
-        )
-
-    # Rectangle (prefer vertices; otherwise width/height + transform)
-    elif shape == "rectangle":
-        if vertices is not None:
-            patch = Polygon(vertices.T)
-            created_element = ax.add_patch(patch)
-            set_patch_property(
-                created_element,
-                ax,
-                state=state,  # vertices are absolute
-                color=color,
-                facecolor=facecolor,
-                edgecolor=edgecolor,
-                alpha=alpha,
-                zorder=zorder,
-                linestyle=linestyle,
-                fill=fill,
-            )
-        else:
-            width = kwargs.pop("width", None)
-            height = kwargs.pop("height", None)
-            if width is None or height is None:
-                raise ValueError("rectangle requires either vertices or width/height")
-
-            xy = (float(vertices[0, 0]), float(vertices[1, 0]))
-            patch = Rectangle(xy, width, height)
-            created_element = ax.add_patch(patch)
-            set_patch_property(
-                created_element,
-                ax,
-                state=state,
-                color=color,
-                facecolor=facecolor,
-                edgecolor=edgecolor,
-                alpha=alpha,
-                zorder=zorder,
-                linestyle=linestyle,
-                fill=fill,
-            )
-
-    # Polygon
-    elif shape == "polygon":
-        if vertices is None:
-            raise ValueError("polygon requires vertices (2xN)")
-        patch = Polygon(vertices.T)
-        created_element = ax.add_patch(patch)
-        set_patch_property(
-            created_element,
-            ax,
-            state=state,  # vertices are absolute
-            color=color,
-            facecolor=facecolor,
-            edgecolor=edgecolor,
-            alpha=alpha,
-            zorder=zorder,
-            linestyle=linestyle,
-            fill=fill,
-        )
-
-    # Compound Polygon / MultiPolygon
-    elif shape == "compound":
-        if geometry is None:
-            raise ValueError("compound requires a Polygon or MultiPolygon geometry")
-        patch = PathPatch(geometry_to_path(geometry))
-        created_element = ax.add_patch(patch)
-        set_patch_property(
-            created_element,
-            ax,
-            state=state,
-            color=color,
-            facecolor=facecolor,
-            edgecolor=edgecolor,
-            alpha=alpha,
-            zorder=zorder,
-            linestyle=linestyle,
-            fill=fill,
-        )
-
-    # Ellipse
-    elif shape == "ellipse":
-        width = kwargs.pop("width", None)
-        height = kwargs.pop("height", None)
-        if width is None or height is None:
-            raise ValueError("ellipse requires width and height")
-        patch = Ellipse((0.0, 0.0), width, height, angle=0.0)
-        created_element = ax.add_patch(patch)
-        set_patch_property(
-            created_element,
-            ax,
-            state=state,
-            color=color,
-            facecolor=facecolor,
-            edgecolor=edgecolor,
-            alpha=alpha,
-            zorder=zorder,
-            linestyle=linestyle,
-            fill=fill,
-        )
-
-    # Wedge (FOV)
-    elif shape == "wedge":
-        use_radius = radius if radius is not None else kwargs.pop("radius", None)
-        if use_radius is None:
-            raise ValueError("wedge requires radius")
-        if "theta1" in kwargs and "theta2" in kwargs:
-            theta1 = kwargs.pop("theta1")
-            theta2 = kwargs.pop("theta2")
-        else:
-            # build from fov in radians centered at 0
-            fov = kwargs.pop("fov", np.pi)
-            theta1 = -180 * fov / (2 * np.pi)
-            theta2 = 180 * fov / (2 * np.pi)
-        patch = Wedge((0.0, 0.0), use_radius, theta1, theta2)
-        created_element = ax.add_patch(patch)
-        set_patch_property(
-            created_element,
-            ax,
-            state=state,
-            color=color,
-            facecolor=facecolor,
-            edgecolor=edgecolor,
-            alpha=alpha,
-            zorder=zorder,
-            linestyle=linestyle,
-            fill=fill,
-        )
-
-    # Arrow (velocity/heading)
-    elif shape == "arrow":
-        arrow_length = kwargs.pop("arrow_length", 0.4)
-        arrow_width = kwargs.pop("arrow_width", 0.6)
-        # Orientation: use provided theta or state[2]
-        theta = kwargs.pop("theta", float(state[2, 0]) if state.shape[0] >= 3 else 0.0)
-        x = float(state[0, 0])
-        y = float(state[1, 0])
-        dx = float(arrow_length * cos(theta))
-        dy = float(arrow_length * sin(theta))
-        patch = Arrow(x, y, dx, dy, width=arrow_width)
-        created_element = ax.add_patch(patch)
+    if shape == "arrow":
+        # The arrow is built in absolute coordinates and has its own color and
+        # zorder fallbacks, so it is styled without a state transform.
+        created_element = ax.add_patch(_arrow_patch(state, kwargs))
         set_patch_property(
             created_element,
             ax,
@@ -1048,50 +887,180 @@ def draw_patch(
             zorder=zorder if zorder is not None else kwargs.pop("arrow_zorder", None),
             fill=fill,
         )
-
-    # Line / LineString
-    elif shape in ("line", "linestring"):
-        if vertices is None:
-            raise ValueError("line/linestring requires vertices (2xN)")
-        if isinstance(ax, Axes3D):
-            line3d = art3d.Line3D(
-                vertices[0, :], vertices[1, :], zs=kwargs.pop("z", np.zeros((3,)))
-            )
-            if color is not None:
-                line3d.set_color(color)
-            if alpha is not None:
-                line3d.set_alpha(alpha)
-            if zorder is not None:
-                line3d.set_zorder(zorder)
-            if fill is not None:
-                line3d.set_fill(fill)
-            ax.add_line(line3d)
-            created_element = line3d
-        else:
-            line2d = Line2D(vertices[0, :], vertices[1, :])
-            if linestyle is not None:
-                line2d.set_linestyle(linestyle)
-            if color is not None:
-                line2d.set_color(color)
-            if alpha is not None:
-                line2d.set_alpha(alpha)
-            if zorder is not None:
-                line2d.set_zorder(zorder)
-            ax.add_line(line2d)
-            created_element = line2d
-
     else:
-        raise ValueError(f"Unsupported shape type: {shape}")
+        builder = _PATCH_BUILDERS.get(shape)
+        if builder is None:
+            raise ValueError(f"Unsupported shape type: {shape}")
+
+        created_element = ax.add_patch(
+            builder(radius=radius, vertices=vertices, geometry=geometry, **kwargs)
+        )
+        set_patch_property(
+            created_element,
+            ax,
+            state=state,
+            color=color,
+            facecolor=facecolor,
+            edgecolor=edgecolor,
+            alpha=alpha,
+            zorder=zorder,
+            linestyle=linestyle,
+            fill=fill,
+        )
 
     # 3D conversion for patches if needed
-    if (
-        isinstance(ax, Axes3D)
-        and created_element is not None
-        and shape not in ("line", "linestring")
-    ):
+    if isinstance(ax, Axes3D) and created_element is not None:
         art3d.patch_2d_to_3d(created_element, z=kwargs.pop("z", 0), zdir="z")
 
     return created_element
+
+
+def _circle_patch(radius: float | None = None, center: Any = None, **_: Any) -> Circle:
+    """Build a circle at the body-frame center, ready for the state transform."""
+    if radius is None:
+        raise ValueError("circle requires radius")
+
+    if center is None:
+        xy = (0.0, 0.0)
+    else:
+        c = np.asarray(center, dtype=float).flatten()
+        xy = (c[0], c[1])
+
+    return Circle(xy, radius)
+
+
+def _rectangle_patch(
+    vertices: np.ndarray | None = None,
+    width: float | None = None,
+    height: float | None = None,
+    **_: Any,
+) -> Any:
+    """Build a rectangle from absolute vertices, or from width and height."""
+    if vertices is not None:
+        return Polygon(vertices.T)
+
+    if width is None or height is None:
+        raise ValueError("rectangle requires either vertices or width/height")
+
+    xy = (float(vertices[0, 0]), float(vertices[1, 0]))
+    return Rectangle(xy, width, height)
+
+
+def _polygon_patch(vertices: np.ndarray | None = None, **_: Any) -> Polygon:
+    """Build a polygon from absolute vertices."""
+    if vertices is None:
+        raise ValueError("polygon requires vertices (2xN)")
+
+    return Polygon(vertices.T)
+
+
+def _compound_patch(geometry: Any = None, **_: Any) -> PathPatch:
+    """Build one patch for a Polygon or MultiPolygon, holes included."""
+    if geometry is None:
+        raise ValueError("compound requires a Polygon or MultiPolygon geometry")
+
+    return PathPatch(geometry_to_path(geometry))
+
+
+def _ellipse_patch(
+    width: float | None = None, height: float | None = None, **_: Any
+) -> Ellipse:
+    """Build a body-frame ellipse, ready for the state transform."""
+    if width is None or height is None:
+        raise ValueError("ellipse requires width and height")
+
+    return Ellipse((0.0, 0.0), width, height, angle=0.0)
+
+
+def _wedge_patch(
+    radius: float | None = None,
+    theta1: float | None = None,
+    theta2: float | None = None,
+    fov: float | None = None,
+    **_: Any,
+) -> Wedge:
+    """Build a field-of-view wedge from explicit angles, or from an fov."""
+    if radius is None:
+        raise ValueError("wedge requires radius")
+
+    if theta1 is None or theta2 is None:
+        # build from fov in radians centered at 0
+        fov = np.pi if fov is None else fov
+        theta1 = -180 * fov / (2 * np.pi)
+        theta2 = 180 * fov / (2 * np.pi)
+
+    return Wedge((0.0, 0.0), radius, theta1, theta2)
+
+
+# Shapes drawn as a patch: each builder takes what it needs and ignores the rest,
+# after which draw_patch adds and styles the patch the same way for all of them.
+_PATCH_BUILDERS = {
+    "circle": _circle_patch,
+    "rectangle": _rectangle_patch,
+    "polygon": _polygon_patch,
+    "compound": _compound_patch,
+    "ellipse": _ellipse_patch,
+    "wedge": _wedge_patch,
+}
+
+
+def _arrow_patch(state: np.ndarray, kwargs: dict[str, Any]) -> Arrow:
+    """Build a heading arrow in absolute coordinates."""
+    arrow_length = kwargs.pop("arrow_length", 0.4)
+    arrow_width = kwargs.pop("arrow_width", 0.6)
+    # Orientation: use provided theta or state[2]
+    theta = kwargs.pop("theta", float(state[2, 0]) if state.shape[0] >= 3 else 0.0)
+
+    return Arrow(
+        float(state[0, 0]),
+        float(state[1, 0]),
+        float(arrow_length * cos(theta)),
+        float(arrow_length * sin(theta)),
+        width=arrow_width,
+    )
+
+
+def _draw_line(
+    ax: Any,
+    vertices: np.ndarray | None,
+    color: str | None,
+    alpha: float | None,
+    zorder: int | None,
+    linestyle: str | None,
+    fill: bool | None,
+    kwargs: dict[str, Any],
+) -> Any:
+    """Add a 2D or 3D line for the given vertices and style it directly."""
+    if vertices is None:
+        raise ValueError("line/linestring requires vertices (2xN)")
+
+    if isinstance(ax, Axes3D):
+        line3d = art3d.Line3D(
+            vertices[0, :], vertices[1, :], zs=kwargs.pop("z", np.zeros((3,)))
+        )
+        if color is not None:
+            line3d.set_color(color)
+        if alpha is not None:
+            line3d.set_alpha(alpha)
+        if zorder is not None:
+            line3d.set_zorder(zorder)
+        if fill is not None:
+            line3d.set_fill(fill)
+        ax.add_line(line3d)
+        return line3d
+
+    line2d = Line2D(vertices[0, :], vertices[1, :])
+    if linestyle is not None:
+        line2d.set_linestyle(linestyle)
+    if color is not None:
+        line2d.set_color(color)
+    if alpha is not None:
+        line2d.set_alpha(alpha)
+    if zorder is not None:
+        line2d.set_zorder(zorder)
+    ax.add_line(line2d)
+
+    return line2d
 
 
 def set_patch_property(

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -25,6 +25,7 @@ from matplotlib.patches import (
     Ellipse,
     PathPatch,
     Polygon,
+    Rectangle,
     Wedge,
 )
 from matplotlib.path import Path
@@ -846,7 +847,7 @@ def draw_patch(
 
     - circle: use ``state`` (x,y,theta), ``radius``, and optional ``center`` (body-frame
       offset); created in the body frame and transformed, matching the collision geometry
-    - rectangle: use ``vertices`` (2xN), as for polygon
+    - rectangle: prefer ``vertices`` (2xN) else use ``width``/``height`` with ``state`` transform
     - polygon: use ``vertices`` (2xN)
     - compound: use a local-frame Shapely Polygon or MultiPolygon as ``geometry``
     - ellipse: use ``width``/``height`` with ``state`` transform
@@ -928,17 +929,33 @@ def _circle_patch(radius: float | None = None, center: Any = None, **_: Any) -> 
     return Circle(xy, radius)
 
 
-def _rectangle_patch(vertices: np.ndarray | None = None, **_: Any) -> Polygon:
-    """Build a rectangle from its body-frame vertices.
+def _rectangle_patch(
+    vertices: np.ndarray | None = None,
+    width: float | None = None,
+    height: float | None = None,
+    center: Any = None,
+    **_: Any,
+) -> Any:
+    """Build a rectangle from its vertices, or from width and height.
 
-    A rectangle is a four-vertex polygon, and ``RectangleGeometry`` already
-    carries the box placement - including the Ackermann offset that puts the
-    body origin on the rear axle - so the vertices are the whole description.
+    ``center`` is the body-frame center of the box, as it is for a circle. It
+    defaults to the origin, which matches the collision geometry of a plain
+    rectangle; an Ackermann box, offset from the origin by half a wheelbase,
+    passes its own centroid so the two still coincide.
     """
-    if vertices is None:
-        raise ValueError("rectangle requires vertices (2xN)")
+    if vertices is not None:
+        return Polygon(vertices.T)
 
-    return Polygon(vertices.T)
+    if width is None or height is None:
+        raise ValueError("rectangle requires either vertices or width/height")
+
+    if center is None:
+        cx, cy = 0.0, 0.0
+    else:
+        c = np.asarray(center, dtype=float).flatten()
+        cx, cy = float(c[0]), float(c[1])
+
+    return Rectangle((cx - width / 2.0, cy - height / 2.0), width, height)
 
 
 def _polygon_patch(vertices: np.ndarray | None = None, **_: Any) -> Polygon:

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -149,6 +149,10 @@ class EnvPlot:
 
         self.ax.set_xlim(self.world.x_range)
         self.ax.set_ylim(self.world.y_range)
+        # Centre the camera before the first frame is drawn: the limits above
+        # frame the whole world, so a follow viewpoint would otherwise show one
+        # frame at the world centre and only jump to its target on the next step.
+        self.set_ax_viewpoint(objects)
 
         self.ax.set_xlabel("x [m]")
         self.ax.set_ylabel("y [m]")
@@ -273,6 +277,9 @@ class EnvPlot:
             for obj in objects:
                 obj.plot_clear(all=True)
             self._clear_dynamic_artists()
+
+        else:
+            self.logger.error("Error: Invalid clear mode")
 
     def _clear_dynamic_artists(self) -> None:
         """Remove the per-step lines, points, and quivers, then forget them."""
@@ -1064,9 +1071,11 @@ def _draw_line(
         raise ValueError("line/linestring requires vertices (2xN)")
 
     if isinstance(ax, Axes3D):
-        line3d = art3d.Line3D(
-            vertices[0, :], vertices[1, :], zs=kwargs.pop("z", np.zeros((3,)))
-        )
+        zs = kwargs.pop("z", None)
+        if zs is None:
+            # One height per vertex: a shorter default breaks the draw.
+            zs = np.zeros(vertices.shape[1])
+        line3d = art3d.Line3D(vertices[0, :], vertices[1, :], zs=zs)
         if color is not None:
             line3d.set_color(color)
         if alpha is not None:

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -942,8 +942,9 @@ def _rectangle_patch(
     if width is None or height is None:
         raise ValueError("rectangle requires either vertices or width/height")
 
-    xy = (float(vertices[0, 0]), float(vertices[1, 0]))
-    return Rectangle(xy, width, height)
+    # Centered on the body-frame origin, like the collision geometry, so the
+    # state transform places it the same way.
+    return Rectangle((-width / 2.0, -height / 2.0), width, height)
 
 
 def _polygon_patch(vertices: np.ndarray | None = None, **_: Any) -> Polygon:

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -885,7 +885,7 @@ def draw_patch(
 
     if shape in ("line", "linestring"):
         # Lines are artists rather than patches, so they are styled directly.
-        return _draw_line(ax, vertices, color, alpha, zorder, linestyle, fill, kwargs)
+        return _draw_line(ax, vertices, color, alpha, zorder, linestyle, kwargs)
 
     if shape == "arrow":
         # The arrow is built in world coordinates and has its own color and
@@ -1052,14 +1052,13 @@ def _draw_line(
     alpha: float | None,
     zorder: int | None,
     linestyle: str | None,
-    fill: bool | None,
     kwargs: dict[str, Any],
 ) -> Any:
     """Add a 2D or 3D line and style it directly.
 
     The vertices are used as data coordinates: a line carries no patch
     transform, so ``state`` never reaches it and the vertices must be in world
-    coordinates.
+    coordinates. ``fill`` does not apply to a line and is ignored.
     """
     if vertices is None:
         raise ValueError("line/linestring requires vertices (2xN)")
@@ -1074,8 +1073,6 @@ def _draw_line(
             line3d.set_alpha(alpha)
         if zorder is not None:
             line3d.set_zorder(zorder)
-        if fill is not None:
-            line3d.set_fill(fill)
         ax.add_line(line3d)
         return line3d
 

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -847,13 +847,26 @@ def draw_patch(
 
     - circle: use ``state`` (x,y,theta), ``radius``, and optional ``center`` (body-frame
       offset); created in the body frame and transformed, matching the collision geometry
-    - rectangle: prefer ``vertices`` (2xN) else use ``width``/``height`` with ``state`` transform
-    - polygon: use ``vertices`` (2xN)
+    - rectangle: prefer body-frame ``vertices`` (2xN) else use ``width``/``height``
+      with an optional ``center``; transformed by ``state``
+    - polygon: use body-frame ``vertices`` (2xN); transformed by ``state``
     - compound: use a local-frame Shapely Polygon or MultiPolygon as ``geometry``
     - ellipse: use ``width``/``height`` with ``state`` transform
     - wedge: use ``radius`` and either ``theta1``/``theta2`` (deg) or ``fov`` (rad); transformed by ``state``
     - arrow: use ``state`` for position/orientation or provide ``theta``; supports ``arrow_length`` and ``arrow_width``
-    - line|linestring: use ``vertices`` (2xN) to draw a line element
+    - line|linestring: use ``vertices`` (2xN) in world coordinates; ``state`` is not
+      applied to them
+
+    Coordinate frames:
+
+    - A patch is built in the object's body frame and placed by ``state``, which
+      rotates by theta and then translates by (x, y). Pass body-frame vertices -
+      :py:attr:`~irsim.world.object_base.ObjectBase.original_vertices` - together
+      with the pose, as ``ObjectPlot`` does; passing vertices that already carry
+      the pose applies it twice. Pass ``state=None`` for vertices that are
+      already in world coordinates.
+    - A line is added with its vertices as data coordinates and receives no
+      transform, so its vertices are always world coordinates.
 
     Styling:
 
@@ -875,13 +888,13 @@ def draw_patch(
         return _draw_line(ax, vertices, color, alpha, zorder, linestyle, fill, kwargs)
 
     if shape == "arrow":
-        # The arrow is built in absolute coordinates and has its own color and
+        # The arrow is built in world coordinates and has its own color and
         # zorder fallbacks, so it is styled without a state transform.
         created_element = ax.add_patch(_arrow_patch(state, kwargs))
         set_patch_property(
             created_element,
             ax,
-            state=None,  # absolute coords already applied
+            state=None,  # world coords already applied
             color=color if color is not None else kwargs.pop("arrow_color", None),
             alpha=alpha,
             zorder=zorder if zorder is not None else kwargs.pop("arrow_zorder", None),
@@ -936,7 +949,7 @@ def _rectangle_patch(
     center: Any = None,
     **_: Any,
 ) -> Any:
-    """Build a rectangle from its vertices, or from width and height.
+    """Build a rectangle from its body-frame vertices, or from width and height.
 
     ``center`` is the body-frame center of the box, as it is for a circle. It
     defaults to the origin, which matches the collision geometry of a plain
@@ -959,7 +972,7 @@ def _rectangle_patch(
 
 
 def _polygon_patch(vertices: np.ndarray | None = None, **_: Any) -> Polygon:
-    """Build a polygon from absolute vertices."""
+    """Build a polygon from its body-frame vertices, placed later by ``state``."""
     if vertices is None:
         raise ValueError("polygon requires vertices (2xN)")
 
@@ -1017,7 +1030,7 @@ _PATCH_BUILDERS = {
 
 
 def _arrow_patch(state: np.ndarray, kwargs: dict[str, Any]) -> Arrow:
-    """Build a heading arrow in absolute coordinates."""
+    """Build a heading arrow in world coordinates, from the pose in ``state``."""
     arrow_length = kwargs.pop("arrow_length", 0.4)
     arrow_width = kwargs.pop("arrow_width", 0.6)
     # Orientation: use provided theta or state[2]
@@ -1042,7 +1055,12 @@ def _draw_line(
     fill: bool | None,
     kwargs: dict[str, Any],
 ) -> Any:
-    """Add a 2D or 3D line for the given vertices and style it directly."""
+    """Add a 2D or 3D line and style it directly.
+
+    The vertices are used as data coordinates: a line carries no patch
+    transform, so ``state`` never reaches it and the vertices must be in world
+    coordinates.
+    """
     if vertices is None:
         raise ValueError("line/linestring requires vertices (2xN)")
 

--- a/irsim/gui/keyboard_control.py
+++ b/irsim/gui/keyboard_control.py
@@ -336,8 +336,15 @@ class KeyboardControl:
             "escape": self._quit_env,
         }
         command = commands.get(key)
-        if command is not None:
-            command()
+        if command is None:
+            return
+
+        # Every command but the control-mode switch acts on the environment.
+        if self.env_ref is None and command != self._toggle_control_mode:
+            self.logger.warning(f"Environment reference not set. Ignoring '{key}'.")
+            return
+
+        command()
 
     # ------------------------------------------------------------------
     # pynput key event handlers (backend = 'pynput')

--- a/irsim/gui/keyboard_control.py
+++ b/irsim/gui/keyboard_control.py
@@ -391,8 +391,10 @@ class KeyboardControl:
         try:
             # Keys are matched as typed here: 'Z'/'C' carry the shift variant.
             char = key.char or ""
-            self._release_motion_key(char)
-            self._adjust_speed_limit(char.lower(), char.isupper())
+            if self._world_param.control_mode == "keyboard":
+                self._release_motion_key(char)
+                self._adjust_speed_limit(char.lower(), char.isupper())
+
             self._run_command_key(char)
             self._update_key_vel()
 

--- a/irsim/gui/keyboard_control.py
+++ b/irsim/gui/keyboard_control.py
@@ -39,7 +39,8 @@ class KeyboardControl:
     Control mode gating:
         - Robot control keys (w/s/a/d, q/e, z/c, alt+number) only take effect when
           ``world_param.control_mode == "keyboard"``.
-        - Environment keys (space to pause/resume, r to reset, esc to quit) are always active.
+        - Environment keys (space to pause/resume, r to reset, esc to quit) are active
+          in either control mode, and are ignored when no ``env_ref`` was given.
 
     Key mappings (both backends):
         - w/s: Increase/decrease linear velocity (forward/backward)
@@ -66,7 +67,9 @@ class KeyboardControl:
         Initialize keyboard control for the environment.
 
         Args:
-            env_ref: Reference to the environment instance. Used for pause/resume and reset.
+            env_ref: Reference to the environment instance, used by the command
+                keys - reset, pause/resume, reload, debug, save figure, display
+                and quit. Those keys are ignored when it is omitted.
             keyboard_kwargs (dict): Optional settings for keyboard control.
 
                 - key_lv_max (float): Maximum linear velocity. Default is 3.0.
@@ -324,7 +327,11 @@ class KeyboardControl:
             self.logger.info("switch to keyboard control")
 
     def _run_command_key(self, key: str) -> None:
-        """Run the environment command bound to a released key, if any."""
+        """Run the environment command bound to a released key, if any.
+
+        A command that acts on the environment is ignored when the control was
+        built without a reference to one.
+        """
         commands = {
             "r": self._reset_env,
             "space": self._toggle_pause,

--- a/irsim/gui/keyboard_control.py
+++ b/irsim/gui/keyboard_control.py
@@ -162,14 +162,6 @@ class KeyboardControl:
 
             headers = ["Key", "Function"]
             print(self._format_grid_table(headers, commands))
-        # else:
-        #     commands = [
-        #         ["r", "reset the environment"],
-        #         ["space", "pause/resume the environment"],
-        #         ["esc", "quit the environment"],
-        #         ["x", "switch keyboard control and auto control"],
-        #         ["l", "reload the environment"],
-        #     ]
 
         if self.backend == "pynput" and not _PYNPUT_AVAILABLE:
             self.logger.warning("pynput is not available. Using matplotlib backend.")
@@ -219,6 +211,15 @@ class KeyboardControl:
             self._mpl_release_cid = fig.canvas.mpl_connect(
                 "key_release_event", self._on_mpl_release
             )
+
+    def _toggle_control_mode(self) -> None:
+        """Switch between keyboard and automatic control, and log the new mode."""
+        if self._world_param.control_mode == "keyboard":
+            self._world_param.control_mode = "auto"
+            self.logger.info("switch to auto control")
+        else:
+            self._world_param.control_mode = "keyboard"
+            self.logger.info("switch to keyboard control")
 
     def _on_pynput_press(self, key: Any) -> None:
         """
@@ -320,12 +321,7 @@ class KeyboardControl:
 
             # Switch control mode with 'x'
             if key.char == "x":
-                if self._world_param.control_mode == "keyboard":
-                    self._world_param.control_mode = "auto"
-                    self.logger.info("switch to auto control")
-                else:
-                    self._world_param.control_mode = "keyboard"
-                    self.logger.info("switch to keyboard control")
+                self._toggle_control_mode()
 
             if key.char == "v":
                 self.logger.info("save the figure")
@@ -463,12 +459,7 @@ class KeyboardControl:
 
         # Switch control mode with 'x'
         if base == "x":
-            if self._world_param.control_mode == "keyboard":
-                self._world_param.control_mode = "auto"
-                self.logger.info("switch to auto control")
-            else:
-                self._world_param.control_mode = "keyboard"
-                self.logger.info("switch to keyboard control")
+            self._toggle_control_mode()
 
         if base == "l":
             self.env_ref.reload_flag = True

--- a/irsim/gui/keyboard_control.py
+++ b/irsim/gui/keyboard_control.py
@@ -212,6 +212,108 @@ class KeyboardControl:
                 "key_release_event", self._on_mpl_release
             )
 
+    # ------------------------------------------------------------------
+    # Shared key actions (both backends)
+    # ------------------------------------------------------------------
+
+    def _select_robot_id(self, digit: str) -> None:
+        """Point keyboard control at the robot with the given id."""
+        target = int(digit)
+        if self.env_ref and target >= self.env_ref.robot_number:
+            self.logger.warning(
+                f"{target} over the maximum id: {self.env_ref.robot_number - 1}"
+            )
+        else:
+            self.logger.info(f"Current control id: {target}")
+        self.key_id = target
+
+    def _press_motion_key(self, key: str) -> None:
+        """Apply the velocity a motion key commands while it is held."""
+        if key == "w":
+            self.key_lv = self.key_lv_max
+        elif key == "s":
+            self.key_lv = -self.key_lv_max
+        elif key == "a":
+            self.key_ang = self.key_ang_max
+        elif key == "d":
+            self.key_ang = -self.key_ang_max
+        elif key == "q":
+            self.key_rot = self.key_ang_max
+        elif key == "e":
+            self.key_rot = -self.key_ang_max
+
+    def _release_motion_key(self, key: str) -> None:
+        """Stop the motion a released key was commanding."""
+        if key in ("w", "s"):
+            self.key_lv = 0
+        elif key in ("a", "d"):
+            self.key_ang = 0
+        elif key in ("q", "e"):
+            self.key_rot = 0
+
+    def _adjust_speed_limit(self, key: str, shift: bool) -> None:
+        """Step the linear (with shift) or angular speed limit by 0.2."""
+        if key not in ("z", "c"):
+            return
+
+        step = -0.2 if key == "z" else 0.2
+        if shift:
+            self.key_lv_max = self.key_lv_max + step
+            self.logger.info(f"current linear velocity: {self.key_lv_max}")
+        else:
+            self.key_ang_max = self.key_ang_max + step
+            self.logger.info(f"current angular velocity: {self.key_ang_max}")
+
+    def _update_key_vel(self) -> None:
+        """Publish the current keyboard velocity command."""
+        self.key_vel = np.array([[self.key_lv], [self.key_ang], [self.key_rot]])
+
+    def _reset_env(self) -> None:
+        """Ask the environment to reset on its next step."""
+        self.logger.info("reset the environment")
+        if self.env_ref is not None:
+            self.env_ref.reset_flag = True
+        else:
+            self.logger.warning("Environment reference not set. Cannot reset.")
+
+    def _toggle_pause(self) -> None:
+        """Pause a running environment, or resume a paused one."""
+        if "Pause" not in self.env_ref.status:
+            self.logger.info("pause the environment")
+            self.env_ref.pause()
+        else:
+            self.logger.info("resume the environment")
+            self.env_ref.resume()
+
+    def _step_debug(self) -> None:
+        """Enter single-step debug mode, or advance it by one step."""
+        if not self.env_ref.debug_flag:
+            self.env_ref.debug_flag = True
+            self.env_ref.debug_count = self._world_param.count
+            self.env_ref.pause_flag = False
+        else:
+            self.env_ref.debug_count += 1
+
+    def _save_figure(self) -> None:
+        """Ask the environment to save the current figure."""
+        self.logger.info("save the figure")
+        self.env_ref.save_figure_flag = True
+
+    def _reload_env(self) -> None:
+        """Ask the environment to reload its YAML configuration."""
+        self.env_ref.reload_flag = True
+        self.logger.info("reload the environment")
+
+    def _toggle_display(self) -> None:
+        """Turn rendering of the environment on or off."""
+        self.env_ref.display = not self.env_ref.display
+        state = "on" if self.env_ref.display else "off"
+        self.logger.info(f"toggle display: {state}")
+
+    def _quit_env(self) -> None:
+        """Ask the environment to quit."""
+        self.env_ref.quit_flag = True
+
     def _toggle_control_mode(self) -> None:
         """Switch between keyboard and automatic control, and log the new mode."""
         if self._world_param.control_mode == "keyboard":
@@ -220,6 +322,26 @@ class KeyboardControl:
         else:
             self._world_param.control_mode = "keyboard"
             self.logger.info("switch to keyboard control")
+
+    def _run_command_key(self, key: str) -> None:
+        """Run the environment command bound to a released key, if any."""
+        commands = {
+            "r": self._reset_env,
+            "space": self._toggle_pause,
+            "x": self._toggle_control_mode,
+            "l": self._reload_env,
+            "f5": self._step_debug,
+            "v": self._save_figure,
+            "y": self._toggle_display,
+            "escape": self._quit_env,
+        }
+        command = commands.get(key)
+        if command is not None:
+            command()
+
+    # ------------------------------------------------------------------
+    # pynput key event handlers (backend = 'pynput')
+    # ------------------------------------------------------------------
 
     def _on_pynput_press(self, key: Any) -> None:
         """
@@ -245,29 +367,10 @@ class KeyboardControl:
         try:
             if self._world_param.control_mode == "keyboard":
                 if key.char.isdigit() and self.alt_flag:
-                    if self.env_ref and int(key.char) >= self.env_ref.robot_number:
-                        self.logger.warning(
-                            f"{int(key.char)} over the maximum id: {self.env_ref.robot_number - 1}"
-                        )
-                        self.key_id = int(key.char)
-                    else:
-                        self.logger.info(f"Current control id: {int(key.char)}")
-                        self.key_id = int(key.char)
+                    self._select_robot_id(key.char)
 
-                if key.char == "w":
-                    self.key_lv = self.key_lv_max
-                if key.char == "s":
-                    self.key_lv = -self.key_lv_max
-                if key.char == "a":
-                    self.key_ang = self.key_ang_max
-                if key.char == "d":
-                    self.key_ang = -self.key_ang_max
-                if key.char == "q":
-                    self.key_rot = self.key_ang_max
-                if key.char == "e":
-                    self.key_rot = -self.key_ang_max
-
-                self.key_vel = np.array([[self.key_lv], [self.key_ang], [self.key_rot]])
+                self._press_motion_key(key.char)
+                self._update_key_vel()
 
         except AttributeError:
             # Handle other special keys that don't have char attribute
@@ -286,84 +389,35 @@ class KeyboardControl:
             return
 
         try:
-            if key.char == "w":
-                self.key_lv = 0
-            if key.char == "s":
-                self.key_lv = 0
-            if key.char == "a":
-                self.key_ang = 0
-            if key.char == "d":
-                self.key_ang = 0
-            if key.char == "q":
-                self.key_rot = 0
-            if key.char == "e":
-                self.key_rot = 0
-
-            if key.char == "z":
-                self.key_ang_max = self.key_ang_max - 0.2
-                self.logger.info(f"current angular velocity: {self.key_ang_max}")
-            if key.char == "c":
-                self.key_ang_max = self.key_ang_max + 0.2
-                self.logger.info(f"current angular velocity: {self.key_ang_max}")
-            if key.char == "Z":
-                self.key_lv_max = self.key_lv_max - 0.2
-                self.logger.info(f"current linear velocity: {self.key_lv_max}")
-            if key.char == "C":
-                self.key_lv_max = self.key_lv_max + 0.2
-                self.logger.info(f"current linear velocity: {self.key_lv_max}")
-
-            if key.char == "r":
-                self.logger.info("reset the environment")
-                if self.env_ref is not None:
-                    self.env_ref.reset_flag = True
-                else:
-                    self.logger.warning("Environment reference not set. Cannot reset.")
-
-            # Switch control mode with 'x'
-            if key.char == "x":
-                self._toggle_control_mode()
-
-            if key.char == "v":
-                self.logger.info("save the figure")
-                self.env_ref.save_figure_flag = True
-
-            if key.char == "l":
-                self.env_ref.reload_flag = True
-                self.logger.info("reload the environment")
-
-            if key.char == "y":
-                self.env_ref.display = not self.env_ref.display
-                state = "on" if self.env_ref.display else "off"
-                self.logger.info(f"toggle display: {state}")
-
-            self.key_vel = np.array([[self.key_lv], [self.key_ang], [self.key_rot]])
+            # Keys are matched as typed here: 'Z'/'C' carry the shift variant.
+            char = key.char or ""
+            self._release_motion_key(char)
+            self._adjust_speed_limit(char.lower(), char.isupper())
+            self._run_command_key(char)
+            self._update_key_vel()
 
         except AttributeError:
-            if "alt" in key.name:
-                self.alt_flag = False
+            self._on_pynput_special_release(key)
 
-            if keyboard is not None and key == keyboard.Key.space:
-                if "Pause" not in self.env_ref.status:
-                    self.logger.info("pause the environment")
-                    self.env_ref.pause()
-                else:
-                    self.logger.info("resume the environment")
-                    self.env_ref.resume()
+    def _on_pynput_special_release(self, key: Any) -> None:
+        """Handle release of keys that carry no character (alt, space, F5, ESC)."""
+        if "alt" in key.name:
+            self.alt_flag = False
 
-            # Single-step debug on F5
-            if keyboard is not None and key == keyboard.Key.f5:
-                if not self.env_ref.debug_flag:
-                    self.env_ref.debug_flag = True
-                    self.env_ref.debug_count = self._world_param.count
-                    self.env_ref.pause_flag = False
-                else:
-                    self.env_ref.debug_count += 1
+        if keyboard is None:
+            return
 
-            # Quit environment on ESC
-            if keyboard is not None and key == keyboard.Key.esc:
-                self.env_ref.quit_flag = True
+        if key == keyboard.Key.space:
+            self._toggle_pause()
+        elif key == keyboard.Key.f5:
+            self._step_debug()
+        elif key == keyboard.Key.esc:
+            self._quit_env()
 
+    # ------------------------------------------------------------------
     # Matplotlib key event handlers (backend = 'mpl')
+    # ------------------------------------------------------------------
+
     def _on_mpl_press(self, event: Any) -> None:
         """
         Handle Matplotlib figure key press events.
@@ -377,33 +431,14 @@ class KeyboardControl:
         self.alt_flag = key.startswith("alt+") or key == "alt"
 
         # Extract base key without modifiers
-        base = key.replace("alt+", "").replace("shift+", "").replace("ctrl+", "")
+        base = self._mpl_base_key(key)
 
         if self._world_param.control_mode == "keyboard":
             if base.isdigit() and self.alt_flag:
-                if self.env_ref and int(base) >= self.env_ref.robot_number:
-                    self.logger.warning(
-                        f"{int(base)} over the maximum id: {self.env_ref.robot_number - 1}"
-                    )
-                    self.key_id = int(base)
-                else:
-                    self.logger.info(f"Current control id: {int(base)}")
-                    self.key_id = int(base)
+                self._select_robot_id(base)
 
-            if base == "w":
-                self.key_lv = self.key_lv_max
-            if base == "s":
-                self.key_lv = -self.key_lv_max
-            if base == "a":
-                self.key_ang = self.key_ang_max
-            if base == "d":
-                self.key_ang = -self.key_ang_max
-            if base == "q":
-                self.key_rot = self.key_ang_max
-            if base == "e":
-                self.key_rot = -self.key_ang_max
-
-            self.key_vel = np.array([[self.key_lv], [self.key_ang], [self.key_rot]])
+            self._press_motion_key(base)
+            self._update_key_vel()
 
     def _on_mpl_release(self, event: Any) -> None:
         """
@@ -414,80 +449,24 @@ class KeyboardControl:
         """
         key = (event.key or "").lower()
         has_shift = "shift+" in key
-        base = key.replace("alt+", "").replace("shift+", "").replace("ctrl+", "")
+        base = self._mpl_base_key(key)
 
         if self._world_param.control_mode == "keyboard":
-            if base == "w":
-                self.key_lv = 0
-            if base == "s":
-                self.key_lv = 0
-            if base == "a":
-                self.key_ang = 0
-            if base == "d":
-                self.key_ang = 0
-            if base == "q":
-                self.key_rot = 0
-            if base == "e":
-                self.key_rot = 0
-            if base == "z" and has_shift:
-                self.key_lv_max = self.key_lv_max - 0.2
-                self.logger.info(f"current linear velocity: {self.key_lv_max}")
-            elif base == "z":
-                self.key_ang_max = self.key_ang_max - 0.2
-                self.logger.info(f"current angular velocity: {self.key_ang_max}")
-            if base == "c" and has_shift:
-                self.key_lv_max = self.key_lv_max + 0.2
-                self.logger.info(f"current linear velocity: {self.key_lv_max}")
-            elif base == "c":
-                self.key_ang_max = self.key_ang_max + 0.2
-                self.logger.info(f"current angular velocity: {self.key_ang_max}")
+            self._release_motion_key(base)
+            self._adjust_speed_limit(base, has_shift)
 
-        if base == "r":
-            self.logger.info("reset the environment")
-            if self.env_ref is not None:
-                self.env_ref.reset_flag = True
-            else:
-                self.logger.warning("Environment reference not set. Cannot reset.")
+        self._run_command_key(base)
+        self._update_key_vel()
 
-        if base in ("space", " "):
-            if "Pause" not in self.env_ref.status:
-                self.logger.info("pause the environment")
-                self.env_ref.pause()
-            else:
-                self.logger.info("resume the environment")
-                self.env_ref.resume()
-
-        # Switch control mode with 'x'
-        if base == "x":
-            self._toggle_control_mode()
-
-        if base == "l":
-            self.env_ref.reload_flag = True
-            self.logger.info("reload the environment")
-
-        # Single-step debug on F5
-        if base == "f5":
-            if not self.env_ref.debug_flag:
-                self.env_ref.debug_flag = True
-                self.env_ref.debug_count = self._world_param.count
-                self.env_ref.pause_flag = False
-            else:
-                self.env_ref.debug_count += 1
-
-        if base == "v":
-            self.logger.info("save the figure")
-            self.env_ref.save_figure_flag = True
-
-        if base == "y":
-            self.env_ref.display = not self.env_ref.display
-            state = "on" if self.env_ref.display else "off"
-            self.logger.info(f"toggle display: {state}")
-
-        # Quit environment on ESC/escape
-        if base in ("escape", "esc"):
-            self.env_ref.quit_flag = True
-
-        self.key_vel = np.array([[self.key_lv], [self.key_ang], [self.key_rot]])
+    @staticmethod
+    def _mpl_base_key(key: str) -> str:
+        """Strip modifiers from a Matplotlib key name and normalize its spelling."""
+        base = key.replace("alt+", "").replace("shift+", "").replace("ctrl+", "")
+        if base == " ":
+            return "space"
+        if base == "esc":
+            return "escape"
+        return base
 
     # Minimal grid table formatter to avoid external dependency
     def _format_grid_table(self, headers: list[str], rows: list[list[Any]]) -> str:

--- a/irsim/gui/keyboard_control.py
+++ b/irsim/gui/keyboard_control.py
@@ -423,12 +423,14 @@ class KeyboardControl:
         if keyboard is None:
             return
 
+        # Named after the matplotlib keys so both backends dispatch through
+        # _run_command_key, and share its missing-environment guard.
         if key == keyboard.Key.space:
-            self._toggle_pause()
+            self._run_command_key("space")
         elif key == keyboard.Key.f5:
-            self._step_debug()
+            self._run_command_key("f5")
         elif key == keyboard.Key.esc:
-            self._quit_env()
+            self._run_command_key("escape")
 
     # ------------------------------------------------------------------
     # Matplotlib key event handlers (backend = 'mpl')
@@ -550,8 +552,14 @@ class KeyboardControl:
         Get the environment logger.
 
         Returns:
-            EnvLogger: The logger instance for the environment.
+            EnvLogger: The environment logger, or the default loguru logger
+            when the control runs without an environment to borrow one from.
         """
+        if self._env_param.logger is None:
+            from loguru import logger
+
+            return logger
+
         return self._env_param.logger
 
     # Window focus helpers (used to gate pynput when active_only=True)

--- a/irsim/gui/mouse_control.py
+++ b/irsim/gui/mouse_control.py
@@ -53,7 +53,6 @@ class MouseControl:
         """
         if event.inaxes:
             self.mouse_pos = (event.xdata, event.ydata)
-            # self.current_axes = event.inaxes
 
         else:
             self.mouse_pos = None

--- a/irsim/lib/algorithm/kinematics.py
+++ b/irsim/lib/algorithm/kinematics.py
@@ -12,6 +12,40 @@ from irsim.util.random import rng
 from irsim.util.util import WrapToPi, validate_shape
 
 
+def _apply_velocity_noise(
+    velocity: np.ndarray, noise: bool, alpha: list[float]
+) -> np.ndarray:
+    """
+    Sample a velocity from the noise model of a [linear, angular] command.
+
+    Args:
+        velocity: A 2x1 vector [linear, angular] representing the commanded velocities.
+        noise: Whether to sample; when False the command is returned unchanged.
+        alpha: Noise parameters; alpha[0:2] scale the linear standard deviation
+            and alpha[2:4] the angular one.
+
+    Returns:
+        np.ndarray: The velocity actually executed by the model.
+
+    Raises:
+        ValueError: If noise is requested with fewer than four parameters.
+    """
+    if not noise:
+        return velocity
+
+    if len(alpha) < 4:
+        raise ValueError("Parameter 'alpha' must have length >= 4 when noise=True")
+
+    std_linear = np.sqrt(
+        alpha[0] * (velocity[0, 0] ** 2) + alpha[1] * (velocity[1, 0] ** 2)
+    )
+    std_angular = np.sqrt(
+        alpha[2] * (velocity[0, 0] ** 2) + alpha[3] * (velocity[1, 0] ** 2)
+    )
+
+    return velocity + rng.normal([[0], [0]], scale=[[std_linear], [std_angular]])
+
+
 @validate_shape(state=3, velocity=2)
 def differential_kinematics(
     state: np.ndarray,
@@ -36,20 +70,7 @@ def differential_kinematics(
     if alpha is None:
         alpha = [0.03, 0, 0, 0.03]
 
-    if noise:
-        if len(alpha) < 4:
-            raise ValueError("Parameter 'alpha' must have length >= 4 when noise=True")
-        std_linear = np.sqrt(
-            alpha[0] * (velocity[0, 0] ** 2) + alpha[1] * (velocity[1, 0] ** 2)
-        )
-        std_angular = np.sqrt(
-            alpha[2] * (velocity[0, 0] ** 2) + alpha[3] * (velocity[1, 0] ** 2)
-        )
-        real_velocity = velocity + rng.normal(
-            [[0], [0]], scale=[[std_linear], [std_angular]]
-        )
-    else:
-        real_velocity = velocity
+    real_velocity = _apply_velocity_noise(velocity, noise, alpha)
 
     phi = state[2, 0]
     co_matrix = np.array([[cos(phi), 0], [sin(phi), 0], [0, 1]])
@@ -93,20 +114,7 @@ def ackermann_kinematics(
     phi = state[2, 0]
     psi = state[3, 0]
 
-    if noise:
-        if len(alpha) < 4:
-            raise ValueError("Parameter 'alpha' must have length >= 4 when noise=True")
-        std_linear = np.sqrt(
-            alpha[0] * (velocity[0, 0] ** 2) + alpha[1] * (velocity[1, 0] ** 2)
-        )
-        std_angular = np.sqrt(
-            alpha[2] * (velocity[0, 0] ** 2) + alpha[3] * (velocity[1, 0] ** 2)
-        )
-        real_velocity = velocity + rng.normal(
-            [[0], [0]], scale=[[std_linear], [std_angular]]
-        )
-    else:
-        real_velocity = velocity
+    real_velocity = _apply_velocity_noise(velocity, noise, alpha)
 
     if mode == "steer" or mode == "angular":
         co_matrix = np.array(

--- a/irsim/lib/algorithm/rvo.py
+++ b/irsim/lib/algorithm/rvo.py
@@ -83,6 +83,47 @@ class reciprocal_vel_obs:
         vo_outside, vo_inside = self.vel_candidate(rvo_list)
         return self.vel_select(vo_outside, vo_inside)
 
+    @staticmethod
+    def _cone_angles(
+        x: float, y: float, r: float, mx: float, my: float, mr: float
+    ) -> tuple[float, float, float]:
+        """
+        Compute the edges of the velocity-obstacle cone towards one obstacle.
+
+        The cone spans the directions from ``(x, y)`` that touch the obstacle
+        disc at ``(mx, my)`` inflated by the combined radius. Obstacles closer
+        than that combined radius are treated as tangent, giving a half cone of
+        90 degrees instead of an undefined one.
+
+        Args:
+            x (float): Ego x position.
+            y (float): Ego y position.
+            r (float): Ego radius.
+            mx (float): Obstacle x position.
+            my (float): Obstacle y position.
+            mr (float): Obstacle radius.
+
+        Returns:
+            tuple: ``(line_left_ori, line_right_ori, half_angle)`` in radians.
+        """
+
+        dis_mr = np.sqrt((my - y) ** 2 + (mx - x) ** 2)
+        angle_mr = atan2(my - y, mx - x)
+
+        if dis_mr < r + mr:
+            dis_mr = r + mr
+
+        ratio = (r + mr) / dis_mr
+
+        if ratio > 1:
+            ratio = 1
+        if ratio < -1:
+            ratio = -1
+
+        half_angle = asin(ratio)
+
+        return angle_mr + half_angle, angle_mr - half_angle, half_angle
+
     def config_rvo(self):
         """Build reciprocal velocity-obstacle cones for all obstacles."""
         rvo_list = []
@@ -134,27 +175,9 @@ class reciprocal_vel_obs:
         else:  # pragma: no cover - unreachable; mode is "moving" or "sta_circular"
             log_error("wrong rvo mode")
 
-        dis_mr = np.sqrt((my - y) ** 2 + (mx - x) ** 2)
-        angle_mr = atan2(my - y, mx - x)
-
-        if dis_mr < r + mr:
-            dis_mr = r + mr
-
-        ratio = (r + mr) / dis_mr
-
-        if ratio > 1:
-            ratio = 1
-        if ratio < -1:
-            ratio = -1
-
-        half_angle = asin(ratio)
-        line_left_ori = angle_mr + half_angle
-        line_right_ori = angle_mr - half_angle
-
+        line_left_ori, line_right_ori, _ = self._cone_angles(x, y, r, mx, my, mr)
         line_left_vector = [cos(line_left_ori), sin(line_left_ori)]
         line_right_vector = [cos(line_right_ori), sin(line_right_ori)]
-
-        # return [rvo_apex, line_left_ori, line_right_ori]
 
         return [rvo_apex, line_left_vector, line_right_vector]
 
@@ -209,23 +232,9 @@ class reciprocal_vel_obs:
         rvo_apex = [(vx + mvx) / 2, (vy + mvy) / 2]
         vo_apex = [mvx, mvy]
 
-        dis_mr = np.sqrt((my - y) ** 2 + (mx - x) ** 2)
-        angle_mr = atan2(my - y, mx - x)
-
-        if dis_mr < r + mr:
-            dis_mr = r + mr
-
-        ratio = (r + mr) / dis_mr
-
-        if ratio > 1:
-            ratio = 1
-        if ratio < -1:
-            ratio = -1
-
-        half_angle = asin(ratio)
-        line_left_ori = angle_mr + half_angle
-        line_right_ori = angle_mr - half_angle
-
+        line_left_ori, line_right_ori, half_angle = self._cone_angles(
+            x, y, r, mx, my, mr
+        )
         line_left_vector = [cos(line_left_ori), sin(line_left_ori)]
         line_right_vector = [cos(line_right_ori), sin(line_right_ori)]
 
@@ -311,23 +320,7 @@ class reciprocal_vel_obs:
             log_error("wrong obstacle mode")
 
         vo_apex = [mvx, mvy]
-        dis_mr = np.sqrt((my - y) ** 2 + (mx - x) ** 2)
-        angle_mr = atan2(my - y, mx - x)
-
-        if dis_mr < r + mr:
-            dis_mr = r + mr
-
-        ratio = (r + mr) / dis_mr
-
-        if ratio > 1:
-            ratio = 1
-        if ratio < -1:
-            ratio = -1
-
-        half_angle = asin(ratio)
-        line_left_ori = angle_mr + half_angle
-        line_right_ori = angle_mr - half_angle
-
+        line_left_ori, line_right_ori, _ = self._cone_angles(x, y, r, mx, my, mr)
         line_left_vector = [cos(line_left_ori), sin(line_left_ori)]
         line_right_vector = [cos(line_right_ori), sin(line_right_ori)]
 
@@ -434,7 +427,6 @@ class reciprocal_vel_obs:
             rel_vx = vx - rvo[0][0]
             rel_vy = vy - rvo[0][1]
 
-            # rel_radians = atan2(rel_vy, rel_vx)
             rel_vector = [rel_vx, rel_vy]
 
             if reciprocal_vel_obs.between_vector(rvo[1], rvo[2], rel_vector):

--- a/irsim/lib/algorithm/rvo.py
+++ b/irsim/lib/algorithm/rvo.py
@@ -113,13 +113,7 @@ class reciprocal_vel_obs:
         if dis_mr < r + mr:
             dis_mr = r + mr
 
-        ratio = (r + mr) / dis_mr
-
-        if ratio > 1:
-            ratio = 1
-        if ratio < -1:
-            ratio = -1
-
+        ratio = min(max((r + mr) / dis_mr, -1.0), 1.0)
         half_angle = asin(ratio)
 
         return angle_mr + half_angle, angle_mr - half_angle, half_angle

--- a/irsim/lib/behavior/behavior_methods.py
+++ b/irsim/lib/behavior/behavior_methods.py
@@ -43,6 +43,51 @@ details.
 """
 
 
+def _goal_pending(ego_object: Any, behavior: str) -> bool:
+    """
+    Report whether a behavior is still waiting for a goal to be configured.
+
+    Args:
+        ego_object: The ego robot object.
+        behavior (str): Behavior name, used in the periodic warning.
+
+    Returns:
+        bool: True while ``ego_object`` has no goal, in which case the caller
+        should return a zero velocity of its own shape.
+    """
+
+    if ego_object.goal is not None:
+        return False
+
+    if ego_object._world_param.count % 10 == 0:
+        ego_object.logger.warning(
+            f"Goal is currently None. This {behavior} behavior is waiting for goal configuration"
+        )
+
+    return True
+
+
+def _rvo_params(kwargs: dict[str, Any]) -> tuple[Any, ...]:
+    """
+    Read the shared RVO tuning parameters, in the order the solvers take them.
+
+    Args:
+        kwargs (dict): Behavior keyword arguments.
+
+    Returns:
+        tuple: ``(vxmax, vymax, acce, factor, mode, neighbor_threshold)``.
+    """
+
+    return (
+        kwargs.get("vxmax", 1.5),
+        kwargs.get("vymax", 1.5),
+        kwargs.get("acce", 1.0),
+        kwargs.get("factor", 1.0),
+        kwargs.get("mode", "rvo"),
+        kwargs.get("neighbor_threshold", 3.0),
+    )
+
+
 @register_behavior("diff", "rvo")
 def beh_diff_rvo(
     ego_object: Any, external_objects: list[Any], **kwargs: Any
@@ -65,11 +110,7 @@ def beh_diff_rvo(
         np.array: Velocity [linear, angular] (2x1) for differential drive.
     """
 
-    if ego_object.goal is None:
-        if ego_object._world_param.count % 10 == 0:
-            ego_object.logger.warning(
-                "Goal is currently None. This rvo behavior is waiting for goal configuration"
-            )
+    if _goal_pending(ego_object, "rvo"):
         return np.zeros((2, 1))
 
     rvo_neighbor = []
@@ -81,12 +122,7 @@ def beh_diff_rvo(
         else:
             rvo_neighbor.append(obj.rvo_neighbor_state)
     rvo_state = ego_object.rvo_state
-    vxmax = kwargs.get("vxmax", 1.5)
-    vymax = kwargs.get("vymax", 1.5)
-    acce = kwargs.get("acce", 1.0)
-    factor = kwargs.get("factor", 1.0)
-    mode = kwargs.get("mode", "rvo")
-    neighbor_threshold = kwargs.get("neighbor_threshold", 3.0)
+    vxmax, vymax, acce, factor, mode, neighbor_threshold = _rvo_params(kwargs)
     return DiffRVO(
         rvo_state,
         rvo_neighbor,
@@ -125,12 +161,7 @@ def beh_diff_dash(
     angular_acce = ego_object.info.acce[1, 0]
     dt = ego_object._world_param.step_time
 
-    if goal is None:
-        if ego_object._world_param.count % 10 == 0:
-            ego_object.logger.warning(
-                "Goal is currently None. This dash behavior is waiting for goal configuration"
-            )
-
+    if _goal_pending(ego_object, "dash"):
         return np.zeros((2, 1))
 
     vel = DiffDash(
@@ -156,11 +187,7 @@ def beh_omni_dash(
         np.array: Velocity [vx, vy] (2x1) for omnidirectional drive.
     """
 
-    if ego_object.goal is None:
-        if ego_object._world_param.count % 10 == 0:
-            ego_object.logger.warning(
-                "Goal is currently None. This dash behavior is waiting for goal configuration"
-            )
+    if _goal_pending(ego_object, "dash"):
         return np.zeros((2, 1))
 
     state = ego_object.state
@@ -194,11 +221,7 @@ def beh_omni_rvo(
         np.array: Velocity [vx, vy] (2x1) for omnidirectional drive.
     """
 
-    if ego_object.goal is None:
-        if ego_object._world_param.count % 10 == 0:
-            ego_object.logger.warning(
-                "Goal is currently None. This rvo behavior is waiting for goal configuration"
-            )
+    if _goal_pending(ego_object, "rvo"):
         return np.zeros((2, 1))
 
     rvo_neighbor = []
@@ -210,12 +233,7 @@ def beh_omni_rvo(
         else:
             rvo_neighbor.append(obj.rvo_neighbor_state)
     rvo_state = ego_object.rvo_state
-    vxmax = kwargs.get("vxmax", 1.5)
-    vymax = kwargs.get("vymax", 1.5)
-    acce = kwargs.get("acce", 1.0)
-    factor = kwargs.get("factor", 1.0)
-    mode = kwargs.get("mode", "rvo")
-    neighbor_threshold = kwargs.get("neighbor_threshold", 3.0)
+    vxmax, vymax, acce, factor, mode, neighbor_threshold = _rvo_params(kwargs)
     world_vel = OmniRVO(
         rvo_state,
         rvo_neighbor,
@@ -245,11 +263,7 @@ def beh_diff_sfm(
     Returns:
         np.array: Velocity [linear, angular] (2x1) for differential drive.
     """
-    if ego_object.goal is None:
-        if ego_object._world_param.count % 10 == 0:
-            ego_object.logger.warning(
-                "Goal is currently None. This sfm behavior is waiting for goal configuration"
-            )
+    if _goal_pending(ego_object, "sfm"):
         return np.zeros((2, 1))
 
     neighbors = []
@@ -297,11 +311,7 @@ def beh_omni_sfm(
     Returns:
         np.array: Velocity [vx, vy] (2x1) for omnidirectional drive.
     """
-    if ego_object.goal is None:
-        if ego_object._world_param.count % 10 == 0:
-            ego_object.logger.warning(
-                "Goal is currently None. This sfm behavior is waiting for goal configuration"
-            )
+    if _goal_pending(ego_object, "sfm"):
         return np.zeros((2, 1))
 
     neighbors = []
@@ -340,11 +350,7 @@ def beh_omni_angular_dash(
         np.array: Velocity [forward, lateral, yaw_rate] (3x1) in body frame.
     """
 
-    if ego_object.goal is None:
-        if ego_object._world_param.count % 10 == 0:
-            ego_object.logger.warning(
-                "Goal is currently None. This dash behavior is waiting for goal configuration"
-            )
+    if _goal_pending(ego_object, "dash"):
         return np.zeros((3, 1))
 
     state = ego_object.state
@@ -379,11 +385,7 @@ def beh_acker_dash(
         np.array: Velocity [linear, steering angle] (2x1) for Ackermann drive.
     """
 
-    if ego_object.goal is None:
-        if ego_object._world_param.count % 10 == 0:
-            ego_object.logger.warning(
-                "Goal is currently None. This dash behavior is waiting for goal configuration"
-            )
+    if _goal_pending(ego_object, "dash"):
         return np.zeros((2, 1))
 
     state = ego_object.state

--- a/irsim/lib/handler/geometry_handler.py
+++ b/irsim/lib/handler/geometry_handler.py
@@ -668,9 +668,4 @@ class GeometryFactory:
         if name == "map":
             return PointsGeometry(name, **kwargs)
 
-        # elif name == 'sphere3d':
-        #     return Sphere3DGeometry(name, **kwargs)
-        # elif name == 'cuboid3d':
-        #     return Cuboid3DGeometry(name, **kwargs)
-
         raise ValueError(f"Invalid geometry name: {name}")

--- a/irsim/lib/handler/kinematics_handler.py
+++ b/irsim/lib/handler/kinematics_handler.py
@@ -447,9 +447,6 @@ class KinematicsFactory:
             if issubclass(handler_cls, AckermannKinematics):
                 return handler_cls(name, noise, alpha, mode, wheelbase or 1.0)
             return handler_cls(name, noise, alpha)
-
-        # elif name == 'rigid3d':
-        #     return Rigid3DKinematics(name, noise, alpha)
         if role == "robot":
             log_warning(
                 f"Unknown kinematics type: {name}, the robot will be stationary."

--- a/irsim/lib/path_planners/a_star.py
+++ b/irsim/lib/path_planners/a_star.py
@@ -17,18 +17,18 @@ See Wikipedia article (https://en.wikipedia.org/wiki/A*_search_algorithm)
 
 from __future__ import annotations
 
-import contextlib
 import math
 
 import matplotlib.pyplot as plt
 import numpy as np
 
 from irsim.lib.handler.geometry_handler import GeometryFactory
+from irsim.lib.path_planners.grid_planner_base import GridPlannerBase
 from irsim.util.util import to_numpy
 from irsim.world.map import EnvGridMap
 
 
-class AStarPlanner:
+class AStarPlanner(GridPlannerBase):
     """Grid-based A* planner over an :class:`~irsim.world.map.EnvGridMap`.
 
     The planner uses the map grid when available and falls back to Shapely
@@ -46,29 +46,7 @@ class AStarPlanner:
                 compatible object).
         """
 
-        self._map = env_map
-        self.obstacle_list = env_map.obstacle_list[:]
-        off = np.asarray(env_map.world_offset, dtype=float).flatten()
-        self.origin_x = float(off[0])
-        self.origin_y = float(off[1])
-        self.min_x, self.min_y = 0, 0  # grid indices are 0-based
-        self.max_x = self.origin_x + env_map.width
-        self.max_y = self.origin_y + env_map.height
-        # When map has a grid, use its actual resolution and shape so planner grid
-        # matches collision lookups (avoids "Open set is empty" on resolution mismatch).
-        grid = getattr(env_map, "grid", None)
-        gr = None
-        if grid is not None and hasattr(env_map, "grid_resolution"):
-            with contextlib.suppress(Exception):
-                gr = env_map.grid_resolution
-        if grid is not None and gr is not None:
-            self.resolution = gr[0]  # m/cell; assume square cells (gr[0]==gr[1])
-            self.x_width = grid.shape[0]
-            self.y_width = grid.shape[1]
-        else:
-            self.resolution = env_map.resolution
-            self.x_width = round((self.max_x - self.origin_x) / self.resolution)
-            self.y_width = round((self.max_y - self.origin_y) / self.resolution)
+        super().__init__(env_map)
         self.motion = self.get_motion_model()
 
     class Node:

--- a/irsim/lib/path_planners/grid_planner_base.py
+++ b/irsim/lib/path_planners/grid_planner_base.py
@@ -1,0 +1,53 @@
+"""Shared grid geometry for the occupancy-grid planners (A*, JPS)."""
+
+from __future__ import annotations
+
+import contextlib
+
+import numpy as np
+
+from irsim.world.map import EnvGridMap
+
+
+class GridPlannerBase:
+    """Bounds, resolution, and grid shape derived from an environment map.
+
+    Both :class:`~irsim.lib.path_planners.a_star.AStarPlanner` and
+    :class:`~irsim.lib.path_planners.jps.JPSPlanner` search the same discrete
+    grid, so they derive their search space the same way.
+    """
+
+    def __init__(self, env_map: EnvGridMap) -> None:
+        """
+        Derive the search grid from an environment map.
+
+        Args:
+            env_map: Environment map (any :class:`~irsim.world.map.EnvGridMap`
+                compatible object).
+        """
+        self._map = env_map
+        self.obstacle_list = env_map.obstacle_list[:]
+
+        off = np.asarray(env_map.world_offset, dtype=float).flatten()
+        self.origin_x = float(off[0])
+        self.origin_y = float(off[1])
+        self.min_x, self.min_y = 0, 0  # grid indices are 0-based
+        self.max_x = self.origin_x + env_map.width
+        self.max_y = self.origin_y + env_map.height
+
+        # When map has a grid, use its actual resolution and shape so planner grid
+        # matches collision lookups (avoids "Open set is empty" on resolution mismatch).
+        grid = getattr(env_map, "grid", None)
+        gr = None
+        if grid is not None and hasattr(env_map, "grid_resolution"):
+            with contextlib.suppress(Exception):
+                gr = env_map.grid_resolution
+
+        if grid is not None and gr is not None:
+            self.resolution = gr[0]  # m/cell; assume square cells (gr[0]==gr[1])
+            self.x_width = grid.shape[0]
+            self.y_width = grid.shape[1]
+        else:
+            self.resolution = env_map.resolution
+            self.x_width = round((self.max_x - self.origin_x) / self.resolution)
+            self.y_width = round((self.max_y - self.origin_y) / self.resolution)

--- a/irsim/lib/path_planners/informed_rrt_star.py
+++ b/irsim/lib/path_planners/informed_rrt_star.py
@@ -120,13 +120,7 @@ class InformedRRTStar(RRTStar):
         Returns:
             ``(2, N)`` waypoint array or *None*.
         """
-        start_pose = np.asarray(start_pose, dtype=float).flatten()
-        goal_pose = np.asarray(goal_pose, dtype=float).flatten()
-        sx, sy = float(start_pose[0]), float(start_pose[1])
-        gx, gy = float(goal_pose[0]), float(goal_pose[1])
-
-        self.start = TreeNode(x=sx, y=sy, cost=0.0)
-        self.end = TreeNode(x=gx, y=gy, cost=float("inf"))
+        sx, sy, gx, gy = self._init_search(start_pose, goal_pose)
 
         # -- ellipse invariants --
         self._c_min = math.hypot(gx - sx, gy - sy)
@@ -151,10 +145,6 @@ class InformedRRTStar(RRTStar):
         self._ellipse_line = None
         self._best_path_line = None
         self._vis_setup_done = False
-
-        # -- reset tree --
-        self.node_list = [self.start]
-        self._kd_dirty = True
 
         goal_found = False
 

--- a/irsim/lib/path_planners/jps.py
+++ b/irsim/lib/path_planners/jps.py
@@ -21,7 +21,6 @@ References
 
 from __future__ import annotations
 
-import contextlib
 import itertools
 import math
 from dataclasses import dataclass
@@ -30,7 +29,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from irsim.lib.handler.geometry_handler import GeometryFactory
-from irsim.world.map import EnvGridMap
+from irsim.lib.path_planners.grid_planner_base import GridPlannerBase
 
 # Type alias: ((jx, jy, dx, dy), cost) for each jump successor
 JpsSuccessor = tuple[tuple[int, int, int, int], float]
@@ -128,46 +127,13 @@ def _dir_id(dx: int, dy: int) -> int:
     return (dx + 1) + 3 * (dy + 1)
 
 
-class JPSPlanner:
+class JPSPlanner(GridPlannerBase):
     """Jump Point Search planner for uniform-cost 8-connected grids.
 
     When the environment map carries an occupancy grid (``env_map.grid``),
     collision checks use a fast O(1) grid lookup.  Otherwise, the planner
     falls back to Shapely geometry intersection (same as :class:`AStarPlanner`).
     """
-
-    def __init__(self, env_map: EnvGridMap) -> None:
-        """
-        Initialize JPS planner.
-
-        Args:
-            env_map: Environment map (any :class:`~irsim.world.map.EnvGridMap`
-                compatible object).  Resolution and bounds are taken from the
-                map (same as :class:`AStarPlanner`).
-        """
-        self._map = env_map
-        off = np.asarray(env_map.world_offset, dtype=float).flatten()
-        self.origin_x = float(off[0])
-        self.origin_y = float(off[1])
-        self.min_x, self.min_y = 0, 0  # grid indices are 0-based
-        self.max_x = self.origin_x + env_map.width
-        self.max_y = self.origin_y + env_map.height
-        # When map has a grid, use its actual resolution and shape so planner grid
-        # matches collision lookups (avoids "Open set is empty" on resolution mismatch).
-        grid = getattr(env_map, "grid", None)
-        gr = None
-        if grid is not None and hasattr(env_map, "grid_resolution"):
-            with contextlib.suppress(Exception):
-                gr = env_map.grid_resolution
-        if grid is not None and gr is not None:
-            self.resolution = gr[0]  # m/cell; assume square cells (gr[0]==gr[1])
-            self.x_width = grid.shape[0]
-            self.y_width = grid.shape[1]
-        else:
-            self.resolution = env_map.resolution
-            self.x_width = round((self.max_x - self.origin_x) / self.resolution)
-            self.y_width = round((self.max_y - self.origin_y) / self.resolution)
-        self.obstacle_list = env_map.obstacle_list[:]
 
     def planning(
         self,

--- a/irsim/lib/path_planners/probabilistic_road_map.py
+++ b/irsim/lib/path_planners/probabilistic_road_map.py
@@ -229,8 +229,6 @@ class PRMPlanner:
 
             road_map.append(edge_id)
 
-        # self.plot_road_map(road_map, sample_x, sample_y)
-
         return road_map
 
     @staticmethod

--- a/irsim/lib/path_planners/rrt.py
+++ b/irsim/lib/path_planners/rrt.py
@@ -272,6 +272,31 @@ class RRT:
     # Planning
     # ------------------------------------------------------------------
 
+    def _init_search(
+        self, start_pose: list[float], goal_pose: list[float]
+    ) -> tuple[float, float, float, float]:
+        """Set the start and goal nodes and reset the tree for a new run.
+
+        Args:
+            start_pose: Start position ``[x, y]``.
+            goal_pose: Goal position ``[x, y]``.
+
+        Returns:
+            tuple: The planar ``(sx, sy, gx, gy)`` the nodes were built from.
+        """
+        start_pose = np.asarray(start_pose, dtype=float).flatten()
+        goal_pose = np.asarray(goal_pose, dtype=float).flatten()
+        sx, sy = float(start_pose[0]), float(start_pose[1])
+        gx, gy = float(goal_pose[0]), float(goal_pose[1])
+
+        self.start = TreeNode(x=sx, y=sy, cost=0.0)
+        self.end = TreeNode(x=gx, y=gy, cost=float("inf"))
+
+        self.node_list = [self.start]
+        self._kd_dirty = True
+
+        return sx, sy, gx, gy
+
     def planning(
         self,
         start_pose: list[float],
@@ -288,17 +313,9 @@ class RRT:
         Returns:
             ``(2, N)`` numpy array ``[rx, ry]`` or *None*.
         """
-        start_pose = np.asarray(start_pose, dtype=float).flatten()
-        goal_pose = np.asarray(goal_pose, dtype=float).flatten()
-        sx, sy = float(start_pose[0]), float(start_pose[1])
-        gx, gy = float(goal_pose[0]), float(goal_pose[1])
+        self._init_search(start_pose, goal_pose)
 
-        self.start = TreeNode(x=sx, y=sy, cost=0.0)
-        self.end = TreeNode(x=gx, y=gy, cost=float("inf"))
-
-        # Reset
-        self.node_list = [self.start]
-        self._kd_dirty = True
+        # Reset visuals
         self._vis_setup_done = False
         self._tree_line = None
         self._vis_temp = []
@@ -518,24 +535,6 @@ class RRT:
             self._tree_line.set_data(xs, ys)
 
         plt.pause(0.01)
-
-    @staticmethod
-    def _plot_circle(
-        x: float,
-        y: float,
-        size: float,
-        color: str = "-b",
-        ax: plt.Axes | None = None,
-    ) -> Line2D:
-        """Plot a circle and return the ``Line2D`` artist."""
-        if ax is None:
-            ax = plt.gca()
-        deg = list(range(0, 360, 5))
-        deg.append(0)
-        xl = [x + size * math.cos(np.deg2rad(d)) for d in deg]
-        yl = [y + size * math.sin(np.deg2rad(d)) for d in deg]
-        (line,) = ax.plot(xl, yl, color)
-        return line
 
     # ------------------------------------------------------------------
     # Utility

--- a/irsim/lib/path_planners/rrt_star.py
+++ b/irsim/lib/path_planners/rrt_star.py
@@ -92,17 +92,9 @@ class RRTStar(RRT):
         Returns:
             ``(2, N)`` waypoint array or *None*.
         """
-        start_pose = np.asarray(start_pose, dtype=float).flatten()
-        goal_pose = np.asarray(goal_pose, dtype=float).flatten()
-        sx, sy = float(start_pose[0]), float(start_pose[1])
-        gx, gy = float(goal_pose[0]), float(goal_pose[1])
+        self._init_search(start_pose, goal_pose)
 
-        self.start = TreeNode(x=sx, y=sy, cost=0.0)
-        self.end = TreeNode(x=gx, y=gy, cost=float("inf"))
-
-        # Reset
-        self.node_list = [self.start]
-        self._kd_dirty = True
+        # Reset visuals
         self._vis_setup_done = False
         self._tree_line = None
         self._vis_temp = []

--- a/irsim/util/util.py
+++ b/irsim/util/util.py
@@ -720,7 +720,6 @@ def is_2d_list(data: list | deque) -> bool:
     if isinstance(data, np.ndarray):
         return False
 
-    # assert isinstance(data, list)
     # Check if data is a list and is not empty.
     if data:
         first_element = data[0]

--- a/irsim/world/__init__.py
+++ b/irsim/world/__init__.py
@@ -2,9 +2,6 @@ from irsim.world.map.obstacle_map import ObstacleMap
 from irsim.world.object_base import ObjectBase
 from irsim.world.object_factory import ObjectFactory
 from irsim.world.obstacles.obstacle_acker import ObstacleAcker
-
-# from irsim.world.object_base_3d import ObjectBase3D
-# from irsim.world.robots.robot_rigid3d import RobotRigid3D
 from irsim.world.obstacles.obstacle_diff import ObstacleDiff
 from irsim.world.obstacles.obstacle_omni import ObstacleOmni
 from irsim.world.obstacles.obstacle_static import ObjectStatic

--- a/irsim/world/map/__init__.py
+++ b/irsim/world/map/__init__.py
@@ -5,16 +5,10 @@ from typing import Any, Optional, Protocol, Union, runtime_checkable
 
 import numpy as np
 import shapely
-from shapely.geometry import Point
 
 from .grid_map_generator_base import GridMapGenerator
 from .image_map_generator import ImageGridGenerator
-from .obstacle_map import (
-    CELL_CENTER_OFFSET,
-    COLLISION_RADIUS_FACTOR,
-    OCCUPANCY_THRESHOLD,
-    ObstacleMap,
-)
+from .obstacle_map import ObstacleMap, grid_collision_geometry
 from .perlin_map_generator import PerlinGridGenerator
 
 # ---------------------------------------------------------------------------
@@ -106,45 +100,6 @@ def _downsample_occupancy_grid(
             j_hi = min(j_hi, fine_ny)
             out[ic, jc] = np.max(grid[i_lo:i_hi, j_lo:j_hi])
     return out
-
-
-def _grid_collision_geometry(
-    grid: np.ndarray,
-    grid_reso: tuple[float, float],
-    geometry,
-    world_offset: tuple[float, float] = (0.0, 0.0),
-) -> bool:
-    """Check collision of a Shapely geometry against an occupancy grid.
-
-    Uses the same logic as ObstacleMap.check_grid_collision.
-    """
-    if grid is None:
-        return False
-
-    minx, miny, maxx, maxy = geometry.bounds
-    x_reso, y_reso = grid_reso
-    offset_x, offset_y = world_offset
-
-    i_min = max(0, int((minx - offset_x) / x_reso))
-    i_max = min(grid.shape[0] - 1, int((maxx - offset_x) / x_reso))
-    j_min = max(0, int((miny - offset_y) / y_reso))
-    j_max = min(grid.shape[1] - 1, int((maxy - offset_y) / y_reso))
-
-    if i_min > i_max or j_min > j_max:
-        return False
-
-    collision_radius = max(x_reso, y_reso) * COLLISION_RADIUS_FACTOR
-
-    for i in range(i_min, i_max + 1):
-        for j in range(j_min, j_max + 1):
-            if grid[i, j] > OCCUPANCY_THRESHOLD:
-                cell_x = offset_x + (i + CELL_CENTER_OFFSET) * x_reso
-                cell_y = offset_y + (j + CELL_CENTER_OFFSET) * y_reso
-                cell_center = Point(cell_x, cell_y)
-                if geometry.distance(cell_center) <= collision_radius:
-                    return True
-
-    return False
 
 
 def resolve_obstacle_map(
@@ -373,7 +328,7 @@ class Map:
             return True
         if self.grid is not None:
             gr = self.grid_resolution
-            if gr is not None and _grid_collision_geometry(
+            if gr is not None and grid_collision_geometry(
                 self.grid, gr, geometry, world_offset=self.world_offset
             ):
                 return True

--- a/irsim/world/map/obstacle_map.py
+++ b/irsim/world/map/obstacle_map.py
@@ -16,6 +16,57 @@ CELL_CENTER_OFFSET = 0.5
 COLLISION_RADIUS_FACTOR = 0.5
 
 
+def grid_collision_geometry(
+    grid: np.ndarray | None,
+    grid_reso: tuple[float, float],
+    geometry,
+    world_offset: tuple[float, float] = (0.0, 0.0),
+) -> bool:
+    """Check collision of a Shapely geometry against an occupancy grid.
+
+    Uses a two-phase approach:
+    1. Quick bounding box check for early rejection
+    2. Precise check: verify if geometry actually intersects occupied cells
+
+    Args:
+        grid: Occupancy grid, or None when the map carries no grid.
+        grid_reso: Cell size ``(x_reso, y_reso)`` in meters.
+        geometry: Shapely geometry object to check collision for.
+        world_offset: World coordinates of the grid origin.
+
+    Returns:
+        bool: True if collision detected, False otherwise.
+    """
+    if grid is None:
+        return False
+
+    minx, miny, maxx, maxy = geometry.bounds
+    x_reso, y_reso = grid_reso
+    offset_x, offset_y = world_offset
+
+    # Convert world coordinates to grid indices (clamped to valid range)
+    i_min = max(0, int((minx - offset_x) / x_reso))
+    i_max = min(grid.shape[0] - 1, int((maxx - offset_x) / x_reso))
+    j_min = max(0, int((miny - offset_y) / y_reso))
+    j_max = min(grid.shape[1] - 1, int((maxy - offset_y) / y_reso))
+
+    if i_min > i_max or j_min > j_max:
+        return False
+
+    collision_radius = max(x_reso, y_reso) * COLLISION_RADIUS_FACTOR
+
+    for i in range(i_min, i_max + 1):
+        for j in range(j_min, j_max + 1):
+            if grid[i, j] > OCCUPANCY_THRESHOLD:
+                # Geometry within the collision radius of an occupied cell center
+                cell_x = offset_x + (i + CELL_CENTER_OFFSET) * x_reso
+                cell_y = offset_y + (j + CELL_CENTER_OFFSET) * y_reso
+                if geometry.distance(Point(cell_x, cell_y)) <= collision_radius:
+                    return True
+
+    return False
+
+
 class ObstacleMap(ObjectBase):
     """Static obstacle object backed by map line segments and optional grid data."""
 
@@ -64,52 +115,18 @@ class ObstacleMap(ObjectBase):
     def check_grid_collision(self, geometry) -> bool:
         """Check collision using grid array lookup.
 
-        Uses a two-phase approach:
-        1. Quick bounding box check for early rejection
-        2. Precise check: verify if geometry actually intersects occupied cells
-
         Args:
             geometry: Shapely geometry object to check collision for.
 
         Returns:
             bool: True if collision detected, False otherwise.
         """
-        if self.grid_map is None:
-            return False
-
-        # Get bounding box of the geometry
-        minx, miny, maxx, maxy = geometry.bounds
-
-        # Convert world coordinates to grid indices
-        x_reso = self.grid_reso[0, 0]
-        y_reso = self.grid_reso[1, 0]
-        offset_x, offset_y = self.world_offset
-
-        # Calculate grid indices (clamp to valid range)
-        i_min = max(0, int((minx - offset_x) / x_reso))
-        i_max = min(self.grid_map.shape[0] - 1, int((maxx - offset_x) / x_reso))
-        j_min = max(0, int((miny - offset_y) / y_reso))
-        j_max = min(self.grid_map.shape[1] - 1, int((maxy - offset_y) / y_reso))
-
-        if i_min > i_max or j_min > j_max:
-            return False
-
-        # Check each occupied cell in bounding box region
-        collision_radius = max(x_reso, y_reso) * COLLISION_RADIUS_FACTOR
-
-        for i in range(i_min, i_max + 1):
-            for j in range(j_min, j_max + 1):
-                if self.grid_map[i, j] > OCCUPANCY_THRESHOLD:
-                    # Get cell center in world coordinates
-                    cell_x = offset_x + (i + CELL_CENTER_OFFSET) * x_reso
-                    cell_y = offset_y + (j + CELL_CENTER_OFFSET) * y_reso
-                    cell_center = Point(cell_x, cell_y)
-
-                    # Check if geometry is within or exactly at the collision radius of the cell center
-                    if geometry.distance(cell_center) <= collision_radius:
-                        return True
-
-        return False
+        return grid_collision_geometry(
+            self.grid_map,
+            (self.grid_reso[0, 0], self.grid_reso[1, 0]),
+            geometry,
+            self.world_offset,
+        )
 
     def is_collision(self, geometry) -> bool:
         """Check collision against grid (if present) and map geometry."""

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -277,7 +277,35 @@ class ObjectBase:
         self.description = description
         self.color = color
 
-        # --- 2. Geometry & kinematics handlers ---
+        # --- 2-4. Handlers, and the dimensions and limits derived from them ---
+        self._init_handlers(shape, kinematics, role)
+        action_dim = self._init_dimensions(state_dim, vel_dim)
+        acce, vel_max, vel_min, angle_range = self._resolve_limits(
+            acce, vel_max, vel_min, angle_range
+        )
+
+        # --- 5-7. Motion state, goal, and geometry ---
+        self._init_motion_state(state, velocity, vel_min, vel_max, static, action_dim)
+        self._init_goal(goal, goal_threshold, arrive_mode)
+        self._init_geometry()
+
+        # --- 8. ObjectInfo ---
+        self._init_info(role, color, static, goal, acce, angle_range, goal_threshold)
+
+        # --- 9-10. Sensors and behavior ---
+        self._init_sensors(sensors, fov, fov_radius)
+        self._init_behavior(behavior, group_behavior)
+
+        # --- 11-12. Runtime flags and plot state ---
+        self._init_runtime_state(unobstructed, kwargs)
+
+        # --- 13. Validate kwargs ---
+        check_unknown_kwargs(kwargs, self._VALID_PARAMS, context=f" in '{role}' config")
+
+    def _init_handlers(
+        self, shape: dict | None, kinematics: dict | None, role: str
+    ) -> None:
+        """Create the geometry and kinematics handlers and their collision cone."""
         if shape is None:
             self.logger.warning(
                 f"No shape provided for object {self._id}, using default circle"
@@ -298,7 +326,8 @@ class ObjectBase:
         else:
             self.G, self.h, self.cone_type, self.convex_flag = None, None, None, None
 
-        # --- 3. Dimensions (derived from handlers) ---
+    def _init_dimensions(self, state_dim: int | None, vel_dim: int | None) -> int:
+        """Set the state and velocity shapes, and return the kinematics action dim."""
         action_dim = self.kf.action_dim if self.kf else 2
         self.state_dim = state_dim if state_dim is not None else self.state_shape[0]
         self.state_shape = (
@@ -307,7 +336,21 @@ class ObjectBase:
         self.vel_dim = vel_dim if vel_dim is not None else action_dim
         self.vel_shape = (self.vel_dim, 1)
 
-        # --- 4. Resolve defaults from kf ---
+        return action_dim
+
+    def _resolve_limits(
+        self,
+        acce: list | None,
+        vel_max: list | None,
+        vel_min: list | None,
+        angle_range: list | None,
+    ) -> tuple[list, list, list, list]:
+        """Fill in acceleration, velocity, and angle limits left unset by the config.
+
+        The kinematics model supplies the defaults when there is one; otherwise
+        the object is treated as unconstrained in acceleration and unit-limited
+        in velocity.
+        """
         if angle_range is None:
             angle_range = [-pi, pi]
 
@@ -320,7 +363,18 @@ class ObjectBase:
             vel_max = vel_max or [1, 1]
             vel_min = vel_min or [-1, -1]
 
-        # --- 5. State & velocity ---
+        return acce, vel_max, vel_min, angle_range
+
+    def _init_motion_state(
+        self,
+        state: list | None,
+        velocity: list | None,
+        vel_min: list,
+        vel_max: list,
+        static: bool,
+        action_dim: int,
+    ) -> None:
+        """Set the current and initial state, velocity, and velocity limits."""
         if state is None:
             state = [0, 0, 0]
         if velocity is None:
@@ -337,7 +391,10 @@ class ObjectBase:
         self.vel_max = np.c_[vel_max]
         self.static = static if self.kf is not None else True
 
-        # --- 6. Goal ---
+    def _init_goal(
+        self, goal: list | None, goal_threshold: float, arrive_mode: str
+    ) -> None:
+        """Store the goal queue, its footprint, and how arrival is judged."""
         self._goal = (
             deque(goal)
             if goal is not None and is_2d_list(goal)
@@ -357,13 +414,24 @@ class ObjectBase:
         self.goal_threshold = goal_threshold
         self.arrive_mode = arrive_mode
 
-        # --- 7. Geometry instance ---
+    def _init_geometry(self) -> None:
+        """Place the geometry at the current state and record its validity."""
         self._geometry = self.gf.step(self.state) if self.gf is not None else None
         self._geometry_valid = (
             shapely.is_valid(self._geometry) if self._geometry is not None else False
         )
 
-        # --- 8. ObjectInfo ---
+    def _init_info(
+        self,
+        role: str,
+        color: str,
+        static: bool,
+        goal: list | None,
+        acce: list,
+        angle_range: list,
+        goal_threshold: float,
+    ) -> None:
+        """Bundle the values behaviors and plots read into an ObjectInfo."""
         self.info = ObjectInfo(
             self._id,
             self.shape,
@@ -387,7 +455,10 @@ class ObjectBase:
         self.obstacle_info = None
         self.trajectory = []
 
-        # --- 9. Sensors ---
+    def _init_sensors(
+        self, sensors: dict | None, fov: float | None, fov_radius: float | None
+    ) -> None:
+        """Create the configured sensors and the field of view they imply."""
         sf = SensorFactory()
         self.lidar = None
         if sensors is not None:
@@ -418,7 +489,10 @@ class ObjectBase:
             self.fov = WrapTo2Pi(fov)
             self.fov_radius = fov_radius
 
-        # --- 10. Behavior ---
+    def _init_behavior(
+        self, behavior: dict | None, group_behavior: dict | None
+    ) -> None:
+        """Set up the behavior handlers and the goal sampling they may need."""
         self.obj_behavior = Behavior(self.info, behavior)
         self.group_behavior_dict = group_behavior if group_behavior is not None else {}
 
@@ -437,13 +511,13 @@ class ObjectBase:
         if self.wander:
             self._goal = deque([random_point_range(self.rl, self.rh)])
 
-        # --- 11. Flags ---
+    def _init_runtime_state(self, unobstructed: bool, kwargs: dict) -> None:
+        """Initialize the per-step flags and the plotting state."""
         self.stop_flag = False
         self.arrive_flag = False
         self.collision_flag = False
         self.unobstructed = unobstructed
 
-        # --- 12. Plot state ---
         self.plot_kwargs = kwargs.get("plot", {})
         self.plot_patch_list = []
         self.plot_line_list = []
@@ -453,9 +527,6 @@ class ObjectBase:
         self.collision_obj = []
         self.plot_trail_list = []
         self._object_plot = ObjectPlot(self)
-
-        # --- 13. Validate kwargs ---
-        check_unknown_kwargs(kwargs, self._VALID_PARAMS, context=f" in '{role}' config")
 
     def __eq__(self, o: "ObjectBase") -> bool:
         if isinstance(o, ObjectBase):

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -241,6 +241,31 @@ class TestKeyboardControlPynput:
         env.step()
         assert env.time > t1
 
+    def test_special_keys_without_env_are_ignored(self):
+        """Space/F5/ESC go through the guard, so a missing env is not a crash."""
+        # mpl backend: no environment means no display to gate on, and the
+        # pynput handlers stay directly callable regardless of backend.
+        kb = irsim.gui.keyboard_control.KeyboardControl(env_ref=None, backend="mpl")
+
+        for special in (keyboard.Key.space, keyboard.Key.f5, keyboard.Key.esc):
+            kb._on_pynput_special_release(special)  # must not raise
+
+    def test_special_keys_run_commands_with_env(self):
+        """With an environment attached the same keys reach their commands."""
+        kb = irsim.gui.keyboard_control.KeyboardControl(env_ref=None, backend="mpl")
+        kb.env_ref = Mock()
+        kb._toggle_pause = Mock()
+        kb._step_debug = Mock()
+        kb._quit_env = Mock()
+
+        kb._on_pynput_special_release(keyboard.Key.space)
+        kb._on_pynput_special_release(keyboard.Key.f5)
+        kb._on_pynput_special_release(keyboard.Key.esc)
+
+        kb._toggle_pause.assert_called_once()
+        kb._step_debug.assert_called_once()
+        kb._quit_env.assert_called_once()
+
     def test_invalid_backend_falls_back_to_mpl(self, env_factory):
         """Test invalid backend falls back to mpl."""
         env = env_factory("test_keyboard_control.yaml")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -46,16 +46,21 @@ class TestKeyboardControlPynput:
         env.keyboard._on_pynput_release(mock_keyboard_key("l"))
         assert len(env.names) == len(pre_names)
 
-    def test_reset_without_env_reference_warns(self, env_factory, mock_keyboard_key):
-        """Releasing 'r' without an environment reference warns instead of failing."""
+    def test_commands_without_env_reference_warn(self, env_factory):
+        """Command keys need the environment, and are ignored when it is unset."""
         env = env_factory("test_keyboard_control.yaml")
         keyboard_control = env.keyboard
         keyboard_control._active_only = False
         keyboard_control.env_ref = None
 
-        keyboard_control._reset_env()
+        for key in ("r", "space", "l", "f5", "v", "y", "escape"):
+            keyboard_control._run_command_key(key)  # ignored, never raises
+
+        # the control mode needs no environment, so it still switches
+        keyboard_control._run_command_key("x")
 
         assert keyboard_control.env_ref is None
+        assert env._world_param.control_mode == "auto"
 
     def test_escape_key_quits_pynput(self, env_factory):
         """ESC has no character, so it is handled as a special key release."""

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -46,6 +46,47 @@ class TestKeyboardControlPynput:
         env.keyboard._on_pynput_release(mock_keyboard_key("l"))
         assert len(env.names) == len(pre_names)
 
+    def test_reset_without_env_reference_warns(self, env_factory, mock_keyboard_key):
+        """Releasing 'r' without an environment reference warns instead of failing."""
+        env = env_factory("test_keyboard_control.yaml")
+        keyboard_control = env.keyboard
+        keyboard_control._active_only = False
+        keyboard_control.env_ref = None
+
+        keyboard_control._reset_env()
+
+        assert keyboard_control.env_ref is None
+
+    def test_escape_key_quits_pynput(self, env_factory):
+        """ESC has no character, so it is handled as a special key release."""
+        env = env_factory("test_keyboard_control.yaml")
+        env.keyboard._active_only = False
+
+        class EscKeyMock:
+            name = "esc"
+
+            def __eq__(self, other):
+                return other == keyboard.Key.esc
+
+        env.keyboard._on_pynput_release(EscKeyMock())
+
+        assert env.quit_flag is True
+
+    def test_special_release_without_pynput(self, env_factory, monkeypatch):
+        """Without pynput there are no key constants to compare, so nothing runs."""
+        env = env_factory("test_keyboard_control.yaml")
+        env.keyboard._active_only = False
+        monkeypatch.setattr(irsim.gui.keyboard_control, "keyboard", None)
+
+        class AltKeyMock:
+            name = "alt"
+
+        env.keyboard.alt_flag = True
+        env.keyboard._on_pynput_release(AltKeyMock())
+
+        assert env.keyboard.alt_flag is False
+        assert env.quit_flag is False
+
     def test_alt_key_robot_selection(self, env_factory):
         """Test Alt+number selects robot."""
         env = env_factory("test_keyboard_control.yaml")
@@ -439,6 +480,17 @@ class TestKeyboardControlMpl:
         assert env.keyboard._world_param.control_mode != mode0
         env.keyboard._on_mpl_release(mock_mpl_event("x"))
         assert env.keyboard._world_param.control_mode == mode0
+
+    def test_space_key_normalized_from_blank(self, env_factory, mock_mpl_event):
+        """Matplotlib spells the space key both ways; both pause the environment."""
+        env = env_factory("test_keyboard_control.yaml")
+        env.keyboard._active_only = False
+
+        env.keyboard._on_mpl_release(mock_mpl_event(" "))
+        assert "Pause" in env.status
+
+        env.keyboard._on_mpl_release(mock_mpl_event("space"))
+        assert "Pause" not in env.status
 
     def test_escape_key_quit(self, env_factory, mock_mpl_event):
         """Test escape key sets quit flag in mpl backend."""

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -344,6 +344,22 @@ class TestDrawPatch:
             atol=1e-9,
         )
 
+    def test_state_transforms_patches_but_not_lines(self, ax_2d):
+        """The documented frame contract: a patch follows state, a line does not."""
+        state = np.array([[10.0], [20.0], [0.0]])
+        vertices = np.array([[0.0, 1.0, 1.0], [0.0, 0.0, 1.0]])
+
+        polygon = draw_patch(ax_2d, "polygon", state=state, vertices=vertices)
+        line = draw_patch(ax_2d, "linestring", state=state, vertices=vertices)
+
+        drawn = ax_2d.transData.inverted().transform(
+            polygon.get_transform().transform(polygon.get_path().vertices)
+        )
+        np.testing.assert_allclose(drawn[0], [10.0, 20.0], atol=1e-9)
+        np.testing.assert_allclose(
+            np.asarray(line.get_xydata())[0], [0.0, 0.0], atol=1e-9
+        )
+
     def test_draw_polygon(self, ax_2d):
         """Test drawing polygon patch."""
         state = np.array([[0.0], [0.0], [0.0]])

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -259,16 +259,65 @@ class TestDrawPatch:
         assert rect is not None
 
     def test_draw_rectangle_missing_params_raises(self, ax_2d):
-        """Test rectangle without vertices raises."""
+        """Test rectangle without vertices or width/height raises."""
         state = np.array([[0.0], [0.0], [0.0]])
-        with pytest.raises(ValueError, match="rectangle requires vertices"):
+        with pytest.raises(
+            ValueError, match="rectangle requires either vertices or width/height"
+        ):
             draw_patch(ax_2d, "rectangle", state=state)
 
-    def test_draw_rectangle_requires_vertices(self, ax_2d):
-        """A rectangle is described by its vertices, as a polygon is."""
-        state = np.array([[0.0], [0.0], [0.0]])
-        with pytest.raises(ValueError, match="rectangle requires vertices"):
-            draw_patch(ax_2d, "rectangle", state=state, width=1.0, height=0.5)
+    def test_draw_rectangle_from_width_height(self, ax_2d):
+        """A width/height rectangle lands where the collision geometry does."""
+        state = np.array([[1.0], [2.0], [0.4]])
+        rect = draw_patch(ax_2d, "rectangle", state=state, width=2.0, height=1.0)
+
+        assert rect is not None
+        drawn = ax_2d.transData.inverted().transform(
+            rect.get_transform().transform(rect.get_path().vertices)
+        )
+        geometry = GeometryFactory.create_geometry(
+            name="rectangle", length=2.0, width=1.0
+        ).step(state)
+
+        def ordered(points):
+            points = np.unique(np.round(np.asarray(points, dtype=float), 9), axis=0)
+            return points[np.lexsort((points[:, 1], points[:, 0]))]
+
+        np.testing.assert_allclose(
+            ordered(drawn),
+            ordered(np.asarray(geometry.exterior.coords)[:-1]),
+            atol=1e-9,
+        )
+
+    def test_draw_rectangle_width_height_honors_center(self, ax_2d):
+        """An Ackermann box is offset from the origin, and center reproduces it."""
+        state = np.array([[1.0], [2.0], [0.4]])
+        handler = GeometryFactory.create_geometry(
+            name="rectangle", length=2.0, width=1.0, wheelbase=1.0
+        )
+        geometry = handler.step(state)
+        rect = draw_patch(
+            ax_2d,
+            "rectangle",
+            state=state,
+            width=2.0,
+            height=1.0,
+            center=handler.original_vertices.mean(axis=1),
+        )
+
+        drawn = ax_2d.transData.inverted().transform(
+            rect.get_transform().transform(rect.get_path().vertices)
+        )
+
+        def ordered(points):
+            points = np.unique(np.round(np.asarray(points, dtype=float), 9), axis=0)
+            return points[np.lexsort((points[:, 1], points[:, 0]))]
+
+        np.testing.assert_allclose(
+            ordered(drawn),
+            ordered(np.asarray(geometry.exterior.coords)[:-1]),
+            atol=1e-9,
+        )
 
     def test_draw_rectangle_matches_collision_geometry(self, ax_2d):
         """Body-frame vertices plus the state transform land on the geometry."""

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -259,50 +259,26 @@ class TestDrawPatch:
         assert rect is not None
 
     def test_draw_rectangle_missing_params_raises(self, ax_2d):
-        """Test rectangle without vertices or width/height raises."""
+        """Test rectangle without vertices raises."""
         state = np.array([[0.0], [0.0], [0.0]])
-        with pytest.raises(
-            ValueError, match="rectangle requires either vertices or width/height"
-        ):
+        with pytest.raises(ValueError, match="rectangle requires vertices"):
             draw_patch(ax_2d, "rectangle", state=state)
 
-    def test_draw_rectangle_from_width_height(self, ax_2d):
-        """A width/height rectangle lands where the collision geometry does."""
-        state = np.array([[1.0], [2.0], [0.4]])
-        rect = draw_patch(ax_2d, "rectangle", state=state, width=2.0, height=1.0)
+    def test_draw_rectangle_requires_vertices(self, ax_2d):
+        """A rectangle is described by its vertices, as a polygon is."""
+        state = np.array([[0.0], [0.0], [0.0]])
+        with pytest.raises(ValueError, match="rectangle requires vertices"):
+            draw_patch(ax_2d, "rectangle", state=state, width=1.0, height=0.5)
 
-        assert rect is not None
-        drawn = ax_2d.transData.inverted().transform(
-            rect.get_transform().transform(rect.get_path().vertices)
-        )
-        geometry = GeometryFactory.create_geometry(
-            name="rectangle", length=2.0, width=1.0
-        ).step(state)
-
-        def ordered(points):
-            points = np.unique(np.round(np.asarray(points, dtype=float), 9), axis=0)
-            return points[np.lexsort((points[:, 1], points[:, 0]))]
-
-        np.testing.assert_allclose(
-            ordered(drawn),
-            ordered(np.asarray(geometry.exterior.coords)[:-1]),
-            atol=1e-9,
-        )
-
-    def test_draw_rectangle_width_height_honors_center(self, ax_2d):
-        """An Ackermann box is offset from the origin, and center reproduces it."""
+    def test_draw_rectangle_matches_collision_geometry(self, ax_2d):
+        """Body-frame vertices plus the state transform land on the geometry."""
         state = np.array([[1.0], [2.0], [0.4]])
         handler = GeometryFactory.create_geometry(
             name="rectangle", length=2.0, width=1.0, wheelbase=1.0
         )
         geometry = handler.step(state)
         rect = draw_patch(
-            ax_2d,
-            "rectangle",
-            state=state,
-            width=2.0,
-            height=1.0,
-            center=handler.original_vertices.mean(axis=1),
+            ax_2d, "rectangle", state=state, vertices=handler.original_vertices
         )
 
         drawn = ax_2d.transData.inverted().transform(

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -96,6 +96,44 @@ class TestEnvPlot2D:
         """Test clearing all dynamic components."""
         plot_2d.clear_components("all", [])
 
+    def test_clear_components_removes_dynamic_artists(self, plot_2d):
+        """Lines, points and quivers drawn this step are removed and forgotten."""
+        plot_2d.draw_trajectory(np.array([[0.0, 1.0], [0.0, 1.0]]), refresh=True)
+        plot_2d.draw_points(np.array([[0.0], [1.0]]), refresh=True)
+        plot_2d.draw_quiver(np.array([[0.0], [0.0], [1.0], [1.0]]), refresh=True)
+        assert plot_2d.dyna_line_list
+        assert plot_2d.dyna_point_list
+        assert plot_2d.dyna_quiver_list
+
+        plot_2d.clear_components("dynamic", [])
+
+        assert plot_2d.dyna_line_list == []
+        assert plot_2d.dyna_point_list == []
+        assert plot_2d.dyna_quiver_list == []
+
+    def test_static_mode_touches_only_static_objects(self, plot_2d):
+        """Static mode draws and clears the static objects and leaves the rest."""
+
+        class FakeObject:
+            def __init__(self, static):
+                self.static = static
+                self.drawn = self.cleared = 0
+
+            def plot(self, ax, **kwargs):
+                self.drawn += 1
+
+            def plot_clear(self, all=False):
+                self.cleared += 1
+
+        static_obj, moving_obj = FakeObject(True), FakeObject(False)
+        objects = [static_obj, moving_obj]
+
+        plot_2d.draw_components("static", objects)
+        plot_2d.clear_components("static", objects)
+
+        assert (static_obj.drawn, static_obj.cleared) == (1, 1)
+        assert (moving_obj.drawn, moving_obj.cleared) == (0, 0)
+
     def test_set_ax_viewpoint_none_objects(self, dummy_world_2d, dummy_logger):
         """Test set_ax_viewpoint with None objects."""
         plot = EnvPlot(
@@ -446,6 +484,19 @@ class TestDrawPatch:
         ls = draw_patch(ax_2d, "linestring", vertices=line_vertices, color="k")
         assert ls is not None
 
+    def test_shape_builders_require_their_inputs(self, ax_2d):
+        """Each shape reports the input it is missing."""
+        state = np.array([[0.0], [0.0], [0.0]])
+        for shape, match in (
+            ("circle", "circle requires radius"),
+            ("polygon", "polygon requires vertices"),
+            ("ellipse", "ellipse requires width and height"),
+            ("wedge", "wedge requires radius"),
+            ("line", "line/linestring requires vertices"),
+        ):
+            with pytest.raises(ValueError, match=match):
+                draw_patch(ax_2d, shape, state=state)
+
     def test_draw_unknown_shape_raises(self, ax_2d):
         """Test unknown shape type raises ValueError."""
         state = np.array([[0.0], [0.0], [0.0]])
@@ -459,6 +510,19 @@ class TestDrawPatch:
             ax_3d, "line", vertices=line_vertices, color="k", alpha=0.8, zorder=2
         )
         assert line3d is not None
+
+    def test_draw_line_3d_ignores_fill(self, ax_3d):
+        """A line has no fill to set, so the flag is ignored rather than applied."""
+        line3d = draw_patch(
+            ax_3d,
+            "line",
+            vertices=np.array([[0.0, 1.0], [0.0, 1.0]]),
+            color="k",
+            fill=False,
+        )
+
+        assert line3d is not None
+        assert not hasattr(line3d, "set_fill")
 
     def test_draw_circle_3d(self, ax_3d):
         """Test drawing circle on 3D axes (patch_2d_to_3d conversion)."""

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -289,6 +289,36 @@ class TestDrawPatch:
             atol=1e-9,
         )
 
+    def test_draw_rectangle_width_height_honors_center(self, ax_2d):
+        """An Ackermann box is offset from the origin, and center reproduces it."""
+        state = np.array([[1.0], [2.0], [0.4]])
+        handler = GeometryFactory.create_geometry(
+            name="rectangle", length=2.0, width=1.0, wheelbase=1.0
+        )
+        geometry = handler.step(state)
+        rect = draw_patch(
+            ax_2d,
+            "rectangle",
+            state=state,
+            width=2.0,
+            height=1.0,
+            center=handler.original_vertices.mean(axis=1),
+        )
+
+        drawn = ax_2d.transData.inverted().transform(
+            rect.get_transform().transform(rect.get_path().vertices)
+        )
+
+        def ordered(points):
+            points = np.unique(np.round(np.asarray(points, dtype=float), 9), axis=0)
+            return points[np.lexsort((points[:, 1], points[:, 0]))]
+
+        np.testing.assert_allclose(
+            ordered(drawn),
+            ordered(np.asarray(geometry.exterior.coords)[:-1]),
+            atol=1e-9,
+        )
+
     def test_draw_polygon(self, ax_2d):
         """Test drawing polygon patch."""
         state = np.array([[0.0], [0.0], [0.0]])

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -22,6 +22,7 @@ import irsim
 import irsim.env.env_plot as env_plot_module
 from irsim.env.env_plot import EnvPlot, draw_patch
 from irsim.env.env_plot3d import EnvPlot3D
+from irsim.lib.handler.geometry_handler import GeometryFactory
 from irsim.world.object_base import ObjectBase
 from irsim.world.object_plot import ObjectPlotOptions
 
@@ -265,11 +266,28 @@ class TestDrawPatch:
         ):
             draw_patch(ax_2d, "rectangle", state=state)
 
-    def test_draw_rectangle_partial_params_raises(self, ax_2d):
-        """Test rectangle with width/height but no vertices raises."""
-        state = np.array([[0.0], [0.0], [0.0]])
-        with pytest.raises(TypeError):
-            draw_patch(ax_2d, "rectangle", state=state, width=1.0, height=0.5)
+    def test_draw_rectangle_from_width_height(self, ax_2d):
+        """A width/height rectangle lands where the collision geometry does."""
+        state = np.array([[1.0], [2.0], [0.4]])
+        rect = draw_patch(ax_2d, "rectangle", state=state, width=2.0, height=1.0)
+
+        assert rect is not None
+        drawn = ax_2d.transData.inverted().transform(
+            rect.get_transform().transform(rect.get_path().vertices)
+        )
+        geometry = GeometryFactory.create_geometry(
+            name="rectangle", length=2.0, width=1.0
+        ).step(state)
+
+        def ordered(points):
+            points = np.unique(np.round(np.asarray(points, dtype=float), 9), axis=0)
+            return points[np.lexsort((points[:, 1], points[:, 0]))]
+
+        np.testing.assert_allclose(
+            ordered(drawn),
+            ordered(np.asarray(geometry.exterior.coords)[:-1]),
+            atol=1e-9,
+        )
 
     def test_draw_polygon(self, ax_2d):
         """Test drawing polygon patch."""

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -20,6 +20,7 @@ from matplotlib.lines import Line2D
 
 import irsim
 import irsim.env.env_plot as env_plot_module
+from irsim.config import env_param
 from irsim.env.env_plot import EnvPlot, draw_patch
 from irsim.env.env_plot3d import EnvPlot3D
 from irsim.lib.handler.geometry_handler import GeometryFactory
@@ -110,6 +111,15 @@ class TestEnvPlot2D:
         assert plot_2d.dyna_line_list == []
         assert plot_2d.dyna_point_list == []
         assert plot_2d.dyna_quiver_list == []
+
+    def test_clear_components_reports_invalid_mode(self, plot_2d, monkeypatch):
+        """An unknown mode is reported rather than silently doing nothing."""
+        logger = Mock()
+        monkeypatch.setattr(env_param, "logger", logger)
+
+        plot_2d.clear_components("bogus", [])
+
+        logger.error.assert_called_once()
 
     def test_static_mode_touches_only_static_objects(self, plot_2d):
         """Static mode draws and clears the static objects and leaves the rest."""
@@ -524,11 +534,66 @@ class TestDrawPatch:
         assert line3d is not None
         assert not hasattr(line3d, "set_fill")
 
+    @pytest.mark.parametrize("num_points", [2, 3, 5])
+    def test_draw_line_3d_matches_vertex_count(self, ax_3d, num_points):
+        """The default z carries one height per vertex, so the line can draw."""
+        vertices = np.vstack(
+            [np.linspace(0.0, 1.0, num_points), np.linspace(0.0, 1.0, num_points)]
+        )
+        line3d = draw_patch(ax_3d, "line", vertices=vertices, color="k")
+
+        assert line3d.get_data_3d()[2].shape == (num_points,)
+        ax_3d.figure.canvas.draw()
+
+    def test_draw_line_3d_explicit_z(self, ax_3d):
+        """An explicit z overrides the flat default."""
+        line3d = draw_patch(
+            ax_3d,
+            "line",
+            vertices=np.array([[0.0, 1.0], [0.0, 1.0]]),
+            z=np.array([2.0, 3.0]),
+        )
+
+        assert list(line3d.get_data_3d()[2]) == [2.0, 3.0]
+
     def test_draw_circle_3d(self, ax_3d):
         """Test drawing circle on 3D axes (patch_2d_to_3d conversion)."""
         state = np.array([[0.0], [0.0], [0.0]])
         circ3d = draw_patch(ax_3d, "circle", state=state, radius=0.2, color="r")
         assert circ3d is not None
+
+
+class TestViewpoint:
+    """Tests for the camera centre set by the ``viewpoint`` plot option."""
+
+    @staticmethod
+    def _center(env):
+        x_lim, y_lim = env._env_plot.ax.get_xlim(), env._env_plot.ax.get_ylim()
+        return ((x_lim[0] + x_lim[1]) / 2, (y_lim[0] + y_lim[1]) / 2)
+
+    def test_follow_viewpoint_centred_before_first_render(self, env_factory):
+        """A followed object is framed at creation, not after the first step."""
+        env = env_factory("test_multi_objects_world.yaml")
+
+        assert self._center(env) == pytest.approx(tuple(env.robot.state[:2, 0]))
+
+    def test_follow_viewpoint_centred_after_reset(self, env_factory):
+        """Reset re-frames the followed object without a jump via the world centre."""
+        env = env_factory("test_multi_objects_world.yaml")
+        for _ in range(10):
+            env.step()
+            env.render(0.0)
+
+        env.reset()
+
+        # No render in between: the reset frame is already on the robot.
+        assert self._center(env) == pytest.approx(tuple(env.robot.state[:2, 0]))
+
+    def test_fixed_viewpoint_centred_before_first_render(self, env_factory):
+        """A fixed [x, y] viewpoint is applied at creation too."""
+        env = env_factory("test_all_objects.yaml")
+
+        assert self._center(env) == pytest.approx((3.0, 3.0))
 
 
 class TestGoalText:

--- a/tests/test_world_map.py
+++ b/tests/test_world_map.py
@@ -7,7 +7,7 @@ Covers:
 - GridMapGenerator base (grid property, preview)
 - resolve_obstacle_map and build_grid_from_generator
 - Map (grid_occupied, grid_resolution, is_collision)
-- _grid_collision_geometry (grid vs geometry collision)
+- grid_collision_geometry (grid vs geometry collision)
 - FogMap (fog-of-map overlay) and its world/env integration
 """
 
@@ -692,21 +692,17 @@ class TestMapIsCollision:
         assert m.is_collision(ShapelyPoint(1, 1)) is False
 
     def test_grid_collision_geometry_none_grid_returns_false(self):
-        """_grid_collision_geometry with grid=None returns False."""
+        """grid_collision_geometry with grid=None returns False."""
         pt = ShapelyPoint(1, 1)
-        out = world_map_module._grid_collision_geometry(
-            None, (1.0, 1.0), pt, (0.0, 0.0)
-        )
+        out = world_map_module.grid_collision_geometry(None, (1.0, 1.0), pt, (0.0, 0.0))
         assert out is False
 
     def test_grid_collision_geometry_bounds_outside_grid(self):
-        """_grid_collision_geometry returns False when geometry bounds outside grid."""
+        """grid_collision_geometry returns False when geometry bounds outside grid."""
         # Grid 10x10, reso 1.0, offset 0,0. Geometry at 100,100 -> i_min > i_max
         grid = np.zeros((10, 10), dtype=np.float64)
         pt = ShapelyPoint(100, 100)
-        out = world_map_module._grid_collision_geometry(
-            grid, (1.0, 1.0), pt, (0.0, 0.0)
-        )
+        out = world_map_module.grid_collision_geometry(grid, (1.0, 1.0), pt, (0.0, 0.0))
         assert out is False
 
     def test_map_world_offset_accepts_list(self):


### PR DESCRIPTION
This branch removes duplicated and dead code across the simulator. The simulation behavior is unchanged, apart from the fixes listed below.

### Refactor

- `EnvBase` and `EnvConfig` share one scene setup, and the object lookup and duplicate-name checks live in one place.
- The eight behaviors share one goal guard, the RVO cone geometry is computed in one helper, and the two kinematics models share one motion noise model.
- A* and JPS share a grid planner base, and the RRT family shares its per-run setup.
- The two keyboard backends share one key table.
- `draw_patch` builds its shapes from a builder map, and `ObjectBase.__init__` is split into focused steps.
- Dead code is gone: an uncalled bind helper, an unused plotting helper, two unread module flags, and 22 blocks of commented-out code.

### Fix

- `draw_patch` can draw a rectangle from width and height again. That form raised `TypeError` before, because it read vertices it had just checked were `None`.
- A width/height rectangle is placed by its body-frame center, so an Ackermann box lands on its collision geometry.
- A follow viewpoint is centered when the plot is initialized, so `make()` and `reset()` no longer show one frame at the world center before snapping to the target. A fixed `[x, y]` viewpoint was affected the same way.
- A 3D line gets one default z per vertex. The default was hard-coded to length three, which broke the draw for a line with any other number of points.
- Command keys are ignored, with a warning, when the control has no environment to act on, and the pynput backend routes space/F5/ESC through that same guard. The logger falls back to loguru so the warning itself cannot raise.
- The pynput backend changes the speed limits only while keyboard control is active, which is what the matplotlib backend already did.
- `clear_components` reports an invalid mode instead of silently doing nothing, matching `draw_components`.

### Docs

- `draw_patch` now says which frame its vertices are in. A patch is built in the body frame and placed by `state`; a line takes world coordinates and never sees `state`.

### Tests

- New tests cover the shared plot and keyboard helpers, the viewpoint centering, the 3D line z default, and the missing-environment key guard.
