### PR TITLE
feat(env): add headless mode and forward custom kinematics parameters

### DIFF
--- a/docs/locale/zh_CN/LC_MESSAGES/usage/configure_robots_obstacles.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/usage/configure_robots_obstacles.po
@@ -393,3 +393,37 @@ msgid ""
 msgstr ""
 "`distribution` 参数用于控制机器人和障碍物的布局，可选 `'manual'` 或 "
 "`'random'`。更多细节见 {doc}`YAML 配置 <../yaml_config/configuration>`。"
+
+#: ../../source/usage/configure_robots_obstacles.md
+msgid "Advanced Configuration for Custom Kinematics"
+msgstr "自定义运动学的高级配置"
+
+#: ../../source/usage/configure_robots_obstacles.md
+msgid ""
+"If the built-in models (`diff`, `omni`, `omni_angular`, `acker`) do not "
+"match your robot, register your own kinematics handler. Subclass "
+"`KinematicsHandler` (or one of the built-in handlers), add any parameters "
+"your model needs to `__init__`, and register it with `@register_kinematics`:"
+msgstr ""
+"如果内置模型（`diff`、`omni`、`omni_angular`、`acker`）不符合你的机器人，可以注册自己的"
+"运动学处理器：继承 `KinematicsHandler`（或某个内置处理器），把模型需要的参数加到 "
+"`__init__` 中，并用 `@register_kinematics` 注册："
+
+#: ../../source/usage/configure_robots_obstacles.md
+msgid ""
+"Any key under `kinematics` other than `name`, `noise`, and `alpha` is passed "
+"to the handler's `__init__`, so the model's parameters are set directly in "
+"YAML:"
+msgstr ""
+"`kinematics` 下除 `name`、`noise`、`alpha` 之外的任何键都会传给处理器的 `__init__`，"
+"因此模型参数可以直接在 YAML 中设置："
+
+#: ../../source/usage/configure_robots_obstacles.md
+msgid ""
+"The module that defines the handler must be imported before `irsim.make()` "
+"so the registration runs. An unknown `name` raises `NotImplementedError`, "
+"and a key the handler does not accept raises `TypeError`, so typos in either "
+"are reported immediately."
+msgstr ""
+"定义处理器的模块必须在 `irsim.make()` 之前被导入，注册才会生效。未知的 `name` 会抛出 "
+"`NotImplementedError`，处理器不接受的键会抛出 `TypeError`，因此两者的拼写错误都会立即报告。"

--- a/docs/locale/zh_CN/LC_MESSAGES/usage/make_environment.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/usage/make_environment.po
@@ -743,3 +743,27 @@ msgid ""
 "Surplus actions are dropped with a warning; an unknown id or name raises "
 "`ValueError`."
 msgstr "多余的动作会被丢弃并给出警告；不存在的 id 或名字会抛出 `ValueError`。"
+
+#: ../../source/usage/make_environment.md
+msgid "Headless Mode for Batch Training"
+msgstr "用于批量训练的无头模式"
+
+#: ../../source/usage/make_environment.md
+msgid ""
+"Pass `headless=True` to run without any figure, window, or keyboard/mouse "
+"control. Environment creation is several times cheaper and nothing is left "
+"behind when an environment is discarded, which matters when a training loop "
+"creates many environments; `render()`, the drawing helpers, and "
+"`save_figure()` become no-ops so the same script runs unchanged:"
+msgstr ""
+"传入 `headless=True` 即可在没有任何图形、窗口和键盘/鼠标控制的情况下运行。环境创建开销降低数倍，"
+"丢弃环境时也不会留下任何残留，这在训练循环需要创建大量环境时很重要；`render()`、各绘图辅助函数和 "
+"`save_figure()` 都会变成空操作，因此同一脚本无需修改即可运行："
+
+#: ../../source/usage/make_environment.md
+msgid ""
+"`disable_all_plot=True` is kept as an alias. To render offscreen while still "
+"saving animations or figures, use `display=False` instead."
+msgstr ""
+"`disable_all_plot=True` 作为别名保留。如果需要离屏渲染并仍然保存动画或图片，请改用 "
+"`display=False`。"

--- a/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
@@ -3176,3 +3176,13 @@ msgstr "`external`：由外部系统负责更新状态。使用 `set_state()` �
 #: ../../source/yaml_config/configuration.md:594
 msgid "`irsim.make(\"world.yaml\", step_mode=\"...\")` can override the YAML value for a particular run. The override remains active across `env.reload()` and `env.reset(random=True)`."
 msgstr "`irsim.make(\"world.yaml\", step_mode=\"...\")` 可以为特定运行覆盖 YAML 中的值；该覆盖在 `env.reload()` 和 `env.reset(random=True)` 后仍然有效。"
