### PR TITLE
fix: robustness fixes from a code review of sensors, env lifecycle, actions, and logging

### DIFF
--- a/docs/locale/zh_CN/LC_MESSAGES/usage/configure_sensor.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/usage/configure_sensor.po
@@ -103,8 +103,12 @@ msgid "**range_max**: The maximum range of the laser beam."
 msgstr "**range_max**：激光束的最大量程。"
 
 #: ../../source/usage/configure_sensor.md:108
-msgid "**angle_range**: The angle range of the laser beam."
-msgstr "**angle_range**：激光束覆盖的角度范围。"
+msgid ""
+"**angle_range**: The angle range of the laser beam. Use `6.283185` or `2 * "
+"pi` in Python for a full 360-degree scan."
+msgstr ""
+"**angle_range**：激光束覆盖的角度范围。完整的 360 度扫描可在 YAML 中使用 "
+"`6.283185`，或在 Python 中使用 `2 * pi`。"
 
 #: ../../source/usage/configure_sensor.md:109
 msgid "**number**: The number of beams."

--- a/docs/locale/zh_CN/LC_MESSAGES/usage/make_environment.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/usage/make_environment.po
@@ -702,3 +702,44 @@ msgstr "在 `external` 模式下，状态由另一个仿真器或外部系统更
 #: ../../source/usage/make_environment.md:185
 msgid "The external step does not execute IR-SIM kinematics or behaviors. It refreshes all object geometries from one state snapshot, rebuilds the collision index, updates sensors and status, records trajectories, and advances the world clock. Passing `action` to `env.step()` in this mode raises `ValueError`, preventing accidental mixing of internal and external state advancement."
 msgstr "外部步进不会执行 IR-SIM 的运动学或行为逻辑。它基于同一状态快照刷新所有对象的几何信息、重建碰撞索引、更新传感器和状态、记录轨迹，并推进世界时钟。在此模式下向 `env.step()` 传入 `action` 会引发 `ValueError`，以防意外混用内部和外部状态推进方式。"
+
+#: ../../source/usage/make_environment.md:173
+msgid "Actions follow the usual single- and multi-agent conventions:"
+msgstr "动作的传入方式遵循常见的单智能体 / 多智能体惯例："
+
+#: ../../source/usage/make_environment.md:175
+msgid ""
+"`env.step([1.0, 0.5])` applies one action (a list, tuple, or ndarray) to "
+"the first robot."
+msgstr "`env.step([1.0, 0.5])`：把一个动作（列表、元组或 ndarray）施加给第一个机器人。"
+
+#: ../../source/usage/make_environment.md:176
+msgid ""
+"`env.step(action, action_id=2)` targets the object with id `2` (`obj.id`; "
+"robots are created first, so ids `0..n-1` are the robots). A name such as "
+"`\"robot_2\"` works as well."
+msgstr ""
+"`env.step(action, action_id=2)`：作用于 id 为 `2` 的对象（即 `obj.id`；机器人最先创建，"
+"因此 id `0..n-1` 就是机器人）。也可以用名字，如 `\"robot_2\"`。"
+
+#: ../../source/usage/make_environment.md:177
+msgid ""
+"`env.step([a0, a1, a2])` applies one action per robot in order, or from "
+"`action_id` onward."
+msgstr "`env.step([a0, a1, a2])`：按顺序给每个机器人一个动作，或从 `action_id` 开始依次施加。"
+
+#: ../../source/usage/make_environment.md:178
+msgid "`env.step(actions, action_id=[0, 3])` pairs each action with the given id."
+msgstr "`env.step(actions, action_id=[0, 3])`：动作与给定的 id 一一对应。"
+
+#: ../../source/usage/make_environment.md:179
+msgid ""
+"`env.step({\"robot_0\": a0, \"robot_3\": a3})` takes a dict keyed by robot "
+"name."
+msgstr "`env.step({\"robot_0\": a0, \"robot_3\": a3})`：以机器人名字为键的字典。"
+
+#: ../../source/usage/make_environment.md:181
+msgid ""
+"Surplus actions are dropped with a warning; an unknown id or name raises "
+"`ValueError`."
+msgstr "多余的动作会被丢弃并给出警告；不存在的 id 或名字会抛出 `ValueError`。"

--- a/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
@@ -468,10 +468,11 @@ msgstr "**`sample_time`**（`float`，默认与 `step_time` 相同）"
 msgid ""
 "Defines the time interval for rendering the simulation and extracting data. "
 "This controls how frequently visual updates and data recordings occur. If "
-"not specified, defaults to the value of `step_time`."
+"not specified, defaults to the value of `step_time`. The ratio to "
+"`step_time` is rounded to a whole number of steps (at least one)."
 msgstr ""
 "定义渲染与数据采集的时间间隔，决定可视化更新与记录的频率。未指定时默认等于 "
-"`step_time`。"
+"`step_time`；与 `step_time` 的比值会四舍五入为整数步数（至少为 1）。"
 
 #: ../../source/yaml_config/configuration.md:571
 msgid "**`offset`** (`list` of `float`, default: `[0, 0]`)"

--- a/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
@@ -1148,8 +1148,10 @@ msgid "`fov`"
 msgstr "`fov`"
 
 #: ../../source/yaml_config/configuration.md:700
-msgid "Field of view angles in radians for the object's sensors."
-msgstr "对象传感器的视场角（弧度）。"
+msgid ""
+"Field of view angle in radians for the object's sensors, clipped to `[0, "
+"2*pi]`."
+msgstr "对象传感器的视场角（弧度），限制在 `[0, 2*pi]` 内。"
 
 #: ../../source/yaml_config/configuration.md:700
 msgid "`fov_radius`"
@@ -2182,8 +2184,10 @@ msgid "`range_max` (float/`10.0`): Maximum detection range."
 msgstr "`range_max`（float）：最大探测距离，默认 `10.0`。"
 
 #: ../../source/yaml_config/configuration.md:1204
-msgid "`angle_range` (float/`pi`): Total angle range of the sensor."
-msgstr "`angle_range`（float）：传感器覆盖角度，默认 `pi`。"
+msgid ""
+"`angle_range` (float/`pi`): Total angle range of the sensor, clipped to "
+"`[0, 2*pi]` (`6.283185` gives a full 360° scan)."
+msgstr "`angle_range`（float）：传感器覆盖角度，默认 `pi`，限制在 `[0, 2*pi]` 内（`6.283185` 为 360° 全向扫描）。"
 
 #: ../../source/yaml_config/configuration.md:1205
 msgid "`number` (int/`100`): Number of laser beams."

--- a/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
@@ -469,10 +469,10 @@ msgid ""
 "Defines the time interval for rendering the simulation and extracting data. "
 "This controls how frequently visual updates and data recordings occur. If "
 "not specified, defaults to the value of `step_time`. The ratio to "
-"`step_time` is rounded to a whole number of steps (at least one)."
+"`step_time` is truncated to a whole number of steps (at least one)."
 msgstr ""
 "定义渲染与数据采集的时间间隔，决定可视化更新与记录的频率。未指定时默认等于 "
-"`step_time`；与 `step_time` 的比值会四舍五入为整数步数（至少为 1）。"
+"`step_time`；与 `step_time` 的比值会向下取整为整数步数（至少为 1）。"
 
 #: ../../source/yaml_config/configuration.md:571
 msgid "**`offset`** (`list` of `float`, default: `[0, 0]`)"

--- a/docs/source/usage/configure_sensor.md
+++ b/docs/source/usage/configure_sensor.md
@@ -104,7 +104,7 @@ To configure the 2D LiDAR sensor, the sensor name of `lidar2d` should be defined
 
 - **range_min**: The minimum range of the laser beam.
 - **range_max**: The maximum range of the laser beam.
-- **angle_range**: The angle range of the laser beam.
+- **angle_range**: The angle range of the laser beam. Use `6.283185` or `2 * pi` in Python for a full 360-degree scan.
 - **number**: The number of beams.
 - **alpha**: The transparency of the laser beam.
 

