### PR TITLE
fix(behavior): command omni robots in the frame they are steered in

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,19 @@ For more examples, see the [usage directory](https://github.com/hanruihua/ir-sim
 - **[RAL & ICRA 2023]** [rl-rvo-nav](https://github.com/hanruihua/rl_rvo_nav) -- Reinforcement learning-based RVO behavior for multi-robot navigation.
 - **[RAL & IROS 2023]** [RDA_planner](https://github.com/hanruihua/RDA_planner) -- Accelerated collision-free motion planner for cluttered environments.
 - **[T-RO 2025]** [NeuPAN](https://github.com/hanruihua/NeuPAN) -- Direct point robot navigation with end-to-end model-based learning.
+- **[ROBIO 2025]** [MfNeuPAN](https://doi.org/10.1109/ROBIO66223.2025.11377233) -- Proactive end-to-end navigation in dynamic environments using direct multi-frame point constraints.
+- **[IROS 2026]** [SDLW](https://github.com/williamleong/sdlw) -- Decentralized scalable exploration using sensor-driven Lévy walks for minimal-sensing robot teams.
+- **[Sensors 2026]** [PPO-GAT-Follow](https://doi.org/10.3390/s26154711) -- Graph-attention reinforcement learning for robot person following in dense crowds.
+- **[TWC 2026]** [Energy-Efficient Federated Edge Learning for Small-Scale Datasets in Large IoT Networks](https://doi.org/10.1109/TWC.2026.3683911)
 
 ### Community Projects
 
 - [DRL-robot-navigation-IR-SIM](https://github.com/reiniscimurs/DRL-robot-navigation-IR-SIM) -- Deep reinforcement learning for robot navigation.
 - [AutoNavRL](https://github.com/harshmahesheka/AutoNavRL) -- Autonomous navigation using reinforcement learning.
 - [IRSIM-3DGS-Bridge](https://github.com/Wayneyujie/IRSIM-3DGS-Bridge) -- A closed-loop bridge from 3D Gaussian Splatting scenes to IR-SIM planning/following and back to Habitat-GS trajectory playback.
+- [EdgeVox](https://github.com/nrl-ai/edgevox) -- Offline voice-agent framework with an IR-SIM mobile-navigation backend.
+
+*If your publication or project use IR-SIM, we welcome you to propose it for inclusion via an issue or pull request.*
 
 ## Citation
 

--- a/docs/locale/zh_CN/LC_MESSAGES/index.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/index.po
@@ -281,6 +281,52 @@ msgstr ""
 "型学习的点云直接驱动机器人导航。"
 
 #: ../../source/index.rst:236
+msgid ""
+"`MfNeuPAN (ROBIO 2025) <https://doi.org/10.1109/ROBIO66223.2025.11377233>`_ "
+"- Proactive end-to-end navigation in dynamic environments using direct multi-"
+"frame point constraints."
+msgstr ""
+"`MfNeuPAN（ROBIO 2025） <https://doi.org/10.1109/ROBIO66223.2025.11377233>`_ "
+"- 基于直接多帧点约束的动态环境前瞻式端到端导航。"
+
+#: ../../source/index.rst:238
+msgid ""
+"`SDLW (IROS 2026) <https://github.com/williamleong/sdlw>`_ - Decentralized "
+"scalable exploration using sensor-driven Lévy walks for minimal-sensing robot "
+"teams."
+msgstr ""
+"`SDLW（IROS 2026） <https://github.com/williamleong/sdlw>`_ - 面向最小感知机"
+"器人团队的基于传感器驱动列维游走的分布式可扩展探索。"
+
+#: ../../source/index.rst:238
+msgid ""
+"`PPO-GAT-Follow (Sensors 2026) <https://doi.org/10.3390/s26154711>`_ - "
+"Graph-attention reinforcement learning for robot person following in dense "
+"crowds."
+msgstr ""
+"`PPO-GAT-Follow（Sensors 2026） <https://doi.org/10.3390/s26154711>`_ - 面"
+"向密集人群中机器人跟随任务的图注意力强化学习方法。"
+
+#: ../../source/index.rst:239
+msgid ""
+"`Energy-Efficient Federated Edge Learning for Small-Scale Datasets in Large "
+"IoT Networks (TWC 2026) <https://doi.org/10.1109/TWC.2026.3683911>`_ - "
+"Federated edge learning validated through autonomous navigation and collision "
+"avoidance in IR-SIM."
+msgstr ""
+"`面向大规模物联网小规模数据集的节能联邦边缘学习（TWC 2026） <https://doi.org/"
+"10.1109/TWC.2026.3683911>`_ - 通过 IR-SIM 中的自主导航与避障验证联邦边缘"
+"学习方法。"
+
+#: ../../source/index.rst:240
+msgid ""
+"If your publication uses IR-SIM, we welcome you to propose it for inclusion "
+"via an issue or pull request."
+msgstr ""
+"如果您的论文使用了 IR-SIM，欢迎通过 issue 或 pull request 提交收录"
+"建议。"
+
+#: ../../source/index.rst:236
 msgid "Community Projects"
 msgstr "社区项目"
 
@@ -309,6 +355,14 @@ msgstr ""
 "`IRSIM-3DGS-Bridge <https://github.com/Wayneyujie/IRSIM-3DGS-Bridge>`_ - 一座"
 "闭环桥梁，将三维高斯泼溅（3D Gaussian Splatting）场景接入 IR-SIM 进行规划与跟"
 "随，再返回 Habitat-GS 进行轨迹回放。"
+
+#: ../../source/index.rst:242
+msgid ""
+"`EdgeVox <https://github.com/nrl-ai/edgevox>`_ - Offline voice-agent framework "
+"with an IR-SIM mobile-navigation backend."
+msgstr ""
+"`EdgeVox <https://github.com/nrl-ai/edgevox>`_ - 以 IR-SIM 移动导航后端为基础的"
+"离线语音智能体框架。"
 
 #: ../../source/index.rst:244
 msgid "Citation"

--- a/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
@@ -1531,15 +1531,15 @@ msgstr ""
 
 #: ../../source/yaml_config/configuration.md:944
 msgid ""
-"For `diff` and `acker` the conversion passes the velocity through, since "
-"those models are commanded with a speed rather than a frame-dependent "
-"vector. `omni_angular` is commanded directly with `[forward, lateral, "
-"yaw_rate]`, which a world-frame translation does not determine, so it has no "
-"conversion."
+"`omni` rotates `[vx, vy]` into `[forward, lateral]`, and `diff` maps it to "
+"`[linear, angular]` using the robot's angular limit and the world step time. "
+"`acker` and `omni_angular` are commanded directly, and a world-frame "
+"translation does not determine their command, so the conversion raises for "
+"them."
 msgstr ""
-"对于 `diff` 和 `acker`，该转换直接返回原速度：这两种模型由速度标量控制，而非依"
-"赖坐标系的向量。`omni_angular` 直接由 `[forward, lateral, yaw_rate]` 控制，而世"
-"界坐标系下的平移速度无法确定其偏航角速度，因此不提供该转换。"
+"`omni` 将 `[vx, vy]` 旋转为 `[forward, lateral]`；`diff` 则依据机器人的角速度上"
+"限与世界步长，将其映射为 `[linear, angular]`。`acker` 与 `omni_angular` 由指令"
+"直接控制，世界坐标系下的平移速度无法确定其指令，因此该转换会抛出异常。"
 
 #: ../../source/yaml_config/configuration.md:933
 msgid ""

--- a/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
@@ -1517,6 +1517,30 @@ msgstr "**object 运动学**"
 msgid "Kinematics Models"
 msgstr "运动学模型"
 
+#: ../../source/yaml_config/configuration.md:938
+msgid ""
+"Velocity commands are expressed in the robot's own frame, while `[vx, vy]` "
+"describes the rigid-body motion in the world frame. A holonomic planner such "
+"as RVO, SFM or ORCA plans in the world frame, so its velocity is converted "
+"at that boundary. An external controller that plans in the world frame "
+"converts the same way:"
+msgstr ""
+"速度指令在机器人自身坐标系下表示，而 `[vx, vy]` 描述的是世界坐标系下的刚体运"
+"动。RVO、SFM、ORCA 等全向规划器在世界坐标系下求解，因此其速度会在该边界处完成"
+"转换。在世界坐标系下规划的外部控制器同样按此转换："
+
+#: ../../source/yaml_config/configuration.md:944
+msgid ""
+"For `diff` and `acker` the conversion passes the velocity through, since "
+"those models are commanded with a speed rather than a frame-dependent "
+"vector. `omni_angular` is commanded directly with `[forward, lateral, "
+"yaw_rate]`, which a world-frame translation does not determine, so it has no "
+"conversion."
+msgstr ""
+"对于 `diff` 和 `acker`，该转换直接返回原速度：这两种模型由速度标量控制，而非依"
+"赖坐标系的向量。`omni_angular` 直接由 `[forward, lateral, yaw_rate]` 控制，而世"
+"界坐标系下的平移速度无法确定其偏航角速度，因此不提供该转换。"
+
 #: ../../source/yaml_config/configuration.md:933
 msgid ""
 "**`diff`**: Differential drive, controlled by linear speed and angular "

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -232,6 +232,12 @@ Projects using IR-SIM
         * `rl-rvo-nav (RAL & ICRA2023) <https://github.com/hanruihua/rl_rvo_nav>`_ - Reinforcement learning-based RVO behavior for multi-robot navigation.
         * `RDA_planner (RAL & IROS2023) <https://github.com/hanruihua/RDA_planner>`_ - Accelerated collision-free motion planner for cluttered environments.
         * `NeuPAN (T-RO 2025) <https://github.com/hanruihua/NeuPAN>`_ - Direct point robot navigation with end-to-end model-based learning.
+        * `MfNeuPAN (ROBIO 2025) <https://doi.org/10.1109/ROBIO66223.2025.11377233>`_ - Proactive end-to-end navigation in dynamic environments using direct multi-frame point constraints.
+        * `SDLW (IROS 2026) <https://github.com/williamleong/sdlw>`_ - Decentralized scalable exploration using sensor-driven Lévy walks for minimal-sensing robot teams.
+        * `PPO-GAT-Follow (Sensors 2026) <https://doi.org/10.3390/s26154711>`_ - Graph-attention reinforcement learning for robot person following in dense crowds.
+        * `Energy-Efficient Federated Edge Learning for Small-Scale Datasets in Large IoT Networks (TWC 2026) <https://doi.org/10.1109/TWC.2026.3683911>`_ - Federated edge learning validated through autonomous navigation and collision avoidance in IR-SIM.
+
+        If your publication uses IR-SIM, we welcome you to propose it for inclusion via an issue or pull request.
 
     .. grid-item-card:: Community Projects
         :shadow: md
@@ -239,6 +245,7 @@ Projects using IR-SIM
         * `DRL-robot-navigation-IR-SIM <https://github.com/reiniscimurs/DRL-robot-navigation-IR-SIM>`_ - Deep reinforcement learning for robot navigation.
         * `AutoNavRL <https://github.com/harshmahesheka/AutoNavRL>`_ - Autonomous navigation using reinforcement learning.
         * `IRSIM-3DGS-Bridge <https://github.com/Wayneyujie/IRSIM-3DGS-Bridge>`_ - A closed-loop bridge from 3D Gaussian Splatting scenes to IR-SIM planning/following and back to Habitat-GS trajectory playback.
+        * `EdgeVox <https://github.com/nrl-ai/edgevox>`_ - Offline voice-agent framework with an IR-SIM mobile-navigation backend.
 
 Citation
 ========

--- a/docs/source/yaml_config/configuration.md
+++ b/docs/source/yaml_config/configuration.md
@@ -953,6 +953,14 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
 - **`omni`**: Omnidirectional, controlled by body-frame forward and lateral speed (`[forward, lateral]`)
 - **`omni_angular`**: Omnidirectional with angular control, controlled by body-frame speeds and yaw rate (`[forward, lateral, yaw_rate]`)
 - **`acker`**: Ackermann steering, controlled by linear speed and steering angle (`[v, phi]`)
+
+Velocity commands are expressed in the robot's own frame, while `[vx, vy]` describes the rigid-body motion in the world frame. A holonomic planner such as RVO, SFM or ORCA plans in the world frame, so its velocity is converted at that boundary. An external controller that plans in the world frame converts the same way:
+
+```python
+env.step(env.robot.vel_world2body(world_vel))
+```
+
+For `diff` and `acker` the conversion passes the velocity through, since those models are commanded with a speed rather than a frame-dependent vector. `omni_angular` is commanded directly with `[forward, lateral, yaw_rate]`, which a world-frame translation does not determine, so it has no conversion.
 ```
 
 (p-o-kinematics)=

--- a/docs/source/yaml_config/configuration.md
+++ b/docs/source/yaml_config/configuration.md
@@ -960,7 +960,7 @@ Velocity commands are expressed in the robot's own frame, while `[vx, vy]` descr
 env.step(env.robot.vel_world2body(world_vel))
 ```
 
-For `diff` and `acker` the conversion passes the velocity through, since those models are commanded with a speed rather than a frame-dependent vector. `omni_angular` is commanded directly with `[forward, lateral, yaw_rate]`, which a world-frame translation does not determine, so it has no conversion.
+`omni` rotates `[vx, vy]` into `[forward, lateral]`, and `diff` maps it to `[linear, angular]` using the robot's angular limit and the world step time. `acker` and `omni_angular` are commanded directly, and a world-frame translation does not determine their command, so the conversion raises for them.
 ```
 
 (p-o-kinematics)=

--- a/irsim/lib/behavior/behavior_methods.py
+++ b/irsim/lib/behavior/behavior_methods.py
@@ -4,7 +4,12 @@ from typing import Any
 import numpy as np
 
 from irsim.lib import reciprocal_vel_obs, register_behavior, social_force_model
-from irsim.util.util import WrapToPi, omni_to_diff, relative_position
+from irsim.util.util import (
+    WrapToPi,
+    relative_position,
+    vel_world2diff,
+    vel_world2omni,
+)
 
 """
 Behavior Methods Module
@@ -211,7 +216,7 @@ def beh_omni_rvo(
     factor = kwargs.get("factor", 1.0)
     mode = kwargs.get("mode", "rvo")
     neighbor_threshold = kwargs.get("neighbor_threshold", 3.0)
-    return OmniRVO(
+    world_vel = OmniRVO(
         rvo_state,
         rvo_neighbor,
         vxmax,
@@ -222,6 +227,7 @@ def beh_omni_rvo(
         neighbor_threshold,
         line_segments=line_segments,
     )
+    return vel_world2omni(ego_object.state[2, 0], world_vel)
 
 
 @register_behavior("diff", "sfm")
@@ -264,10 +270,10 @@ def beh_diff_sfm(
     )
     # SFM produces a holonomic ``(vx, vy)``; track it tightly so the small
     # sideways component from anisotropic social/obstacle forces doesn't
-    # get clipped by ``omni_to_diff``'s default deadband.
+    # get clipped by ``vel_world2diff``'s default deadband.
     _, vmax_pair = ego_object.get_vel_range()
     w_max = float(vmax_pair[1, 0])
-    return omni_to_diff(
+    return vel_world2diff(
         ego_object.rvo_state[-1],
         [vx, vy],
         w_max=w_max,
@@ -314,7 +320,7 @@ def beh_omni_sfm(
         step_time=ego_object._world_param.step_time,
         **kwargs,
     )
-    return np.array([[vx], [vy]])
+    return vel_world2omni(ego_object.state[2, 0], np.array([[vx], [vy]]))
 
 
 @register_behavior("omni_angular", "dash")
@@ -575,7 +581,7 @@ def DiffRVO(
         line_obs_list=line_segments,
     )
     rvo_vel = rvo_behavior.cal_vel(mode)
-    diff_vel = omni_to_diff(state_tuple[-1], rvo_vel)
+    diff_vel = vel_world2diff(state_tuple[-1], rvo_vel)
 
     if not diff_vel.any() and not filtered_neighbor_list and not line_segments:
         # With no neighbors or obstacles in range, a fully frozen command means
@@ -583,10 +589,10 @@ def DiffRVO(
         # goal lies behind the robot (it cannot represent a reversal), so the
         # diff robot would freeze forever instead of turning around. Rotate in
         # place toward the desired heading; forward speed stays zero and
-        # ``omni_to_diff`` naturally stops the rotation once the robot faces its
+        # ``vel_world2diff`` naturally stops the rotation once the robot faces its
         # goal. When neighbors are present the freeze is collision avoidance and
         # the robot must keep waiting, so this branch is skipped entirely.
-        diff_vel = omni_to_diff(state_tuple[-1], [state_tuple[5], state_tuple[6]])
+        diff_vel = vel_world2diff(state_tuple[-1], [state_tuple[5], state_tuple[6]])
         diff_vel[0, 0] = 0.0
 
     return diff_vel

--- a/irsim/lib/behavior/group_behavior_methods.py
+++ b/irsim/lib/behavior/group_behavior_methods.py
@@ -4,7 +4,7 @@ from typing import Any
 import numpy as np
 
 from irsim.lib.behavior.behavior_registry import register_group_behavior_class
-from irsim.util.util import omni_to_diff, relative_position
+from irsim.util.util import relative_position, vel_world2diff, vel_world2omni
 from irsim.world.object_base import ObjectBase
 
 
@@ -29,9 +29,10 @@ class OrcaGroupBehavior:
     """
     Class-based ORCA group behavior with one-time initialization.
 
-    ORCA plans a collision-free holonomic velocity ``(vx, vy)`` for every
-    member. ``omni`` members use it directly; ``diff`` members map it to a
-    ``(linear, angular)`` command via :func:`omni_to_diff`.
+    ORCA plans a collision-free holonomic velocity ``(vx, vy)`` in the world
+    frame for every member. ``omni`` members have it rotated into their body
+    frame; ``diff`` members map it to a ``(linear, angular)`` command via
+    :func:`vel_world2diff`.
     """
 
     def __init__(
@@ -117,16 +118,22 @@ class OrcaGroupBehavior:
     def _to_action(self, member: ObjectBase, vel_xy: tuple[float, float]) -> np.ndarray:
         """Convert an ORCA world-frame velocity into a member control input.
 
-        ``omni`` members consume ``(vx, vy)`` directly; ``diff`` members get the
-        holonomic velocity mapped to ``(linear, angular)``.
+        ``diff`` members get the holonomic velocity mapped to ``(linear,
+        angular)``; every other model converts it through its own kinematics,
+        which for ``omni`` means rotating it into the body frame the model is
+        commanded in.
         """
         if self._kinematics == "diff":
-            return omni_to_diff(
+            return vel_world2diff(
                 member.state[2, 0],
                 [vel_xy[0], vel_xy[1]],
                 w_max=float(member.vel_max[1, 0]),
                 guarantee_time=member._world_param.step_time,
             )
+
+        if self._kinematics == "omni":
+            return vel_world2omni(member.state[2, 0], [vel_xy[0], vel_xy[1]])
+
         return np.c_[list(vel_xy)]
 
     def __call__(self, members: list[ObjectBase], **kwargs: Any) -> list[np.ndarray]:

--- a/irsim/lib/handler/kinematics_handler.py
+++ b/irsim/lib/handler/kinematics_handler.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from math import atan2, cos, sin
+from math import atan2
 from typing import ClassVar
 
 import numpy as np
@@ -10,7 +10,7 @@ from irsim.lib.algorithm.kinematics import (
     omni_angular_kinematics,
     omni_kinematics,
 )
-from irsim.util.util import log_warning
+from irsim.util.util import log_warning, vel_diff2world, vel_omni2world
 
 # ---------------------------------------------------------------------------
 # Registry
@@ -51,6 +51,11 @@ def register_kinematics(name: str):
 # ---------------------------------------------------------------------------
 # Base class
 # ---------------------------------------------------------------------------
+
+
+def _heading(state: np.ndarray) -> float:
+    """Read the heading from a state that may not carry one."""
+    return state[2, 0] if state.shape[0] > 2 else 0.0
 
 
 class KinematicsHandler(ABC):
@@ -109,8 +114,9 @@ class KinematicsHandler(ABC):
 
         The default implementation follows differential-drive conventions:
         ``velocity[0]`` is the linear speed projected through the heading
-        angle ``state[2]``. Subclasses with different velocity semantics
-        (e.g. omnidirectional) should override this.
+        angle ``state[2]``, which is what :func:`~irsim.util.util.vel_diff2world`
+        does. Subclasses with different velocity semantics (e.g.
+        omnidirectional) should override this.
 
         Args:
             state (np.ndarray): Current state vector.
@@ -121,11 +127,8 @@ class KinematicsHandler(ABC):
         """
         if len(velocity.shape) == 0:
             return np.zeros((2, 1))
-        vel_linear = velocity[0, 0]
-        theta = state[2, 0]
-        vx = vel_linear * cos(theta)
-        vy = vel_linear * sin(theta)
-        return np.array([[vx], [vy]])
+
+        return vel_diff2world(state[2, 0], velocity)
 
     def compute_max_speed(self, vel_max: np.ndarray) -> float:
         """Compute the scalar maximum speed from the vel_max vector.
@@ -214,13 +217,7 @@ class OmniKinematics(KinematicsHandler):
         Returns:
             np.ndarray: ``(2, 1)`` world-frame velocity.
         """
-        theta = state[2, 0] if state.shape[0] > 2 else 0.0
-        cos_t, sin_t = np.cos(theta), np.sin(theta)
-        fwd = velocity[0, 0]
-        lat = velocity[1, 0]
-        vx = fwd * cos_t - lat * sin_t
-        vy = fwd * sin_t + lat * cos_t
-        return np.array([[vx], [vy]])
+        return vel_omni2world(_heading(state), velocity[0:2])
 
     def compute_max_speed(self, vel_max: np.ndarray) -> float:
         """Compute translational speed limit from forward/lateral limits.
@@ -306,13 +303,7 @@ class OmniAngularKinematics(KinematicsHandler):
         Returns:
             np.ndarray: ``(2, 1)`` world-frame velocity.
         """
-        theta = state[2, 0]
-        cos_t, sin_t = np.cos(theta), np.sin(theta)
-        fwd = velocity[0, 0]
-        lat = velocity[1, 0]
-        vx = fwd * cos_t - lat * sin_t
-        vy = fwd * sin_t + lat * cos_t
-        return np.array([[vx], [vy]])
+        return vel_omni2world(_heading(state), velocity[0:2])
 
     def compute_max_speed(self, vel_max: np.ndarray) -> float:
         """Compute translational speed limit from the first two components.

--- a/irsim/util/__init__.py
+++ b/irsim/util/__init__.py
@@ -27,6 +27,10 @@ from .util import (
     time_it,
     time_it2,
     transform_point_with_state,
+    vel_diff2world,
+    vel_omni2world,
+    vel_world2diff,
+    vel_world2omni,
     vertices_transform,
 )
 
@@ -49,5 +53,9 @@ __all__ = [
     "time_it",
     "time_it2",
     "transform_point_with_state",
+    "vel_diff2world",
+    "vel_omni2world",
+    "vel_world2diff",
+    "vel_world2omni",
     "vertices_transform",
 ]

--- a/irsim/util/util.py
+++ b/irsim/util/util.py
@@ -402,8 +402,9 @@ def vel_world2omni(state_ori: float, vel_world: np.ndarray) -> np.ndarray:
 
     ``[vx, vy]`` describes the rigid-body motion in the world, which is what
     holonomic planners such as RVO, SFM and ORCA produce, while a robot is
-    commanded in its own frame. For a model whose command carries translation
-    directly - ``omni`` and ``omni_angular`` - this rotation is the conversion;
+    commanded in its own frame. For ``omni`` this rotation is the whole
+    conversion; a model that also steers, such as ``omni_angular``, gets only
+    its translation from here and needs a yaw rate of its own.
     :func:`vel_world2diff` does the equivalent for a differential robot.
 
     Args:
@@ -456,7 +457,8 @@ def vel_world2diff(
 
     Args:
         state_ori (float): Orientation angle.
-        vel_omni (np.array): Omnidirectional velocity [vx, vy] (2x1).
+        vel_omni (np.array): World-frame velocity [vx, vy] (2x1). The name is
+            kept from ``omni_to_diff`` so existing keyword callers still work.
         w_max (float): Maximum angular velocity.
         guarantee_time (float): Time to guarantee velocity.
         tolerance (float): Angular tolerance.

--- a/irsim/util/util.py
+++ b/irsim/util/util.py
@@ -396,7 +396,54 @@ def vertices_transform(vertices: np.ndarray, state: np.ndarray) -> np.ndarray | 
     return rot @ vertices + trans
 
 
-def omni_to_diff(
+def vel_world2omni(state_ori: float, vel_world: np.ndarray) -> np.ndarray:
+    """
+    Convert a world-frame velocity to an omni command.
+
+    ``[vx, vy]`` describes the rigid-body motion in the world, which is what
+    holonomic planners such as RVO, SFM and ORCA produce, while a robot is
+    commanded in its own frame. For a model whose command carries translation
+    directly - ``omni`` and ``omni_angular`` - this rotation is the conversion;
+    :func:`vel_world2diff` does the equivalent for a differential robot.
+
+    Args:
+        state_ori (float): Orientation angle.
+        vel_world (np.array): World-frame velocity [vx, vy] (2x1).
+
+    Returns:
+        np.array: Body-frame velocity [forward, lateral] (2x1).
+    """
+    vel_world = np.asarray(vel_world, dtype=float).reshape(-1)
+    cos_t, sin_t = cos(state_ori), sin(state_ori)
+    forward = vel_world[0] * cos_t + vel_world[1] * sin_t
+    lateral = -vel_world[0] * sin_t + vel_world[1] * cos_t
+
+    return np.array([[forward], [lateral]])
+
+
+def vel_omni2world(state_ori: float, vel_body: np.ndarray) -> np.ndarray:
+    """
+    Convert an omni command to a world-frame velocity.
+
+    The inverse of :func:`vel_world2omni`; :func:`vel_diff2world` does the
+    equivalent for a differential robot.
+
+    Args:
+        state_ori (float): Orientation angle.
+        vel_body (np.array): Body-frame velocity [forward, lateral] (2x1).
+
+    Returns:
+        np.array: World-frame velocity [vx, vy] (2x1).
+    """
+    vel_body = np.asarray(vel_body, dtype=float).reshape(-1)
+    cos_t, sin_t = cos(state_ori), sin(state_ori)
+    vx = vel_body[0] * cos_t - vel_body[1] * sin_t
+    vy = vel_body[0] * sin_t + vel_body[1] * cos_t
+
+    return np.array([[vx], [vy]])
+
+
+def vel_world2diff(
     state_ori: float,
     vel_omni: np.ndarray,
     w_max: float = 1.5,
@@ -405,7 +452,7 @@ def omni_to_diff(
     mini_speed: float = 0.02,
 ) -> np.ndarray:
     """
-    Convert omnidirectional velocity to differential velocity.
+    Convert a world-frame velocity to a differential command.
 
     Args:
         state_ori (float): Orientation angle.
@@ -450,9 +497,9 @@ def omni_to_diff(
     return np.array([[v], [w]])
 
 
-def diff_to_omni(state_ori: float, vel_diff: np.ndarray) -> np.ndarray:
+def vel_diff2world(state_ori: float, vel_diff: np.ndarray) -> np.ndarray:
     """
-    Convert differential velocity to omnidirectional velocity.
+    Convert a differential command to a world-frame velocity.
 
     Args:
         state_ori (float): Orientation angle.
@@ -1061,3 +1108,8 @@ def check_unknown_kwargs(
         if logger:
             logger.warning(msg)
     return messages
+
+
+# Previous names, kept so existing code keeps working.
+omni_to_diff = vel_world2diff
+diff_to_omni = vel_diff2world

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -19,6 +19,8 @@ from irsim.util.util import (
     random_point_range,
     relative_position,
     to_numpy,
+    vel_world2diff,
+    vel_world2omni,
     vertices_transform,
 )
 from irsim.world.object_plot import ObjectPlot
@@ -1943,6 +1945,50 @@ class ObjectBase:
             out = np.zeros((2, 1))
         self._velocity_xy_cache = out
         return out
+
+    def vel_world2body(self, velocity_xy: np.ndarray) -> np.ndarray:
+        """
+        Convert a world-frame velocity into this object's own command frame.
+
+        Velocity commands are given in the object's own frame, while holonomic
+        planners such as RVO, SFM and ORCA produce a world-frame velocity. This
+        converts one into the other using the object's current state, so the
+        caller does not have to.
+
+        ``omni`` rotates the velocity into its own frame; ``diff`` turns it
+        into ``[linear, angular]`` through :func:`~irsim.util.util.vel_world2diff`,
+        using this object's angular limit and step time.
+
+        Args:
+            velocity_xy: World-frame velocity ``[vx, vy]`` (2x1).
+
+        Returns:
+            np.ndarray: Velocity in the object's command frame, shaped for its
+            kinematics.
+
+        Raises:
+            NotImplementedError: For a model whose command a world-frame
+                velocity does not determine.
+
+        Example:
+            >>> action = env.robot.vel_world2body(world_vel)
+            >>> env.step(action)
+        """
+        if self.kinematics == "omni":
+            return vel_world2omni(self.state[2, 0], velocity_xy)
+
+        if self.kinematics == "diff":
+            return vel_world2diff(
+                self.state[2, 0],
+                velocity_xy,
+                w_max=float(self.vel_max[1, 0]),
+                guarantee_time=self._world_param.step_time,
+            )
+
+        raise NotImplementedError(
+            f"'{self.kinematics}' is commanded directly, and a world-frame "
+            "velocity does not determine its command."
+        )
 
     @property
     def max_speed(self):

--- a/tests/test_behaviors.py
+++ b/tests/test_behaviors.py
@@ -691,7 +691,7 @@ class TestOrcaGroupBehavior:
         def make_member(x, y, vx, vy):
             m = Mock(spec=ObjectBase)
             m.kinematics = "omni"
-            m.state = np.array([[x], [y]])
+            m.state = np.array([[x], [y], [0.0]])
             m.radius = 0.5
             m.max_speed = 1.0
             m.get_desired_omni_vel = Mock(return_value=np.array([[vx], [vy]]))
@@ -818,6 +818,137 @@ class TestOrcaGroupBehavior:
 
         # ORCA produced non-zero diff velocities, so the robots moved.
         assert np.linalg.norm(end - start, axis=1).max() > 0.1
+
+
+class TestOmniVelocityFrame:
+    """Holonomic planners emit world-frame velocity; omni is commanded in body frame."""
+
+    @staticmethod
+    def _two_headings(tmp_path, behavior, group=False):
+        """One omni robot facing along +x and one facing backwards, same goal."""
+        key = "group_behavior" if group else "behavior"
+        config = tmp_path / f"omni_{behavior}_{key}.yaml"
+        robots = "".join(
+            "  - kinematics: {name: 'omni'}\n"
+            "    shape: {name: 'circle', radius: 0.2}\n"
+            f"    state: [2, {y}, {theta}]\n"
+            f"    goal: [18, {y}, {theta}]\n"
+            f"    {key}: {{name: '{behavior}'}}\n"
+            "    vel_max: [2, 2]\n"
+            "    vel_min: [-2, -2]\n"
+            for y, theta in ((10, 0.0), (5, 3.1416))
+        )
+        config.write_text(
+            "world:\n  height: 20\n  width: 20\n  step_time: 0.1\nrobot:\n" + robots
+        )
+        return config
+
+    @pytest.mark.parametrize("behavior", ["dash", "rvo", "sfm"])
+    def test_behavior_is_independent_of_heading(self, tmp_path, behavior):
+        """A holonomic robot travels the same way whichever direction it faces."""
+        import irsim
+
+        env = irsim.make(
+            str(self._two_headings(tmp_path, behavior)), display=False, save_ani=False
+        )
+        try:
+            for _ in range(40):
+                env.step()
+            forward, backward = (float(r.state[0, 0]) for r in env.robot_list)
+        finally:
+            env.end()
+
+        assert forward > 5.0
+        # rotating by pi leaks a ~1e-16 lateral component, so allow a little drift
+        assert backward == pytest.approx(forward, abs=1e-3)
+
+    def test_vel_world2omni_inverts_vel_omni2world(self):
+        """The util takes a planner's world velocity back into the omni frame."""
+        from irsim.lib.handler.kinematics_handler import KinematicsFactory
+        from irsim.util.util import vel_world2omni
+
+        kf = KinematicsFactory.create_kinematics("omni", False, None)
+        state = np.array([[0.0], [0.0], [np.pi / 3]])
+        world = np.array([[1.5], [-0.4]])
+
+        body = vel_world2omni(state[2, 0], world)
+
+        assert body.shape == (2, 1)
+        np.testing.assert_allclose(kf.velocity_to_xy(state, body), world, atol=1e-12)
+
+    def test_vel_world2body_dispatches_on_kinematics(self, tmp_path, env_factory):
+        """Each robot converts with the util its own model is commanded through."""
+        from irsim.util.util import vel_world2diff, vel_world2omni
+
+        config = tmp_path / "mixed.yaml"
+        config.write_text(
+            "world:\n  height: 20\n  width: 20\n  step_time: 0.1\nrobot:\n"
+            "  - kinematics: {name: 'omni'}\n"
+            "    shape: {name: 'circle', radius: 0.2}\n"
+            "    state: [2, 2, 1.5708]\n    goal: [8, 8, 0]\n"
+            "    vel_max: [2, 2]\n"
+            "  - kinematics: {name: 'diff'}\n"
+            "    shape: {name: 'circle', radius: 0.2}\n"
+            "    state: [2, 6, 1.5708]\n    goal: [8, 8, 0]\n"
+            "    vel_max: [2, 1.5]\n"
+        )
+        env = env_factory(str(config))
+        omni_robot, diff_robot = env.robot_list
+        world_vel = np.array([[1.0], [0.0]])
+
+        np.testing.assert_allclose(
+            omni_robot.vel_world2body(world_vel),
+            vel_world2omni(omni_robot.state[2, 0], world_vel),
+        )
+        np.testing.assert_allclose(
+            diff_robot.vel_world2body(world_vel),
+            vel_world2diff(
+                diff_robot.state[2, 0],
+                world_vel,
+                w_max=float(diff_robot.vel_max[1, 0]),
+                guarantee_time=env.step_time,
+            ),
+        )
+
+    def test_omni_angular_refuses_to_invent_a_yaw_rate(self, tmp_path, env_factory):
+        """A world translation does not determine the yaw this model is given."""
+        config = tmp_path / "omni_angular.yaml"
+        config.write_text(
+            "world:\n  height: 20\n  width: 20\nrobot:\n"
+            "  - kinematics: {name: 'omni_angular'}\n"
+            "    shape: {name: 'circle', radius: 0.2}\n"
+            "    state: [2, 2, 0]\n    goal: [8, 8, 0]\n"
+        )
+        env = env_factory(str(config))
+
+        with pytest.raises(NotImplementedError, match="does not determine its command"):
+            env.robot.vel_world2body(np.array([[1.0], [0.0]]))
+
+    def test_orca_rotates_world_velocity_into_the_body_frame(self):
+        """An ORCA velocity is expressed in the frame the member is commanded in."""
+        pytest.importorskip("pyrvo")
+        from irsim.lib.behavior.group_behavior_methods import OrcaGroupBehavior
+        from irsim.util.util import vel_omni2world
+
+        member = Mock(spec=ObjectBase)
+        member.kinematics = "omni"
+        member.state = np.array([[0.0], [0.0], [np.pi]])
+        member.radius = 0.5
+        member.max_speed = 1.0
+        member.get_desired_omni_vel = Mock(return_value=np.array([[1.0], [0.0]]))
+        member._world_param = Mock()
+        member._world_param.step_time = 0.1
+
+        behavior = OrcaGroupBehavior([member])
+        action = behavior._to_action(member, (1.0, 0.0))
+
+        # facing backwards, driving +x in the world means driving -x in the body
+        np.testing.assert_allclose(action.flatten(), [-1.0, 0.0], atol=1e-9)
+        np.testing.assert_allclose(
+            vel_omni2world(member.state[2, 0], action).flatten(),
+            [1.0, 0.0],
+            atol=1e-9,
+        )
 
 
 class TestCustomBehavior:

--- a/tests/test_rvo_line_obstacles.py
+++ b/tests/test_rvo_line_obstacles.py
@@ -356,6 +356,7 @@ class TestBehFunctionsLineSeparation:
         ego = Mock()
         ego.goal = np.array([[5.0], [5.0]])
         ego.rvo_state = (0.0, 0.0, 0.0, 0.0, 0.3, 1.0, 0.0, 0.0)
+        ego.state = np.zeros((3, 1))
         ego._world_param = Mock()
         ego._world_param.count = 1
         ego.logger = Mock()

--- a/usage/19orca_world/orca_world.py
+++ b/usage/19orca_world/orca_world.py
@@ -24,8 +24,10 @@ while True:
         orca.set_agent_position(i, robot.state[:2, 0].tolist())
 
     orca.do_step()
+    # ORCA plans a velocity in the world frame; a robot is commanded in its own.
     action_list = [
-        orca.get_agent_velocity(i).to_tuple() for i in range(orca.get_num_agents())
+        robot.vel_world2body(orca.get_agent_velocity(i).to_tuple())
+        for i, robot in enumerate(env.robot_list)
     ]
 
     env.step(action_list)

--- a/usage/19orca_world/orca_world.py
+++ b/usage/19orca_world/orca_world.py
@@ -24,7 +24,7 @@ while True:
         orca.set_agent_position(i, robot.state[:2, 0].tolist())
 
     orca.do_step()
-    # ORCA plans a velocity in the world frame; a robot is commanded in its own.
+    # ORCA plans a velocity in the world frame; a robot is commanded in its own frame.
     action_list = [
         robot.vel_world2body(orca.get_agent_velocity(i).to_tuple())
         for i, robot in enumerate(env.robot_list)


### PR DESCRIPTION
Omni robots are commanded in their own frame, but ORCA, RVO and SFM plan in the world frame. That velocity was passed to the robot unchanged, so a robot facing away from its goal drove away from it. Every robot in `usage/19orca_world` starts facing the centre, so the whole scene was affected.

Velocity transforms now go through one util family: `vel_world2omni`, `vel_omni2world`, `vel_world2diff` and `vel_diff2world`. The last two were `omni_to_diff` and `diff_to_omni`, which stay as aliases. An external controller can call `env.robot.vel_world2body(world_vel)`.