+
+#: ../../source/yaml_config/configuration.md:1010
+msgid ""
+"Any other key under `kinematics` is passed to the handler's constructor. "
+"This is how a model registered with `@register_kinematics` receives its own "
+"parameters, e.g. `kinematics: {name: 'lag', tau: 0.5}`."
+msgstr ""
+"`kinematics` 下的其他任何键都会传给运动学处理器的构造函数。通过 "
+"`@register_kinematics` 注册的自定义模型正是以此方式接收自己的参数，例如 "
+"`kinematics: {name: 'lag', tau: 0.5}`。"

--- a/docs/source/usage/configure_robots_obstacles.md
+++ b/docs/source/usage/configure_robots_obstacles.md
@@ -288,3 +288,42 @@ obstacle:
 ```
 :::
 ::::
+
+## Advanced Configuration for Custom Kinematics
+
+If the built-in models (`diff`, `omni`, `omni_angular`, `acker`) do not match your robot, register your own kinematics handler. Subclass `KinematicsHandler` (or one of the built-in handlers), add any parameters your model needs to `__init__`, and register it with `@register_kinematics`:
+
+```python
+import numpy as np
+from irsim.lib import register_kinematics
+from irsim.lib.handler.kinematics_handler import DifferentialKinematics
+
+
+@register_kinematics("lag_diff")
+class LagDiffKinematics(DifferentialKinematics):
+    """Differential drive whose velocity follows the command with a first-order lag."""
+
+    def __init__(self, name, noise=False, alpha=None, tau=0.5):
+        super().__init__(name, noise, alpha)
+        self.tau = tau  # time constant of the lag, in seconds
+        self._vel = None
+
+    def step(self, state, velocity, step_time):
+        if self._vel is None:
+            self._vel = np.zeros_like(velocity)
+        self._vel = self._vel + (velocity - self._vel) * min(step_time / self.tau, 1.0)
+        return super().step(state, self._vel, step_time)
+```
+
+Any key under `kinematics` other than `name`, `noise`, and `alpha` is passed to the handler's `__init__`, so the model's parameters are set directly in YAML:
+
+```yaml
+robot:
+  - kinematics: {name: 'lag_diff', tau: 0.5}
+    shape: {name: 'circle', radius: 0.2}
+    state: [1, 1, 0]
+```
+
+:::{important}
+The module that defines the handler must be imported before `irsim.make()` so the registration runs. An unknown `name` raises `NotImplementedError`, and a key the handler does not accept raises `TypeError`, so typos in either are reported immediately.
+:::

--- a/docs/source/usage/make_environment.md
+++ b/docs/source/usage/make_environment.md
@@ -160,6 +160,16 @@ Update order
 The environment advances all objects first, then updates all sensors. This two-phase update ensures sensors read the latest world state consistently. If you step objects manually, either pass `sensor_step=True` to `ObjectBase.step(...)` or call `obj.sensor_step()` after updating states.
 ::::
 
+### Headless Mode for Batch Training
+
+Pass `headless=True` to run without any figure, window, or keyboard/mouse control. Environment creation is several times cheaper and nothing is left behind when an environment is discarded, which matters when a training loop creates many environments; `render()`, the drawing helpers, and `save_figure()` become no-ops so the same script runs unchanged:
+
+```python
+env = irsim.make("config.yaml", headless=True)
+```
+
+`disable_all_plot=True` is kept as an alias. To render offscreen while still saving animations or figures, use `display=False` instead.
+
 ### Internal and External Step Modes
 
 The default `internal` mode preserves the normal IR-SIM loop. Actions may be

--- a/docs/source/usage/multiple_environments.md
+++ b/docs/source/usage/multiple_environments.md
@@ -82,10 +82,10 @@ env2.end()
 ```python
 import irsim
 
-# Create multiple headless environments for training
+# Create multiple headless environments for training (no figures or input devices)
 num_envs = 4
 envs = [
-    irsim.make(f"training_world.yaml", display=False, seed=i) for i in range(num_envs)
+    irsim.make(f"training_world.yaml", headless=True, seed=i) for i in range(num_envs)
 ]
 
 # Run training loop