--- a/docs/source/usage/make_environment.md
+++ b/docs/source/usage/make_environment.md
@@ -170,6 +170,16 @@ env = irsim.make("config.yaml")
 env.step(action=[1.0, 0.0], action_id=0)
 ```
 
+Actions follow the usual single- and multi-agent conventions:
+
+- `env.step([1.0, 0.5])` applies one action (a list, tuple, or ndarray) to the first robot.
+- `env.step(action, action_id=2)` targets the object with id `2` (`obj.id`; robots are created first, so ids `0..n-1` are the robots). A name such as `"robot_2"` works as well.
+- `env.step([a0, a1, a2])` applies one action per robot in order, or from `action_id` onward.
+- `env.step(actions, action_id=[0, 3])` pairs each action with the given id.
+- `env.step({"robot_0": a0, "robot_3": a3})` takes a dict keyed by robot name.
+
+Surplus actions are dropped with a warning; an unknown id or name raises `ValueError`.
+
 In `external` mode, another simulator or system owns the state update. Supply
 the new state and velocity first, then call `env.step()` without an action:
 

--- a/docs/source/yaml_config/configuration.md
+++ b/docs/source/yaml_config/configuration.md
@@ -575,7 +575,7 @@ This section outlines the configuration parameters available for the `world` sec
 
 (p-w-sample-time)=
 **`sample_time`** (`float`, default: `step_time`)
-: Defines the time interval for rendering the simulation and extracting data. This controls how frequently visual updates and data recordings occur. If not specified, defaults to the value of `step_time`.
+: Defines the time interval for rendering the simulation and extracting data. This controls how frequently visual updates and data recordings occur. If not specified, defaults to the value of `step_time`. The ratio to `step_time` is rounded to a whole number of steps (at least one).
 
 (p-w-offset)=
 **`offset`** (`list` of `float`, default: `[0, 0]`)

--- a/docs/source/yaml_config/configuration.md
+++ b/docs/source/yaml_config/configuration.md
@@ -761,7 +761,7 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
 | `plot`           | `dict`                                           | `{}`             | Plotting options for object visualization.                                                                         |
 | `state_dim`      | `int`                                            | `None`           | Dimension of the state vector.                                                                                     |
 | `vel_dim`        | `int`                                            | `None`           | Dimension of the velocity vector.                                                                                  |
-| `fov`            | `float`                                          | `None`           | Field of view angles in radians for the object's sensors.                                                          |
+| `fov`            | `float`                                          | `None`           | Field of view angle in radians for the object's sensors, clipped to `[0, 2*pi]`.                                                          |
 | `fov_radius`     | `float`                                          | `None`           | Field of view radius for the object's sensors.                                                                     |
 
 ### Detailed Parameter Descriptions
@@ -1242,7 +1242,7 @@ env.step(env.robot.vel_world2body(world_vel))
   - `lidar2d`: 2D LiDAR sensor for distance measurements. Parameters include:
     - `range_min` (float/`0.0`): Minimum detection range.
     - `range_max` (float/`10.0`): Maximum detection range.
-    - `angle_range` (float/`pi`): Total angle range of the sensor.
+    - `angle_range` (float/`pi`): Total angle range of the sensor, clipped to `[0, 2*pi]` (`6.283185` gives a full 360° scan).
     - `number` (int/`100`): Number of laser beams.
     - `scan_time` (float/`0.1`): Time taken for one complete scan.
     - `noise` (bool/`False`): Whether noise is added to measurements.

--- a/docs/source/yaml_config/configuration.md
+++ b/docs/source/yaml_config/configuration.md
@@ -575,7 +575,7 @@ This section outlines the configuration parameters available for the `world` sec
 
 (p-w-sample-time)=
 **`sample_time`** (`float`, default: `step_time`)
-: Defines the time interval for rendering the simulation and extracting data. This controls how frequently visual updates and data recordings occur. If not specified, defaults to the value of `step_time`. The ratio to `step_time` is rounded to a whole number of steps (at least one).
+: Defines the time interval for rendering the simulation and extracting data. This controls how frequently visual updates and data recordings occur. If not specified, defaults to the value of `step_time`. The ratio to `step_time` is truncated to a whole number of steps (at least one).
 
 (p-w-offset)=
 **`offset`** (`list` of `float`, default: `[0, 0]`)

--- a/irsim/env/env_base.py
+++ b/irsim/env/env_base.py
@@ -274,8 +274,8 @@ class EnvBase:
     @normalize_actions
     def step(
         self,
-        action: np.ndarray | list[Any] | None = None,
-        action_id: int | list[int] | None = None,
+        action: np.ndarray | list[Any] | tuple[Any, ...] | dict[str, Any] | None = None,
+        action_id: int | str | list[int | str] | None = None,
     ) -> None:
         """
         Perform a single simulation step in the environment.
@@ -284,8 +284,9 @@ class EnvBase:
         to the specified robots and updating all objects in the environment.
 
         Args:
-            action (Union[np.ndarray, list], optional): Action(s) to be performed in the environment.
-                Can be a single action or a list of actions. Action format depends on robot type:
+            action (Union[np.ndarray, list, tuple, dict], optional): Action(s) to be performed in the environment.
+                Can be a single action, a list/tuple of actions, or a dict ``{name: action}``.
+                Action format depends on robot type:
 
                 - **Differential robot**: [linear_velocity, angular_velocity]
                 - **Omnidirectional robot**: [velocity_x, velocity_y]

--- a/irsim/env/env_base.py
+++ b/irsim/env/env_base.py
@@ -275,7 +275,7 @@ class EnvBase:
     def step(
         self,
         action: np.ndarray | list[Any] | None = None,
-        action_id: int | list[int] | None = 0,
+        action_id: int | list[int] | None = None,
     ) -> None:
         """
         Perform a single simulation step in the environment.
@@ -299,10 +299,14 @@ class EnvBase:
                     2. Apply the provided ``action`` (list of numpy arrays) to robots by ``action_id`` (int or list of int).
                     3. For remaining robots, fall back to their configured behaviors when ``action`` is ``None``.
 
-            action_id (Union[int, list], optional): ID(s) of the robot(s) to apply the action(s) to.
-                Can be a single robot ID or a list of IDs. Default is 0 (first robot).
-                If action is a list and action_id is a single int, all actions will be
-                applied to robots sequentially starting from action_id.
+            action_id (Union[int, str, list], optional): Object id(s) (``obj.id``) or
+                name(s) to apply the action(s) to; robots are created first, so ids
+                ``0..n-1`` are the robots. ``None`` (default) targets the first robot. If
+                action is a list of actions and action_id is a single id, the actions are
+                applied to that object and the following ones in order. A flat list of
+                numbers (e.g. ``[1.0, 0.5]``) is one action; a dict ``{name: action}``
+                can be passed as ``action`` instead of using ``action_id``. Surplus actions
+                are dropped with a warning; an unknown id or name raises ``ValueError``.
 
         Note:
             - If the environment is paused, this method returns without performing any updates.
@@ -319,6 +323,9 @@ class EnvBase:
             >>> # Move multiple robots
             >>> actions = [[1.0, 0.0], [0.5, 0.3]]
             >>> env.step(actions, action_id=[0, 1])  # Move robots 0 and 1
+            >>>
+            >>> # Dict keyed by robot name
+            >>> env.step({"robot_0": [1.0, 0.0], "robot_2": [0.5, 0.3]})
         """
 
         if self.quit_flag:

--- a/irsim/env/env_base.py
+++ b/irsim/env/env_base.py
@@ -211,6 +211,7 @@ class EnvBase:
         self.validate_unique_names()
 
         # Try to initialize keyboard control (pynput or MPL backend inside KeyboardControl)
+        self.keyboard = None
         try:
             keyboard_config = self.env_config.parse["gui"].get("keyboard", {})
             self.keyboard = KeyboardControl(env_ref=self, **keyboard_config)
@@ -595,42 +596,30 @@ class EnvBase:
             **kwargs: Additional keyword arguments for saving the animation, see :py:meth:`.EnvPlot.save_animate` for detail.
         """
 
-        if self.disable_all_plot:
-            return
+        if not self.disable_all_plot:
+            if self.save_ani:
+                # precedence: call kwargs > env ani_kwargs > world-named default
+                self._env_plot.save_animate(
+                    **{
+                        "ani_name": f"animation_{self._world.name}",
+                        **self.ani_kwargs,
+                        **kwargs,
+                    }
+                )
 
-        if self.save_ani:
-            kwargs = {**self.ani_kwargs, **kwargs}
-            if "ani_name" not in kwargs:
-                kwargs["ani_name"] = f"animation_{self._world.name}"
+            if self.display:
+                plt.pause(ending_time)
+                self.logger.info(
+                    f"Simulation Environment '{self._world.name}' closing in {ending_time:.2f} seconds."
+                )
 
-            self._env_plot.save_animate(**kwargs)
+        if self.keyboard is not None:
+            self.keyboard.close()
 
-        if self.display:
-            plt.pause(ending_time)
-            self.logger.info(
-                f"Simulation Environment '{self._world.name}' closing in {ending_time:.2f} seconds."
-            )
-
-        plt.close("all")
+        # The figure exists even when plotting is disabled; close it so that
+        # headless episodic loops do not leak one figure per environment.
+        self._env_plot.close()
         self._env_param.objects = []
-        ObjectBase.reset_id_iter()
-
-        if hasattr(self, "keyboard"):
-            # Stop pynput listener if present; otherwise disconnect MPL callbacks
-            try:
-                if (
-                    hasattr(self.keyboard, "listener")
-                    and self.keyboard.listener is not None
-                ):
-                    self.keyboard.listener.stop()
-                else:
-                    fig = plt.gcf()
-                    if hasattr(self.keyboard, "_mpl_press_cid"):
-                        fig.canvas.mpl_disconnect(self.keyboard._mpl_press_cid)
-                    if hasattr(self.keyboard, "_mpl_release_cid"):
-                        fig.canvas.mpl_disconnect(self.keyboard._mpl_release_cid)
-            except Exception:
-                pass
 
         self.logger.info(
             f"Simulation Environment '{self._world.name}' ended. Total time {self._world.time:.2f} seconds."

--- a/irsim/env/env_logger.py
+++ b/irsim/env/env_logger.py
@@ -28,6 +28,8 @@ class EnvLogger:
         if log_file is not None:
             logger.add(log_file, level=log_level)
 
+        self._once_keys: set[str] = set()
+
     def trace(self, msg: str) -> None:
         """
         Log a trace message.
@@ -72,6 +74,24 @@ class EnvLogger:
             msg (str): The message to log.
         """
         logger.warning(msg)
+
+    def warning_once(self, msg: str, key: str | None = None) -> None:
+        """
+        Log a warning the first time ``key`` (default: ``msg``) is seen, then at DEBUG.
+
+        For per-step conditions that would otherwise flood the log every step.
+
+        Args:
+            msg (str): The message to log.
+            key (str, optional): Identity of the condition when ``msg`` varies.
+        """
+        key = key or msg
+        if key in self._once_keys:
+            logger.debug(msg)
+            return
+
+        self._once_keys.add(key)
+        logger.warning(f"{msg} (further occurrences are logged at DEBUG level)")
 
     def success(self, msg: str) -> None:
         """

--- a/irsim/env/env_plot.py
+++ b/irsim/env/env_plot.py
@@ -726,9 +726,9 @@ class EnvPlot:
 
     def close(self) -> None:
         """
-        Close the plot.
+        Close this plot's figure.
         """
-        plt.close()
+        plt.close(self.fig)
 
     @property
     def _world_param(self):

--- a/irsim/gui/keyboard_control.py
+++ b/irsim/gui/keyboard_control.py
@@ -207,6 +207,7 @@ class KeyboardControl:
 
         else:
             # Fallback to matplotlib figure key events
+            self.listener = None
             fig = plt.gcf()
             self._mpl_press_cid = fig.canvas.mpl_connect(
                 "key_press_event", self._on_mpl_press
@@ -572,11 +573,21 @@ class KeyboardControl:
         if _active_keyboard_instance is self:
             self._is_active = False
 
-    def _on_mpl_close(self, event: Any) -> None:
+    def close(self) -> None:
+        """Release the controller: stop the pynput listener and deactivate it."""
+        if self.listener is not None:
+            self.listener.stop()
+        self._deactivate()
+
+    def _deactivate(self) -> None:
         global _active_keyboard_instance
         self._is_active = False
         if _active_keyboard_instance is self:
             _active_keyboard_instance = None
+
+    def _on_mpl_close(self, event: Any) -> None:
+        """Matplotlib ``close_event`` handler; the event itself is not needed."""
+        self._deactivate()
 
     def _set_active(self) -> None:
         """Set this instance as the active keyboard controller."""

--- a/irsim/lib/behavior/behavior.py
+++ b/irsim/lib/behavior/behavior.py
@@ -56,8 +56,8 @@ class Behavior:
             # Access params via ego_object's env reference if available
             if ego_object is not None:
                 wp = ego_object._world_param
-                if wp.control_mode == "auto" and wp.count % 20 == 0:
-                    ego_object.logger.warning(
+                if wp.control_mode == "auto":
+                    ego_object.logger.warning_once(
                         f"Behavior not defined for {self.object_info.name}. auto control will be static. Available behaviors: rvo, dash"
                     )
 

--- a/irsim/lib/behavior/behavior_methods.py
+++ b/irsim/lib/behavior/behavior_methods.py
@@ -59,10 +59,9 @@ def _goal_pending(ego_object: Any, behavior: str) -> bool:
     if ego_object.goal is not None:
         return False
 
-    if ego_object._world_param.count % 10 == 0:
-        ego_object.logger.warning(
-            f"Goal is currently None. This {behavior} behavior is waiting for goal configuration"
-        )
+    ego_object.logger.warning_once(
+        f"{ego_object.name}: goal is None, the {behavior} behavior is waiting for a goal"
+    )
 
     return True
 

--- a/irsim/lib/behavior/group_behavior.py
+++ b/irsim/lib/behavior/group_behavior.py
@@ -5,7 +5,7 @@ from irsim.lib.behavior.behavior_registry import (
     group_behaviors_class_map,
     group_behaviors_map,
 )
-from irsim.util.util import log_error, log_warning
+from irsim.util.util import log_error, log_warning_once
 from irsim.world.object_base import ObjectBase
 
 
@@ -93,10 +93,10 @@ class GroupBehavior:
             # Access params via first member if available
             if self.members:
                 wp = self.members[0]._world_param
-                if wp.control_mode == "auto" and wp.count % 20 == 0:
-                    log_warning(
-                        "Group behavior not defined. Auto control will be static. "
-                        "Available behaviors: orca"
+                if wp.control_mode == "auto":
+                    log_warning_once(
+                        f"Group behavior not defined for the group of {self.members[0].name}. "
+                        "Auto control will be static. Available behaviors: orca"
                     )
             return [None]
 

--- a/irsim/lib/handler/kinematics_handler.py
+++ b/irsim/lib/handler/kinematics_handler.py
@@ -10,7 +10,7 @@ from irsim.lib.algorithm.kinematics import (
     omni_angular_kinematics,
     omni_kinematics,
 )
-from irsim.util.util import log_warning, vel_diff2world, vel_omni2world
+from irsim.util.util import vel_diff2world, vel_omni2world
 
 # ---------------------------------------------------------------------------
 # Registry
@@ -427,33 +427,37 @@ class KinematicsFactory:
 
         Args:
             name: Registered kinematics name, such as ``diff``, ``omni``,
-                ``omni_angular``, or ``acker``. ``None`` uses the fallback.
+                ``omni_angular``, or ``acker``. ``None`` defaults to ``diff``;
+                ``static`` is retained as the static-object sentinel.
             noise: Whether to apply motion noise.
             alpha: Noise parameters passed to the handler.
             mode: Ackermann mode, used only by ``acker``.
             wheelbase: Ackermann wheelbase; defaults to ``1.0`` for ``acker``.
-            role: Object role used for warnings.
+            role: Object role, retained for API compatibility.
 
         Returns:
             KinematicsHandler: Registered handler instance, or a differential
-            handler fallback when the name is missing or unknown.
-        """
-        name = name.lower() if name else None
+            handler when the name is missing.
 
-        handler_cls = _kinematics_registry.get(name) if name else None
+        Raises:
+            NotImplementedError: If a non-empty name other than ``static`` is
+                not registered.
+        """
+        if name is None:
+            return DifferentialKinematics("diff", noise, alpha)
+
+        name = name.lower()
+        if name == "static":
+            return DifferentialKinematics("static", noise, alpha)
+
+        handler_cls = _kinematics_registry.get(name)
 
         if handler_cls is not None:
             # AckermannKinematics accepts extra kwargs
             if issubclass(handler_cls, AckermannKinematics):
                 return handler_cls(name, noise, alpha, mode, wheelbase or 1.0)
             return handler_cls(name, noise, alpha)
-        if role == "robot":
-            log_warning(
-                f"Unknown kinematics type: {name}, the robot will be stationary."
-            )
-
-        # Fallback to a stationary kinematics handler (differential with zero wheelbase)
-        return DifferentialKinematics(name or "diff", noise, alpha)
+        raise NotImplementedError(f"Kinematics {name!r} is not registered")
 
     @staticmethod
     def get_handler_class(name: str) -> type[KinematicsHandler] | None:

--- a/irsim/util/util.py
+++ b/irsim/util/util.py
@@ -102,8 +102,14 @@ def log_warning(msg: str) -> None:
 
 
 def log_warning_once(msg: str) -> None:
-    """Emit ``msg`` as a warning once (then at DEBUG); see ``EnvLogger.warning_once``."""
-    _emit_log("warning_once", msg)
+    """Emit ``msg`` as a warning once (then at DEBUG); see ``EnvLogger.warning_once``.
+
+    Loggers without ``warning_once`` (e.g. a plain ``logging.Logger``) get a
+    regular warning instead.
+    """
+    logger = getattr(env_param, "logger", None)
+    if logger is not None:
+        getattr(logger, "warning_once", logger.warning)(msg)
 
 
 def log_error(msg: str) -> None:
@@ -154,6 +160,7 @@ def ClipTo2Pi(rad: float) -> float:
     """Clip an angular span, such as a sensor sweep or a field of view, to [0, 2pi].
 
     Unlike :func:`WrapTo2Pi`, a full circle stays ``2pi`` instead of wrapping to ``0``.
+    Non-finite input yields ``0.0``, as in :func:`WrapTo2Pi`.
 
     Args:
         rad (float): Angular span in radians.
@@ -161,6 +168,9 @@ def ClipTo2Pi(rad: float) -> float:
     Returns:
         float: ``rad`` clipped to the range [0, 2pi].
     """
+    if not np.isfinite(rad):
+        return 0.0
+
     return float(np.clip(rad, 0.0, 2 * pi))
 
 
@@ -1036,7 +1046,8 @@ def normalize_actions(func):
             if len(action_list) != len(targets):
                 self.logger.warning_once(
                     f"{len(action_list)} action(s) but {len(targets)} target object(s); "
-                    "matched in order, the rest are ignored"
+                    "matched in order, the rest are ignored",
+                    key="normalize_actions:surplus",
                 )
             for pos, a in zip(targets, action_list, strict=False):
                 actions[pos] = a

--- a/irsim/util/util.py
+++ b/irsim/util/util.py
@@ -145,6 +145,20 @@ def WrapTo2Pi(rad: float) -> float:
     return rad % (2 * pi)
 
 
+def ClipTo2Pi(rad: float) -> float:
+    """Clip an angular span, such as a sensor sweep or a field of view, to [0, 2pi].
+
+    Unlike :func:`WrapTo2Pi`, a full circle stays ``2pi`` instead of wrapping to ``0``.
+
+    Args:
+        rad (float): Angular span in radians.
+
+    Returns:
+        float: ``rad`` clipped to the range [0, 2pi].
+    """
+    return float(np.clip(rad, 0.0, 2 * pi))
+
+
 def WrapToRegion(rad: float, range: list[float]) -> float:
     """
     Transform an angle to a defined range, with length of 2*pi.

--- a/irsim/util/util.py
+++ b/irsim/util/util.py
@@ -101,6 +101,11 @@ def log_warning(msg: str) -> None:
     _emit_log("warning", msg)
 
 
+def log_warning_once(msg: str) -> None:
+    """Emit ``msg`` as a warning once (then at DEBUG); see ``EnvLogger.warning_once``."""
+    _emit_log("warning_once", msg)
+
+
 def log_error(msg: str) -> None:
     """Emit an error through the env logger so it respects ``log_level``."""
     _emit_log("error", msg)
@@ -1029,7 +1034,7 @@ def normalize_actions(func):
             action_list = _as_action_list(action, n_ids)
             targets = _target_positions(objects, action_id, len(action_list))
             if len(action_list) != len(targets):
-                self.logger.warning(
+                self.logger.warning_once(
                     f"{len(action_list)} action(s) but {len(targets)} target object(s); "
                     "matched in order, the rest are ignored"
                 )

--- a/irsim/util/util.py
+++ b/irsim/util/util.py
@@ -247,7 +247,9 @@ def is_list_of_numbers(lst: Any) -> bool:
     Returns:
         bool: True if all elements are numbers, False otherwise.
     """
-    return isinstance(lst, list) and all(isinstance(sub, int | float) for sub in lst)
+    return isinstance(lst, list) and all(
+        isinstance(sub, int | float | np.number) for sub in lst
+    )
 
 
 def is_list_of_lists(lst: Any) -> bool:
@@ -961,34 +963,79 @@ def time_it(name: str = "Function") -> Any:
     return decorator
 
 
+def _as_action_list(action: Any, n_targets: int) -> list:
+    """Return ``action`` as a list with one entry per target object.
+
+    A single action (an ndarray, or a flat list/tuple of numbers such as
+    ``[1.0, 0.5]``) is repeated for every target; a list/tuple of actions is
+    used as is.
+    """
+    if isinstance(action, tuple):
+        action = list(action)
+    if isinstance(action, np.ndarray) or (action and is_list_of_numbers(action)):
+        return [action] * n_targets
+    if isinstance(action, list):
+        return action
+    raise TypeError(
+        f"action must be a list, tuple, or ndarray, got {type(action).__name__}"
+    )
+
+
+def _target_positions(objects: list, action_id: Any, count: int) -> list[int]:
+    """Return the positions in ``objects`` that ``action_id`` refers to.
+
+    ``action_id`` is an object id (``obj.id``) or name, or a list of them. A
+    single id (``None`` means the first object) selects ``count`` consecutive
+    objects starting from it; an unknown id or name raises ``ValueError``.
+    """
+
+    def position(key):
+        if isinstance(key, str):
+            obj = find_object_by_identity(objects, name=key)
+        else:
+            obj = find_object_by_identity(objects, object_id=int(key))
+        if obj is None:
+            raise ValueError(f"no object with id or name {key!r}")
+        return objects.index(obj)
+
+    if isinstance(action_id, list):
+        return [position(i) for i in action_id]
+    start = 0 if action_id is None else position(action_id)
+    return list(range(start, min(start + count, len(objects))))
+
+
 def normalize_actions(func):
     """
     Decorator to normalize (action, action_id) into an aligned actions list.
 
     The wrapped method must belong to a class that has a ``objects`` attribute.
-    It will receive an extra keyword argument ``aligned_actions`` (length == len(self.objects)).
+    It receives ``actions``, a list aligned with ``self.objects`` (``None`` where
+    nothing was given). ``action`` is one action, a list of actions, or a dict
+    ``{name: action}``; ``action_id`` is an object id (``obj.id``) or name
+    (``None`` for the first object), or a list of them. A single action is
+    applied to every id; a list of actions is applied to the given ids, or to
+    consecutive objects starting from the given id. Surplus actions (or ids)
+    are dropped with a warning; an unknown id or name raises.
     """
 
-    def wrapper(self, action=None, action_id=0, *args, **kwargs):
-        num_objects = len(getattr(self, "objects", []))
-        actions = [None] * num_objects
+    def wrapper(self, action=None, action_id=None, *args, **kwargs):
+        objects = getattr(self, "objects", [])
+        actions = [None] * len(objects)
 
+        if isinstance(action, dict):  # {name: action}
+            action_id, action = list(action), list(action.values())
         if action is not None:
-            if isinstance(action, list):
-                if isinstance(action_id, list):
-                    for a, ai in zip(action, action_id, strict=True):
-                        actions[int(ai)] = a
-                else:
-                    start = int(action_id)
-                    actions[start : start + len(action)] = action[:]
-            elif isinstance(action, np.ndarray):
-                if isinstance(action_id, list):
-                    for ai in action_id:
-                        actions[int(ai)] = action
-                else:
-                    actions[int(action_id)] = action
+            n_ids = len(action_id) if isinstance(action_id, list) else 1
+            action_list = _as_action_list(action, n_ids)
+            targets = _target_positions(objects, action_id, len(action_list))
+            if len(action_list) != len(targets):
+                self.logger.warning(
+                    f"{len(action_list)} action(s) but {len(targets)} target object(s); "
+                    "matched in order, the rest are ignored"
+                )
+            for pos, a in zip(targets, action_list, strict=False):
+                actions[pos] = a
 
-        # Call the original function with normalized actions and a neutral action_id
         return func(self, actions, 0, *args, **kwargs)
 
     return wrapper

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -639,11 +639,10 @@ class ObjectBase:
                 self.stop_flag = any(not obj.unobstructed for obj in self.collision_obj)
             elif self.role == "obstacle":
                 self.stop_flag = False
-        else:
-            if self._world_param.count % 50 == 0 and self.role == "robot":
-                self.logger.warning(
-                    f"collision mode {self._world_param.collision_mode} is not defined within [stop, reactive, unobstructed, unobstructed_obstacles], the unobstructed mode is used"
-                )
+        elif self.role == "robot":
+            self.logger.warning_once(
+                f"collision mode {self._world_param.collision_mode} is not defined within [stop, reactive, unobstructed, unobstructed_obstacles], the unobstructed mode is used"
+            )
 
     def check_arrive_status(self):
         """
@@ -762,8 +761,8 @@ class ObjectBase:
         if velocity is None:
             if self.beh_config is None:
                 if self.role == "robot":
-                    self.logger.warning(
-                        "behavior and input velocity is not defined, robot will stay static"
+                    self.logger.warning_once(
+                        f"{self.name}: no behavior configured and no input velocity given, the robot will stay static"
                     )
 
                 return np.zeros_like(self._velocity)
@@ -777,15 +776,12 @@ class ObjectBase:
 
             behavior_vel = velocity
 
-        # clip the behavior_vel by maximum and minimum limits
-        if (behavior_vel < (min_vel - 0.01)).any():
-            self.logger.warning(
-                f"Input velocity {np.round(behavior_vel.flatten(), 2)} below min {np.round(min_vel.flatten(), 2)}. Clipped due to acceleration limit."
-            )
-
-        elif (behavior_vel > (max_vel + 0.01)).any():
-            self.logger.warning(
-                f"Input velocity {np.round(behavior_vel.flatten(), 2)} exceeds max {np.round(max_vel.flatten(), 2)}. Clipped due to acceleration limit."
+        # clip the behavior_vel by maximum and minimum limits; clipping is routine
+        # under a finite ``acce``, so it is reported once per object, not per step
+        if ((behavior_vel < min_vel - 0.01) | (behavior_vel > max_vel + 0.01)).any():
+            self.logger.warning_once(
+                f"{self.name}: input velocity {np.round(behavior_vel.flatten(), 2)} clipped to min {np.round(min_vel.flatten(), 2)} / max {np.round(max_vel.flatten(), 2)} by the velocity/acceleration limits.",
+                key=f"{self.name}:velocity_clip",
             )
 
         return np.clip(behavior_vel, min_vel, max_vel)

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -11,7 +11,7 @@ from shapely.geometry.base import BaseGeometry
 
 from irsim.lib import Behavior, GeometryFactory, KinematicsFactory
 from irsim.util.util import (
-    WrapTo2Pi,
+    ClipTo2Pi,
     WrapToPi,
     WrapToRegion,
     check_unknown_kwargs,
@@ -481,12 +481,10 @@ class ObjectBase:
             self.sensors = []
 
         if fov is None:
-            self.fov = (
-                WrapTo2Pi(self.lidar.angle_range) if self.lidar is not None else None
-            )
+            self.fov = self.lidar.angle_range if self.lidar is not None else None
             self.fov_radius = self.lidar.range_max if self.lidar is not None else None
         else:
-            self.fov = WrapTo2Pi(fov)
+            self.fov = ClipTo2Pi(fov)
             self.fov_radius = fov_radius
 
     def _init_behavior(

--- a/irsim/world/sensors/lidar2d.py
+++ b/irsim/world/sensors/lidar2d.py
@@ -12,7 +12,7 @@ from shapely import MultiLineString
 from irsim.lib.algorithm.ray_casting_2d import cast_rays
 from irsim.util.random import rng
 from irsim.util.util import (
-    WrapTo2Pi,
+    ClipTo2Pi,
     geometry_transform,
     transform_point_with_state,
 )
@@ -46,7 +46,7 @@ class Lidar2D:
         - sensor_type (str): Type of sensor ("lidar2d"). Default is "lidar2d".
         - range_min (float): Minimum detection range in meters. Default is 0.
         - range_max (float): Maximum detection range in meters. Default is 10.
-        - angle_range (float): Total angle range of the sensor in radians. Default is pi. WrapTo2Pi is applied.
+        - angle_range (float): Total angle range of the sensor in radians. Default is pi. Clipped to [0, 2*pi].
         - angle_min (float): Starting angle of the sensor's scan relative to the forward direction in radians. Calculated as -angle_range / 2.
         - angle_max (float): Ending angle of the sensor's scan relative to the forward direction in radians. Calculated as angle_range / 2.
         - angle_inc (float): Angular increment between each laser beam in radians. Calculated as angle_range / (number - 1) when multiple beams are used.
@@ -100,7 +100,7 @@ class Lidar2D:
         self.range_min = range_min
         self.range_max = range_max
 
-        self.angle_range = WrapTo2Pi(angle_range)
+        self.angle_range = ClipTo2Pi(angle_range)
         self.angle_min = -self.angle_range / 2 if number > 1 else 0.0
         self.angle_max = self.angle_range / 2 if number > 1 else 0.0
         self.angle_inc = self.angle_range / (number - 1) if number > 1 else 0.0

--- a/irsim/world/world.py
+++ b/irsim/world/world.py
@@ -119,8 +119,9 @@ class World:
         self.width = width
         self.step_time = step_time
         self.sample_time = sample_time if sample_time is not None else step_time
-        # at least one step per sample; round, not int(): 0.3 / 0.1 is 2.999...
-        self.sample_steps = max(1, round(self.sample_time / step_time))
+        # at least one step per sample; truncate like int() always did, but drop
+        # floating-point noise first (0.3 / 0.1 is 2.999..., which must be 3)
+        self.sample_steps = max(1, int(round(self.sample_time / step_time, 9)))
         self.offset = offset
 
         self.count = 0

--- a/irsim/world/world.py
+++ b/irsim/world/world.py
@@ -119,6 +119,8 @@ class World:
         self.width = width
         self.step_time = step_time
         self.sample_time = sample_time if sample_time is not None else step_time
+        # at least one step per sample; round, not int(): 0.3 / 0.1 is 2.999...
+        self.sample_steps = max(1, round(self.sample_time / step_time))
         self.offset = offset
 
         self.count = 0
@@ -190,7 +192,7 @@ class World:
                 Pass ``None`` or an empty list to skip the fog update.
         """
         self.count += 1
-        self.sampling = self.count % (int(self.sample_time / self.step_time)) == 0
+        self.sampling = self.count % self.sample_steps == 0
 
         self._wp.time = self.time
         self._wp.count = self.count

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,9 @@ class DummyLogger:
     def warning(self, *_args: Any, **_kwargs: Any) -> None:
         pass
 
+    def warning_once(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
     def error(self, *_args: Any, **_kwargs: Any) -> None:
         pass
 

--- a/tests/test_behaviors.py
+++ b/tests/test_behaviors.py
@@ -142,12 +142,12 @@ class TestBehaviorMethodsGoalNone:
         ego = Mock()
         ego.goal = None
         ego._world_param = Mock()
-        ego._world_param.count = 10  # divisible by 10 to trigger warning
+        ego._world_param.count = 10
         ego.logger = Mock()
 
         result = beh_diff_rvo(ego, [])
         assert np.allclose(result, np.zeros((2, 1)))
-        ego.logger.warning.assert_called_once()
+        ego.logger.warning_once.assert_called_once()
 
     def test_diff_dash_goal_none(self, dummy_logger):
         """Test diff dash behavior returns zeros when goal is None."""
@@ -162,7 +162,7 @@ class TestBehaviorMethodsGoalNone:
 
         result = beh_diff_dash(ego, [])
         assert np.allclose(result, np.zeros((2, 1)))
-        ego.logger.warning.assert_called_once()
+        ego.logger.warning_once.assert_called_once()
 
     def test_omni_rvo_goal_none(self, dummy_logger):
         """Test omni rvo behavior returns zeros when goal is None."""
@@ -175,7 +175,7 @@ class TestBehaviorMethodsGoalNone:
 
         result = beh_omni_rvo(ego, [])
         assert np.allclose(result, np.zeros((2, 1)))
-        ego.logger.warning.assert_called_once()
+        ego.logger.warning_once.assert_called_once()
 
     def test_acker_dash_goal_none(self, dummy_logger):
         """Test acker dash behavior returns zeros when goal is None."""
@@ -188,7 +188,7 @@ class TestBehaviorMethodsGoalNone:
 
         result = beh_acker_dash(ego, [])
         assert np.allclose(result, np.zeros((2, 1)))
-        ego.logger.warning.assert_called_once()
+        ego.logger.warning_once.assert_called_once()
 
     def test_omni_dash_goal_none(self, dummy_logger):
         """Test omni dash behavior returns zeros when goal is None."""
@@ -197,12 +197,12 @@ class TestBehaviorMethodsGoalNone:
         ego = Mock()
         ego.goal = None
         ego._world_param = Mock()
-        ego._world_param.count = 10  # divisible by 10 to trigger warning
+        ego._world_param.count = 10
         ego.logger = Mock()
 
         result = beh_omni_dash(ego, [])
         assert np.allclose(result, np.zeros((2, 1)))
-        ego.logger.warning.assert_called_once()
+        ego.logger.warning_once.assert_called_once()
 
     def test_omni_angular_dash_goal_none(self, dummy_logger):
         """Test omni_angular dash behavior returns zeros when goal is None."""
@@ -216,7 +216,7 @@ class TestBehaviorMethodsGoalNone:
 
         result = beh_omni_angular_dash(ego, [])
         assert np.allclose(result, np.zeros((3, 1)))
-        ego.logger.warning.assert_called_once()
+        ego.logger.warning_once.assert_called_once()
 
     def test_omni_angular_dash_with_goal(self, dummy_logger):
         """Test omni_angular dash behavior with valid goal."""
@@ -645,7 +645,7 @@ class TestGroupBehavior:
         member._world_param.count = 20
 
         gb = GroupBehavior([member], name=None)
-        with patch("irsim.lib.behavior.group_behavior.log_warning") as mock_log:
+        with patch("irsim.lib.behavior.group_behavior.log_warning_once") as mock_log:
             result = gb.gen_group_vel()
         assert result == [None]
         mock_log.assert_called_once()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -1457,19 +1458,70 @@ class TestObjectsCheckStatus:
         env._object_step(None)
 
 
-class TestEndDisableAllPlot:
-    """Test end() with disable_all_plot=True (line 524)."""
+class TestEndReleasesFigure:
+    """end() must not leave figures or global state behind in headless loops."""
 
-    def test_end_with_disable_all_plot(self):
-        """end() returns early when disable_all_plot is True."""
+    @pytest.mark.parametrize("projection", ["2d", "3d"])
+    @pytest.mark.parametrize("disable_all_plot", [True, False])
+    def test_end_releases_figure(self, disable_all_plot, projection):
+        """Every env owns one figure; end() must close it and create no other.
+
+        Without this, headless episodic loops (e.g. RL training) leak one
+        figure per environment: the ``disable_all_plot`` path never closed
+        it, and the keyboard cleanup re-created one via ``plt.gcf()``. The 3D
+        env replaces the base 2D figure with its own and must not leak either.
+        """
+        plt.close("all")
+        for _ in range(3):
+            env = irsim.make(
+                "test_collision_world.yaml",
+                save_ani=False,
+                display=False,
+                disable_all_plot=disable_all_plot,
+                projection=projection,
+            )
+            env.step()
+            assert len(plt.get_fignums()) == 1
+            env.end()
+            assert plt.get_fignums() == []
+
+    def test_end_spares_other_figures_and_releases_keyboard(self):
+        """end() is idempotent, closes only its own figure, and frees the keyboard."""
+        import irsim.gui.keyboard_control as kb_module
+
         env = irsim.make(
             "test_collision_world.yaml",
             save_ani=False,
             display=False,
             disable_all_plot=True,
         )
+        env_fig = env._env_plot.fig
+        unrelated_fig = plt.figure()
+        env.keyboard._set_active()
         env.step()
-        env.end()  # Should return immediately
+        env.end()
+        env.end()
+
+        assert not plt.fignum_exists(env_fig.number)
+        assert plt.fignum_exists(unrelated_fig.number)
+        assert env._env_param.objects == []
+        assert not env.keyboard._is_active
+        assert kb_module._active_keyboard_instance is None
+
+    def test_ending_one_environment_does_not_reset_ids_for_another(self):
+        env_a = irsim.make(
+            "test_collision_world.yaml", display=False, disable_all_plot=True
+        )
+        env_b = irsim.make(
+            "test_collision_world.yaml", display=False, disable_all_plot=True
+        )
+        existing_ids = {obj.id for obj in env_b.objects}
+
+        env_a.end()
+        new_obstacle = env_b.create_obstacle(shape={"name": "circle", "radius": 0.2})
+
+        assert new_obstacle.id not in existing_ids
+        env_b.end()
 
 
 class TestStatusArrived:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -762,7 +762,7 @@ class TestSimulationLoop:
     )
     def test_step_warns_and_drops_surplus_actions(self, env_factory, action, action_id):
         env = env_factory("test_multi_objects_world.yaml")
-        with patch.object(env.logger, "warning") as warn:
+        with patch.object(env.logger, "warning_once") as warn:
             env.step(action, action_id)
         assert sum("ignored" in c.args[0] for c in warn.call_args_list) == 1
 
@@ -1656,6 +1656,29 @@ class TestStatusArrived:
         with mock_patch.object(ObjectBase, "check_status", lambda self: None):
             env._status_step()
         assert env.status == "Quit"
+
+
+class TestWarningOnce:
+    """EnvLogger.warning_once reports a keyed condition once, then at DEBUG."""
+
+    def test_warning_once_downgrades_repeats(self):
+        from loguru import logger as loguru_logger
+
+        from irsim.env.env_logger import EnvLogger
+
+        env_logger = EnvLogger(log_file=None, log_level="DEBUG")
+        records = []
+        sink = loguru_logger.add(lambda m: records.append(m.record), level="DEBUG")
+        try:
+            for _ in range(3):
+                env_logger.warning_once("robot_0 is stuck", key="stuck")
+            env_logger.warning_once("another condition")
+        finally:
+            loguru_logger.remove(sink)
+
+        levels = [r["level"].name for r in records]
+        assert levels == ["WARNING", "DEBUG", "DEBUG", "WARNING"]
+        assert "logged at DEBUG" in records[0]["message"]
 
 
 class TestCloseAlias:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -731,6 +731,51 @@ class TestSimulationLoop:
         action_id = 1
         env.step(action_list, action_id)
 
+    def test_step_with_flat_action_list(self, env_factory):
+        """``[1.0, 0.5]`` is one action, not one scalar per object."""
+        env = env_factory("test_multi_objects_world.yaml")
+        x0 = env.robot_list[0].state[0, 0]
+        env.step([1.0, 0.0])
+        assert env.robot_list[0].state[0, 0] > x0
+
+    def test_step_with_flat_action_list_and_id_list(self, env_factory):
+        """A flat action is broadcast to every id in ``action_id``."""
+        env = env_factory("test_multi_objects_world.yaml")
+        xs = [obj.state[0, 0] for obj in env.robot_list[:2]]
+        env.step([1.0, 0.0], action_id=[0, 1])
+        for obj, x in zip(env.robot_list[:2], xs, strict=True):
+            assert obj.state[0, 0] > x
+
+    def test_step_with_tuple_action(self, env_factory):
+        """A tuple action must not be silently dropped."""
+        env = env_factory("test_multi_objects_world.yaml")
+        x0 = env.robot_list[0].state[0, 0]
+        env.step((1.0, 0.0))
+        assert env.robot_list[0].state[0, 0] > x0
+
+    @pytest.mark.parametrize(
+        ("action", "action_id"),
+        [
+            ([[1.0, 0.0]] * 99, None),  # more actions than objects
+            ([[1.0, 0.0], [1.0, 0.0]], [0]),  # more actions than ids
+        ],
+    )
+    def test_step_warns_and_drops_surplus_actions(self, env_factory, action, action_id):
+        env = env_factory("test_multi_objects_world.yaml")
+        with patch.object(env.logger, "warning") as warn:
+            env.step(action, action_id)
+        assert sum("ignored" in c.args[0] for c in warn.call_args_list) == 1
+
+    def test_step_rejects_unknown_action_id(self, env_factory):
+        env = env_factory("test_multi_objects_world.yaml")
+        with pytest.raises(ValueError, match="no object with id or name 99"):
+            env.step([1.0, 0.0], action_id=99)
+
+    def test_step_rejects_unsupported_action_type(self, env_factory):
+        env = env_factory("test_multi_objects_world.yaml")
+        with pytest.raises(TypeError, match="action must be"):
+            env.step("forward")
+
     def test_external_step_synchronizes_supplied_state(self, env_factory, tmp_path):
         """External mode refreshes supplied states without running behaviors."""
         yaml_file = tmp_path / "external_step.yaml"
@@ -1522,6 +1567,49 @@ class TestEndReleasesFigure:
 
         assert new_obstacle.id not in existing_ids
         env_b.end()
+
+
+class TestStepActionIds:
+    """``action_id`` means ``obj.id`` and stays valid after objects are deleted."""
+
+    @staticmethod
+    def _make(env_factory, tmp_path):
+        yaml_file = tmp_path / "ids.yaml"
+        robots = "".join(
+            f"  - {{kinematics: {{name: diff}}, shape: {{name: circle, radius: 0.2}}, state: [{x}, 1, 0]}}\n"
+            for x in (1, 3, 5)
+        )
+        yaml_file.write_text(f"world: {{height: 10, width: 10}}\nrobot:\n{robots}")
+        return env_factory(str(yaml_file))
+
+    @staticmethod
+    def _step_and_moved(env, action, **kwargs):
+        before = {r.id: r.state[0, 0] for r in env.robot_list}
+        env.step(action, **kwargs)
+        return [r.id for r in env.robot_list if r.state[0, 0] > before[r.id]]
+
+    def test_action_id_is_object_id_after_deletion(self, env_factory, tmp_path):
+        env = self._make(env_factory, tmp_path)
+        env.delete_object(0)
+        assert self._step_and_moved(env, [1.0, 0.0], action_id=1) == [1]
+
+    def test_default_targets_first_remaining_robot(self, env_factory, tmp_path):
+        env = self._make(env_factory, tmp_path)
+        env.delete_object(0)
+        assert self._step_and_moved(env, [1.0, 0.0]) == [1]
+
+    def test_dict_keyed_by_name(self, env_factory, tmp_path):
+        env = self._make(env_factory, tmp_path)
+        moved = self._step_and_moved(
+            env, {"robot_0": [1.0, 0.0], "robot_2": [1.0, 0.0]}
+        )
+        assert moved == [0, 2]
+        with pytest.raises(ValueError, match="no object with id or name 'ghost'"):
+            env.step([1.0, 0.0], action_id="ghost")
+
+    def test_sequential_actions_start_at_id(self, env_factory, tmp_path):
+        env = self._make(env_factory, tmp_path)
+        assert self._step_and_moved(env, [[1.0, 0.0]] * 2, action_id=1) == [1, 2]
 
 
 class TestStatusArrived:

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -225,6 +225,20 @@ class TestKinematicsRegistry:
         handler = KinematicsFactory.create_kinematics(name="acker")
         assert isinstance(handler, AckermannKinematics)
 
+    def test_create_kinematics_defaults_to_diff_only_when_name_is_missing(self):
+        handler = KinematicsFactory.create_kinematics(name=None)
+        assert isinstance(handler, DifferentialKinematics)
+        assert handler.name == "diff"
+
+        static_handler = KinematicsFactory.create_kinematics(name="static")
+        assert isinstance(static_handler, DifferentialKinematics)
+        assert static_handler.name == "static"
+
+        with pytest.raises(NotImplementedError, match="not registered"):
+            KinematicsFactory.create_kinematics(name="nonexistent")
+        with pytest.raises(NotImplementedError, match="not registered"):
+            KinematicsFactory.create_kinematics(name="")
+
     def test_register_custom_kinematics(self):
         """A custom kinematics type can be registered and created."""
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -457,6 +457,20 @@ class TestObjectBaseNoKinematics:
         env.end()
 
 
+def test_full_circle_object_fov_is_preserved():
+    """Explicit and lidar-derived fields of view keep a full circle."""
+    obj = ObjectBase(
+        role="robot",
+        kinematics={"name": "diff"},
+        shape={"name": "circle", "radius": 0.2},
+        sensors=[{"name": "lidar2d", "angle_range": 2 * np.pi, "number": 5}],
+    )
+    assert obj.fov == pytest.approx(2 * np.pi)
+
+    explicit_fov = ObjectBase(role="obstacle", fov=2 * np.pi, fov_radius=5.0)
+    assert explicit_fov.fov == pytest.approx(2 * np.pi)
+
+
 # ---------------------------------------------------------------------------
 # Robot API (ObjectBase through a live environment)
 # ---------------------------------------------------------------------------

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -949,10 +949,9 @@ class TestCollisionModes:
 
         env = env_factory("test_collision_world.yaml")
         env._env_param.logger = Mock(
-            warning=lambda msg, *a, **kw: warnings_collected.append(msg)
+            warning_once=lambda msg, *a, **kw: warnings_collected.append(msg)
         )
         env._world_param.collision_mode = "unknown_mode"
-        env._world_param.count = 50
         env.robot.check_status()
 
         assert env.robot.stop_flag is False
@@ -968,3 +967,58 @@ class TestDesiredOmniVel:
         robot = env.robot
         robot.set_goal(robot.state[:3].flatten().tolist())
         assert np.allclose(robot.desired_omni_vel, 0)
+
+
+class TestPerStepWarningsOnce:
+    """Persistent per-step conditions warn once per object, then log at DEBUG."""
+
+    @staticmethod
+    def _make_env(tmp_path, robot_yaml):
+        import irsim
+
+        yaml_file = tmp_path / "w.yaml"
+        yaml_file.write_text(f"world: {{height: 10, width: 10}}\nrobot:\n{robot_yaml}")
+        return irsim.make(
+            str(yaml_file), display=False, disable_all_plot=True, log_level="DEBUG"
+        )
+
+    @staticmethod
+    def _levels(env, action, needle, steps=5):
+        from loguru import logger as loguru_logger
+
+        records = []
+        sink = loguru_logger.add(lambda m: records.append(m.record), level="DEBUG")
+        try:
+            for _ in range(steps):
+                env.step(action)
+        finally:
+            loguru_logger.remove(sink)
+            env.end()
+        return [r["level"].name for r in records if needle in r["message"]]
+
+    def test_acce_clip_warns_once_then_debug(self, tmp_path):
+        """A finite ``acce`` clips every full-throttle step; only the first warns."""
+        env = self._make_env(
+            tmp_path,
+            """
+  - kinematics: {name: diff}
+    acce: [0.5, 1.0]
+    shape: {name: circle, radius: 0.2}
+    state: [1, 1, 0]
+""",
+        )
+        levels = self._levels(env, np.array([[2.0], [0.0]]), "clipped")
+        assert levels == ["WARNING"] + ["DEBUG"] * 4
+
+    def test_robot_without_behavior_warns_once_then_debug(self, tmp_path):
+        """A robot with no behavior and no action is reported once, not per step."""
+        env = self._make_env(
+            tmp_path,
+            """
+  - kinematics: {name: diff}
+    shape: {name: circle, radius: 0.2}
+    state: [1, 1, 0]
+""",
+        )
+        levels = self._levels(env, None, "static")
+        assert levels == ["WARNING"] + ["DEBUG"] * 4

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -207,6 +207,14 @@ class TestFMCWLidar2D:
         assert msg.angle_max == 0.0
         assert msg.angle_increment == 0.0
 
+    @pytest.mark.parametrize("angle_range", [2 * np.pi, 6.283185, 7.0])
+    def test_full_circle_angle_range_is_preserved(self, angle_range):
+        """A full (or over-full) revolution must not wrap to a zero-width scan."""
+        sensor = Lidar2D(state=np.zeros((3, 1)), angle_range=angle_range, number=5)
+
+        assert sensor.angle_range == pytest.approx(2 * np.pi)
+        np.testing.assert_allclose(sensor.angle_list, np.linspace(-np.pi, np.pi, 5))
+
     def test_factory_creates_fmcw_sensor(self):
         """SensorFactory should create the simplified FMCW lidar."""
         factory = SensorFactory()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,6 +2,7 @@ import math
 import os
 import time
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -46,6 +47,21 @@ def test_ClipTo2Pi():
     assert util.ClipTo2Pi(7.0) == pytest.approx(2 * math.pi)
     assert util.ClipTo2Pi(1.0) == 1.0
     assert util.ClipTo2Pi(-0.1) == 0.0
+    assert util.ClipTo2Pi(math.nan) == 0.0
+    assert util.ClipTo2Pi(math.inf) == 0.0
+
+
+def test_log_warning_once_falls_back_to_plain_warning():
+    from irsim.config import env_param
+
+    logger = Mock(spec=["warning"])  # no warning_once, like logging.Logger
+    original = env_param.logger
+    env_param.logger = logger
+    try:
+        util.log_warning_once("plain")
+    finally:
+        env_param.logger = original
+    logger.warning.assert_called_once_with("plain")
 
 
 def test_WrapToRegion():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -40,6 +40,14 @@ def test_WrapTo2Pi():
     assert util.WrapTo2Pi(float("nan")) == 0.0
 
 
+def test_ClipTo2Pi():
+    """A full circle stays 2*pi (WrapTo2Pi would give 0)."""
+    assert util.ClipTo2Pi(2 * math.pi) == pytest.approx(2 * math.pi)
+    assert util.ClipTo2Pi(7.0) == pytest.approx(2 * math.pi)
+    assert util.ClipTo2Pi(1.0) == 1.0
+    assert util.ClipTo2Pi(-0.1) == 0.0
+
+
 def test_WrapToRegion():
     region = [-math.pi, math.pi]
     assert util.WrapToRegion(3 * math.pi, region) == math.pi

--- a/tests/test_world_map.py
+++ b/tests/test_world_map.py
@@ -1815,3 +1815,26 @@ class TestWorld3D:
         w = World3D(name="w3", depth=5.0, offset=[1, 2, 3])
         assert w.offset == [1, 2, 3]
         assert w.z_range == [3, 8]
+
+
+class TestWorldTimeValidation:
+    """The steps per sample are resolved once at construction."""
+
+    def test_sample_time_below_step_time_samples_every_step(self):
+        """Was a ZeroDivisionError on the first step()."""
+        world = World(name="test", step_time=0.1, sample_time=0.05)
+        assert world.sample_steps == 1
+        world.step([])
+        assert world.sampling
+
+    @pytest.mark.parametrize(("sample_time", "steps"), [(0.3, 3), (0.7, 7)])
+    def test_sample_steps_round_float_ratio(self, sample_time, steps):
+        """0.3 / 0.1 is 2.999... in floating point: rounded, not truncated."""
+        world = World(name="test", step_time=0.1, sample_time=sample_time)
+        assert world.sample_steps == steps
+
+        for _ in range(steps - 1):
+            world.step([])
+            assert not world.sampling
+        world.step([])
+        assert world.sampling

--- a/tests/test_world_map.py
+++ b/tests/test_world_map.py
@@ -1827,9 +1827,11 @@ class TestWorldTimeValidation:
         world.step([])
         assert world.sampling
 
-    @pytest.mark.parametrize(("sample_time", "steps"), [(0.3, 3), (0.7, 7)])
-    def test_sample_steps_round_float_ratio(self, sample_time, steps):
-        """0.3 / 0.1 is 2.999... in floating point: rounded, not truncated."""
+    @pytest.mark.parametrize(
+        ("sample_time", "steps"), [(0.3, 3), (0.7, 7), (0.25, 2), (0.35, 3)]
+    )
+    def test_sample_steps_truncate_without_float_noise(self, sample_time, steps):
+        """Whole ratios survive float noise (0.3 / 0.1 is 2.999...); fractional ratios truncate."""
         world = World(name="test", step_time=0.1, sample_time=sample_time)
         assert world.sample_steps == steps
 


### PR DESCRIPTION
This PR fixes six bugs found in a code review and community feedback. Each fix has its own commit and test. YAML docs are updated in English and Chinese where behavior changed.

- **Lidar angle is wrapped.** A lidar `angle_range` of 2π was wrapped to 0, so all beams pointed forward. The same happened to an object `fov`. Both are now clipped to [0, 2π].
- **Figures leak after `end()`.** In headless runs `end()` did not close the figure. In other runs the keyboard cleanup opened a new one. Every environment left a figure behind. `end()` now closes only its own figure. It also no longer resets the global object id counter, which could give another environment duplicate ids.
- **Sampling interval is off by one.** `sample_time / step_time` is computed in floating point, so 0.3 / 0.1 gives 2.999… and `int()` turned it into 3. A `sample_time` smaller than `step_time` crashed with a division by zero. The ratio is still truncated, but the floating-point noise is dropped first, and it is never less than one step.
- **Flat action lists crash.** `env.step([1.0, 0.5])` split the two numbers over two objects and crashed. A tuple action was silently ignored. `action_id` meant a list position, not an object id. Actions now accept flat lists, tuples, and dicts keyed by robot name. `action_id` is the object id. Extra actions are dropped with a warning.
- **Warnings flood the log.** A clipped velocity or a robot without a behavior warned on every step. These now warn once and log later occurrences at DEBUG.
- **Unknown kinematics falls back to diff.** A typo in `kinematics.name` gave a differential-drive robot and a misleading warning. It now raises `NotImplementedError`.