--- a/docs/source/yaml_config/configuration.md
+++ b/docs/source/yaml_config/configuration.md
@@ -1009,6 +1009,9 @@ env.step(env.robot.vel_world2body(world_vel))
     kinematics: {name: 'acker', noise: True, alpha: [0.03, 0, 0, 0.03], mode: 'steer'}
     ```
   
+
+  Any other key under `kinematics` is passed to the handler's constructor. This is how a model registered with `@register_kinematics` receives its own parameters, e.g. `kinematics: {name: 'lag', tau: 0.5}`.
+
 (p-o-vel-min)=
 **`vel_min`** (`list` of `float`, default: `[-1, -1]`) and **`vel_max`** (`list` of `float`, default: `[1, 1]`)
 : Set the minimum and maximum velocity limits for each control dimension (e.g., linear and angular velocities). These constraints ensure the object's motion stays within feasible and safe bounds.

--- a/irsim/env/env_base.py
+++ b/irsim/env/env_base.py
@@ -35,6 +35,7 @@ from irsim.util.util import (
     find_duplicates,
     find_object_by_identity,
     normalize_actions,
+    plot_only,
     to_numpy,
 )
 from irsim.world import ObjectBase, ObjectFactory
@@ -88,7 +89,7 @@ class EnvBase:
             or use a minimal setup.
         display (bool): Whether to display the environment visualization.
             Set to False for headless operation. Default is True.
-        disable_all_plot (bool): Whether to disable all plots and figures completely.
+        disable_all_plot (bool): Same as ``headless``; kept for backward compatibility.
             When True, no visualization will be created even if display is True.
             Default is False.
         save_ani (bool): Whether to save the simulation as an animation file.
@@ -107,6 +108,9 @@ class EnvBase:
         seed (int, optional): Seed for the random number generator. Default is None.
             If None, the seed will be set to a random value, which will make the simulation non-reproducible.
             If a fixed seed is provided, the random simulation scenario will be reproducible.
+        headless (bool): Run without any figure, window, or keyboard/mouse control,
+            e.g. for batch training. Implies ``display=False``; rendering, drawing, and
+            saving helpers become no-ops. Default is False.
         step_mode ({"internal", "external"}, optional): Override the mode from
             ``world.step_mode`` in YAML. ``internal`` runs the normal IR-SIM
             kinematics step. ``external`` expects callers to update object
@@ -115,7 +119,8 @@ class EnvBase:
 
     Attributes:
         display (bool): Whether to display the environment visualization.
-        disable_all_plot (bool): Whether all plotting is disabled.
+        headless (bool): Whether the environment runs without a figure, window, or
+            keyboard/mouse control.
         save_ani (bool): Whether to save animation during simulation.
 
         env_config (EnvConfig): Configuration loader managing YAML parsing and object creation.
@@ -157,6 +162,7 @@ class EnvBase:
         log_level: str = "INFO",
         seed: int | None = None,
         step_mode: Literal["internal", "external"] | None = None,
+        headless: bool = False,
     ) -> None:
         # Reset object ID counter so each environment starts from 0
         ObjectBase.reset_id_iter()
@@ -167,14 +173,14 @@ class EnvBase:
         self._path_manager = PathManager()
         self._bind_config()
 
-        # init env setting
-        self.display = display
+        # init env setting: headless means no figure, no window, no input devices
+        self.headless = headless or disable_all_plot
+        self.display = display and not self.headless
         set_seed(seed)
 
         if not self.display:
             matplotlib.use("Agg")
 
-        self.disable_all_plot = disable_all_plot
         self.save_ani = save_ani
         # Copy so later external mutation of the caller's dict can't change
         # this env's default animation-save behavior.
@@ -188,6 +194,7 @@ class EnvBase:
                 env_param_instance=self._env_param,
                 world_param_instance=self._world_param,
                 step_mode=step_mode,
+                disable_all_plot=self.headless,
             )
         except Exception as e:
             self.logger.critical(f"YAML Configuration load failed: {e}")
@@ -210,20 +217,29 @@ class EnvBase:
         self._env_param.objects = self._objects
         self.validate_unique_names()
 
-        # Try to initialize keyboard control (pynput or MPL backend inside KeyboardControl)
         self.keyboard = None
-        try:
-            keyboard_config = self.env_config.parse["gui"].get("keyboard", {})
-            self.keyboard = KeyboardControl(env_ref=self, **keyboard_config)
-        except Exception as e:
-            self.logger.error(
-                f"Keyboard control unavailable error: {e}. Auto control applied. "
-                "Install 'pynput' or set backend='mpl' in YAML keyboard config."
-            )
+        self.mouse = None
+        if self._env_plot is None:
+            # No figure for keyboard/mouse control to attach to.
+            if self._world_param.control_mode == "keyboard":
+                self.logger.warning(
+                    "Keyboard control needs a figure; headless mode forces auto control."
+                )
             self._world_param.control_mode = "auto"
+        else:
+            # Try to initialize keyboard control (pynput or MPL backend inside KeyboardControl)
+            try:
+                keyboard_config = self.env_config.parse["gui"].get("keyboard", {})
+                self.keyboard = KeyboardControl(env_ref=self, **keyboard_config)
+            except Exception as e:
+                self.logger.error(
+                    f"Keyboard control unavailable error: {e}. Auto control applied. "
+                    "Install 'pynput' or set backend='mpl' in YAML keyboard config."
+                )
+                self._world_param.control_mode = "auto"
 
-        mouse_config = self.env_config.parse["gui"].get("mouse", {})
-        self.mouse = MouseControl(self._env_plot.ax, **mouse_config)
+            mouse_config = self.env_config.parse["gui"].get("mouse", {})
+            self.mouse = MouseControl(self._env_plot.ax, **mouse_config)
 
         # flag for keyboard control
         self.pause_flag = False
@@ -469,6 +485,7 @@ class EnvBase:
         return action
 
     # render
+    @plot_only
     def render(
         self,
         interval: float = 0.01,
@@ -491,7 +508,7 @@ class EnvBase:
 
         if figure_kwargs is None:
             figure_kwargs = {}
-        if not self.disable_all_plot and self._world.sampling:
+        if self._world.sampling:
             if self.display:
                 plt.pause(interval)
 
@@ -510,6 +527,7 @@ class EnvBase:
         if self.reload_flag:
             self.reload()
 
+    @plot_only
     def show(self) -> None:
         """
         Show the environment figure.
@@ -518,6 +536,7 @@ class EnvBase:
         self._env_plot.show()
 
     # draw various components
+    @plot_only
     def draw_trajectory(
         self, traj: list[Any], traj_type: str = "g-", **kwargs: Any
     ) -> None:
@@ -534,6 +553,7 @@ class EnvBase:
 
         self._env_plot.draw_trajectory(traj, traj_type, **kwargs)
 
+    @plot_only
     def draw_points(
         self,
         points: list[Any],
@@ -557,6 +577,7 @@ class EnvBase:
 
         self._env_plot.draw_points(points, s, c, refresh, **kwargs)
 
+    @plot_only
     def draw_box(
         self, vertex: np.ndarray, refresh: bool = False, color: str = "-b"
     ) -> None:
@@ -570,6 +591,7 @@ class EnvBase:
         """
         self._env_plot.draw_box(vertex, refresh, color)
 
+    @plot_only
     def draw_quiver(self, point: Any, refresh: bool = False, **kwargs: Any) -> None:
         """
         Draw a single quiver (arrow) on the environment figure.
@@ -582,6 +604,7 @@ class EnvBase:
         """
         self._env_plot.draw_quiver(point, refresh, **kwargs)
 
+    @plot_only
     def draw_quivers(self, points: Any, refresh: bool = False, **kwargs: Any) -> None:
         """
         Draw multiple quivers (arrows) on the environment figure.
@@ -603,7 +626,7 @@ class EnvBase:
             **kwargs: Additional keyword arguments for saving the animation, see :py:meth:`.EnvPlot.save_animate` for detail.
         """
 
-        if not self.disable_all_plot:
+        if not self.headless:
             if self.save_ani:
                 # precedence: call kwargs > env ani_kwargs > world-named default
                 self._env_plot.save_animate(
@@ -623,9 +646,8 @@ class EnvBase:
         if self.keyboard is not None:
             self.keyboard.close()
 
-        # The figure exists even when plotting is disabled; close it so that
-        # headless episodic loops do not leak one figure per environment.
-        self._env_plot.close()
+        if self._env_plot is not None:
+            self._env_plot.close()
         self._env_param.objects = []
 
         self.logger.info(
@@ -828,6 +850,7 @@ class EnvBase:
         self._objects_sensor_step()
         self._status_step()
 
+    @plot_only
     def reset_plot(self) -> None:
         """
         Reset the environment figure in-place.
@@ -881,7 +904,8 @@ class EnvBase:
                         existing_obj.append(obj)
                         break
 
-        self._env_plot.step("all", self.obstacle_list)
+        if self._env_plot is not None:
+            self._env_plot.step("all", self.obstacle_list)
 
     def random_polygon_shape(
         self,
@@ -942,7 +966,8 @@ class EnvBase:
                 geom = Polygon(vertices_list[i])
                 obj.set_original_geometry(geom)
 
-        self._env_plot.step("all", self.obstacle_list)
+        if self._env_plot is not None:
+            self._env_plot.step("all", self.obstacle_list)
 
     def reload(self, world_name: str | None = None) -> None:
         """
@@ -957,7 +982,8 @@ class EnvBase:
         """
         ObjectBase.reset_id_iter()
         self.reset()
-        self._env_plot.clear_components("all", self.objects)
+        if self._env_plot is not None:
+            self._env_plot.clear_components("all", self.objects)
         (
             self._world,
             self._objects,
@@ -1048,7 +1074,7 @@ class EnvBase:
             raise ValueError(f"Object name '{obj.name}' already exists.")
         obj._env = self
         self._objects.append(obj)
-        if not self.disable_all_plot:
+        if not self.headless:
             obj._init_plot(self._env_plot.ax)
             obj._step_plot()
         self.build_tree()
@@ -1071,7 +1097,7 @@ class EnvBase:
             raise ValueError(f"Object names already exist: {conflicts}")
         for obj in objs:
             obj._env = self
-            if not self.disable_all_plot:
+            if not self.headless:
                 obj._init_plot(self._env_plot.ax)
                 obj._step_plot()
         self._objects.extend(objs)
@@ -1339,6 +1365,7 @@ class EnvBase:
 
     # endregion: get information
 
+    @plot_only
     def set_title(self, title: str) -> None:
         """
         Set the title of the plot.
@@ -1374,6 +1401,7 @@ class EnvBase:
         """
         self._world.status = status
 
+    @plot_only
     def save_figure(
         self,
         save_name: str | None = None,
@@ -1481,6 +1509,11 @@ class EnvBase:
             list: List of dynamic objects in the environment.
         """
         return [obj for obj in self.objects if not obj.static]
+
+    @property
+    def disable_all_plot(self) -> bool:
+        """Alias of :attr:`headless`, kept for backward compatibility."""
+        return self.headless
 
     @property
     def step_time(self) -> float:

--- a/irsim/env/env_base3d.py
+++ b/irsim/env/env_base3d.py
@@ -49,8 +49,10 @@ class EnvBase3D(EnvBase):
             world_offset=self._world.offset[:2],
         )
 
-        self._env_plot.close()
-
-        self._env_plot = EnvPlot3D(self._world, self.objects, **self._world.plot_parse)
+        if self._env_plot is not None:
+            self._env_plot.close()
+            self._env_plot = EnvPlot3D(
+                self._world, self.objects, **self._world.plot_parse
+            )
 
         env_param.objects = self.objects

--- a/irsim/env/env_config.py
+++ b/irsim/env/env_config.py
@@ -35,11 +35,13 @@ class EnvConfig:
         env_param_instance: EnvParam | None = None,
         world_param_instance: WorldParam | None = None,
         step_mode: str | None = None,
+        disable_all_plot: bool = False,
     ) -> None:
         self.object_factory = ObjectFactory()
         self._env_param = env_param_instance
         self._world_param = world_param_instance
         self._step_mode = step_mode
+        self._disable_all_plot = disable_all_plot
         self.load_yaml(world_name)
 
     def load_yaml(self, world_name: str | None = None) -> None:
@@ -114,7 +116,8 @@ class EnvConfig:
 
         world, objects, robots, obstacles, maps, groups = self._build_scene()
 
-        self._env_plot = EnvPlot(world, objects)
+        # No figure at all when plotting is disabled: nothing would draw on it.
+        self._env_plot = None if self._disable_all_plot else EnvPlot(world, objects)
         self._objects = objects
 
         return world, objects, self._env_plot, robots, obstacles, maps, groups
@@ -131,8 +134,9 @@ class EnvConfig:
 
         world, objects, robots, obstacles, maps, groups = self._build_scene()
 
-        self._env_plot.clear_components("all", self._objects)
-        self._env_plot._init_plot(world, objects)
+        if self._env_plot is not None:
+            self._env_plot.clear_components("all", self._objects)
+            self._env_plot._init_plot(world, objects)
 
         # Refresh cached objects so subsequent reloads clear the right set
         self._objects = objects

--- a/irsim/gui/keyboard_control.py
+++ b/irsim/gui/keyboard_control.py
@@ -6,19 +6,23 @@ import numpy as np
 if TYPE_CHECKING:
     pass
 
-# Optional pynput import (allows fallback to Matplotlib key events)
-# Predeclare for type checkers
+# pynput is optional and costs ~85 ms to import, so it is loaded on first use:
+# only when a keyboard controller with the pynput backend is created.
 keyboard: Any | None = None
-try:  # pragma: no cover - availability depends on environment
-    from pynput import keyboard as _pynput_keyboard
 
-    if getattr(_pynput_keyboard, "Listener", None) is not None:
-        keyboard = _pynput_keyboard
-        _PYNPUT_AVAILABLE = True
-    else:
-        _PYNPUT_AVAILABLE = False
-except Exception:  # pragma: no cover
-    _PYNPUT_AVAILABLE = False
+
+def _load_pynput() -> Any | None:
+    """Import ``pynput.keyboard`` on demand; ``None`` when it is unavailable."""
+    global keyboard
+    if keyboard is None:
+        try:  # pragma: no cover - availability depends on environment
+            from pynput import keyboard as pynput_keyboard
+        except Exception:
+            return None
+        if getattr(pynput_keyboard, "Listener", None) is not None:
+            keyboard = pynput_keyboard
+    return keyboard
+
 
 # Global registry to track which KeyboardControl instance is currently active
 # This ensures only one environment responds to keyboard input at a time
@@ -166,7 +170,7 @@ class KeyboardControl:
             headers = ["Key", "Function"]
             print(self._format_grid_table(headers, commands))
 
-        if self.backend == "pynput" and not _PYNPUT_AVAILABLE:
+        if self.backend == "pynput" and _load_pynput() is None:
             self.logger.warning("pynput is not available. Using matplotlib backend.")
             self.backend = "mpl"
 
@@ -198,7 +202,7 @@ class KeyboardControl:
 
         if not interactive:
             self.listener = None
-        elif self.backend == "pynput" and _PYNPUT_AVAILABLE:
+        elif self.backend == "pynput":
             # Use pynput global keyboard listener
             self.listener = keyboard.Listener(
                 on_press=self._on_pynput_press, on_release=self._on_pynput_release

--- a/irsim/lib/handler/kinematics_handler.py
+++ b/irsim/lib/handler/kinematics_handler.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from math import atan2
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import numpy as np
 
@@ -21,6 +21,10 @@ _kinematics_registry: dict[str, type["KinematicsHandler"]] = {}
 
 def register_kinematics(name: str):
     """Decorator to register a KinematicsHandler subclass.
+
+    Any extra key under ``kinematics:`` in YAML is passed to the subclass's
+    ``__init__`` (after ``name``, ``noise``, ``alpha``), so a registered model
+    can take its own parameters, e.g. ``kinematics: {name: lag, tau: 0.5}``.
 
     Args:
         name (str): Name used in YAML configs (e.g. ``"diff"``, ``"omni"``).
@@ -64,7 +68,8 @@ class KinematicsHandler(ABC):
 
     Subclasses should set the class-attribute metadata described below and
     implement :meth:`step`, :meth:`velocity_to_xy`, :meth:`compute_max_speed`,
-    and :meth:`compute_heading`.
+    and :meth:`compute_heading`. A subclass may add keyword parameters to
+    ``__init__``; any extra key under ``kinematics:`` in YAML is passed to it.
     """
 
     # -- Metadata (override in subclasses) --
@@ -419,29 +424,33 @@ class KinematicsFactory:
         name: str | None = None,
         noise: bool = False,
         alpha: list | None = None,
-        mode: str = "steer",
-        wheelbase: float | None = None,
+        *,
         role: str = "robot",
+        wheelbase: float | None = None,
+        **kwargs: Any,
     ) -> KinematicsHandler:
-        """Create a kinematics handler from a YAML ``kinematics.name`` value.
+        """Create a kinematics handler from a YAML ``kinematics`` block.
 
         Args:
-            name: Registered kinematics name, such as ``diff``, ``omni``,
-                ``omni_angular``, or ``acker``. ``None`` defaults to ``diff``;
+            name: Registered kinematics name: ``diff``, ``omni``, ``omni_angular``,
+                ``acker``, or a custom name registered with
+                :func:`register_kinematics`. ``None`` defaults to ``diff``;
                 ``static`` is retained as the static-object sentinel.
             noise: Whether to apply motion noise.
             alpha: Noise parameters passed to the handler.
-            mode: Ackermann mode, used only by ``acker``.
-            wheelbase: Ackermann wheelbase; defaults to ``1.0`` for ``acker``.
             role: Object role, retained for API compatibility.
+            wheelbase: Wheelbase of a car-like shape, used by ``acker`` handlers
+                (default ``1.0``) unless ``kinematics`` sets it itself.
+            **kwargs: Any other ``kinematics`` key, forwarded to the handler's
+                ``__init__`` (``mode`` for ``acker``, or a custom handler's own
+                parameters).
 
         Returns:
-            KinematicsHandler: Registered handler instance, or a differential
-            handler when the name is missing.
+            KinematicsHandler: Handler instance for ``name``.
 
         Raises:
-            NotImplementedError: If a non-empty name other than ``static`` is
-                not registered.
+            NotImplementedError: If ``name`` is not registered.
+            TypeError: If the handler does not accept a forwarded parameter.
         """
         if name is None:
             return DifferentialKinematics("diff", noise, alpha)
@@ -451,13 +460,11 @@ class KinematicsFactory:
             return DifferentialKinematics("static", noise, alpha)
 
         handler_cls = _kinematics_registry.get(name)
-
-        if handler_cls is not None:
-            # AckermannKinematics accepts extra kwargs
-            if issubclass(handler_cls, AckermannKinematics):
-                return handler_cls(name, noise, alpha, mode, wheelbase or 1.0)
-            return handler_cls(name, noise, alpha)
-        raise NotImplementedError(f"Kinematics {name!r} is not registered")
+        if handler_cls is None:
+            raise NotImplementedError(f"Kinematics {name!r} is not registered")
+        if issubclass(handler_cls, AckermannKinematics):
+            kwargs.setdefault("wheelbase", wheelbase or 1.0)
+        return handler_cls(name, noise, alpha, **kwargs)
 
     @staticmethod
     def get_handler_class(name: str) -> type[KinematicsHandler] | None:

--- a/irsim/util/util.py
+++ b/irsim/util/util.py
@@ -1,4 +1,5 @@
 import difflib
+import functools
 import inspect
 import math
 import os
@@ -1007,6 +1008,23 @@ def _target_positions(objects: list, action_id: Any, count: int) -> list[int]:
         return [position(i) for i in action_id]
     start = 0 if action_id is None else position(action_id)
     return list(range(start, min(start + count, len(objects))))
+
+
+def plot_only(method):
+    """Decorator making an env plotting helper a no-op when the env has no figure.
+
+    ``EnvBase`` creates no ``EnvPlot`` in headless mode, so
+    rendering, drawing, and saving helpers decorated with this simply return
+    ``None`` in that case.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if self._env_plot is None:
+            return None
+        return method(self, *args, **kwargs)
+
+    return wrapper
 
 
 def normalize_actions(func):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1526,7 +1526,7 @@ class TestEndReleasesFigure:
                 projection=projection,
             )
             env.step()
-            assert len(plt.get_fignums()) == 1
+            assert len(plt.get_fignums()) == (0 if disable_all_plot else 1)
             env.end()
             assert plt.get_fignums() == []
 
@@ -1534,12 +1534,7 @@ class TestEndReleasesFigure:
         """end() is idempotent, closes only its own figure, and frees the keyboard."""
         import irsim.gui.keyboard_control as kb_module
 
-        env = irsim.make(
-            "test_collision_world.yaml",
-            save_ani=False,
-            display=False,
-            disable_all_plot=True,
-        )
+        env = irsim.make("test_collision_world.yaml", save_ani=False, display=False)
         env_fig = env._env_plot.fig
         unrelated_fig = plt.figure()
         env.keyboard._set_active()
@@ -1610,6 +1605,51 @@ class TestStepActionIds:
     def test_sequential_actions_start_at_id(self, env_factory, tmp_path):
         env = self._make(env_factory, tmp_path)
         assert self._step_and_moved(env, [[1.0, 0.0]] * 2, action_id=1) == [1, 2]
+
+
+class TestDisableAllPlotSkipsFigure:
+    """``disable_all_plot`` creates no figure and turns the plot helpers into no-ops."""
+
+    @pytest.mark.parametrize("projection", ["2d", "3d"])
+    def test_no_figure_and_helpers_are_noops(self, env_factory, projection):
+        plt.close("all")
+        env = env_factory(
+            "test_collision_world.yaml", disable_all_plot=True, projection=projection
+        )
+        assert env._env_plot is None
+        assert env.mouse is None
+        assert plt.get_fignums() == []
+
+        env.step()
+        env.render()
+        env.draw_trajectory(env.robot.trajectory)
+        env.draw_points([[1.0, 1.0]])
+        env.set_title("headless")
+        env.save_figure()
+        env.reset_plot()
+        env.random_obstacle_position()
+        if projection == "2d":
+            env.reset(random=True)
+            env.reload()
+            env.step()
+        env.end()
+
+        assert plt.get_fignums() == []
+
+    def test_headless_argument_and_alias(self, env_factory):
+        env = env_factory("test_collision_world.yaml", headless=True, display=True)
+        assert env.headless
+        assert env.disable_all_plot  # alias
+        assert not env.display  # headless implies no window
+        assert env._env_plot is None
+        alias = env_factory("test_collision_world.yaml", disable_all_plot=True)
+        assert alias.headless
+        assert alias._env_plot is None
+
+    def test_keyboard_control_falls_back_to_auto(self, env_factory):
+        env = env_factory("test_keyboard_control.yaml", disable_all_plot=True)
+        assert env._world_param.control_mode == "auto"
+        env.step()
 
 
 class TestStatusArrived:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -293,7 +293,7 @@ class TestKeyboardControlPynput:
         """Test pynput unavailable falls back to mpl."""
         env = env_factory("test_keyboard_control.yaml")
         with (
-            patch("irsim.gui.keyboard_control._PYNPUT_AVAILABLE", False),
+            patch("irsim.gui.keyboard_control._load_pynput", lambda: None),
             patch.object(env._env_param.logger, "warning") as mock_warning,
         ):
             kb = irsim.gui.keyboard_control.KeyboardControl(env, backend="pynput")
@@ -851,3 +851,37 @@ class TestMouseControl:
         mock_release.button = MouseButton.RIGHT
         mouse_control.on_release(mock_release)
         assert mouse_control.right_click_pos is None
+
+
+class TestPynputIsImportedLazily:
+    """pynput (an input-device library, ~85 ms to import) must only load when used."""
+
+    @staticmethod
+    def _modules_after(code):
+        import subprocess
+        import sys
+
+        script = f"import sys\n{code}\nprint('pynput' in sys.modules)"
+        out = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, check=True
+        )
+        return out.stdout.strip().splitlines()[-1] == "True"
+
+    def test_import_and_headless_env_do_not_load_pynput(self, tmp_path):
+        assert not self._modules_after("import irsim")
+        yaml_file = tmp_path / "w.yaml"
+        yaml_file.write_text(
+            "world: {height: 5, width: 5}\nrobot:\n  - {kinematics: {name: diff}, shape: {name: circle, radius: 0.2}, state: [1, 1, 0]}\n"
+        )
+        assert not self._modules_after(
+            f"import irsim\nenv = irsim.make({str(yaml_file)!r}, headless=True, log_level='ERROR')\nenv.step()\nenv.end()"
+        )
+
+    @requires_pynput
+    def test_pynput_backend_loads_it(self):
+        import os
+
+        yaml_file = os.path.abspath("test_keyboard_control.yaml")
+        assert self._modules_after(
+            f"import irsim\nenv = irsim.make({yaml_file!r}, display=False, log_level='ERROR')\nenv.end()"
+        )

--- a/tests/test_kinematics.py
+++ b/tests/test_kinematics.py
@@ -522,3 +522,39 @@ class TestVelocityToXYZeroShape:
         velocity = np.float64(0.0)  # ndim == 0
         result = handler.velocity_to_xy(state, velocity)
         np.testing.assert_array_equal(result, np.zeros((2, 1)))
+
+
+class TestKinematicsParameters:
+    """Extra ``kinematics`` keys reach the handler's constructor."""
+
+    def test_extra_parameters_are_forwarded(self):
+        @register_kinematics("test_lag")
+        class LagKinematics(DifferentialKinematics):
+            def __init__(self, name, noise=False, alpha=None, tau=0.3):
+                super().__init__(name, noise, alpha)
+                self.tau = tau
+
+        assert KinematicsFactory.create_kinematics(name="test_lag", tau=0.5).tau == 0.5
+        acker = KinematicsFactory.create_kinematics(
+            name="acker", mode="angular", wheelbase=2.0
+        )
+        assert (acker.mode, acker.wheelbase) == ("angular", 2.0)
+        with pytest.raises(TypeError, match="tau"):
+            KinematicsFactory.create_kinematics(name="diff", tau=0.5)
+
+        # a shape's wheelbase only concerns Ackermann handlers
+        assert (
+            KinematicsFactory.create_kinematics(name="acker", wheelbase=3.0).wheelbase
+            == 3.0
+        )
+        assert KinematicsFactory.create_kinematics(name="acker").wheelbase == 1.0
+        assert KinematicsFactory.create_kinematics(name="omni_angular", wheelbase=3.0)
+
+        # the same path through an object's YAML ``kinematics`` block
+        from irsim.world.object_base import ObjectBase
+
+        robot = ObjectBase(
+            kinematics={"name": "test_lag", "tau": 0.5},
+            shape={"name": "circle", "radius": 0.2},
+        )
+        assert robot.kf.tau == 0.5


### PR DESCRIPTION
Two features on top of #360 (base branch `fix/review-robustness`). The diff shows only the three commits of this branch.

- **Headless mode.** Batch training creates many environments. Each one built a matplotlib figure it never used. `irsim.make(..., headless=True)` now creates no figure, no window, and no keyboard or mouse controller. Rendering and saving helpers do nothing. Creating an environment is about six times cheaper and nothing leaks. `disable_all_plot` still works as an alias.
- **Custom kinematics parameters.** A model registered with `@register_kinematics` could not take its own parameters from YAML; the factory raised `TypeError`. Any extra key under `kinematics:` is now passed to the handler's `__init__`, for example `kinematics: {name: lag_diff, tau: 0.5}`. The docs show a first-order lag model.
- **pynput is imported lazily.** `import irsim` loaded pynput even when no keyboard was used. That cost about 85 ms per process. It is now imported only when a pynput keyboard controller is created.