### PR TITLE
fix(fov): keep a close object inside the field of view

### DIFF
--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -903,8 +903,12 @@ class ObjectBase:
         """
         Detect whether the input object is in the field of view.
 
+        The object counts as detected when any part of it falls inside the
+        view cone, so its radius widens the angular test and shortens the
+        range test.
+
         Args:
-            object: The object that to be detected.
+            detected_object: The object that to be detected.
 
         Returns:
             bool: Whether the object is in the field of view.
@@ -923,12 +927,16 @@ class ObjectBase:
         rad_diff = WrapToPi(rad_to_do - object_orientation, True)
         distance_do = math.hypot(dx, dy)
 
-        if distance_do == 0:
-            rad_offset = pi / 2
+        if distance_do <= radius_do:
+            # The object encloses the view point, so it spans every bearing.
+            rad_offset = pi
         else:
-            rad_offset = WrapToPi(math.asin(min(radius_do / distance_do, 1)))
+            rad_offset = math.asin(radius_do / distance_do)
 
-        fov_diff = abs(rad_diff - rad_offset)
+        # Bearing of the near edge, measured from the view axis. It goes
+        # negative once the object straddles that axis, which keeps a large or
+        # close object inside the cone instead of pushing it back out.
+        fov_diff = rad_diff - rad_offset
 
         return bool(
             fov_diff <= self.fov / 2 and distance_do - radius_do <= self.fov_radius

--- a/tests/test_behaviors.py
+++ b/tests/test_behaviors.py
@@ -987,6 +987,53 @@ class TestFOVDetection:
             )
         assert isinstance(detected, list)
 
+    @staticmethod
+    def _viewer(fov=1.57, fov_radius=5.0):
+        """Build a viewer at the origin facing +x with the given view cone."""
+        return ObjectBase(
+            shape={"name": "circle", "radius": 0.4},
+            state=[0, 0, 0],
+            fov=fov,
+            fov_radius=fov_radius,
+        )
+
+    @staticmethod
+    def _target(x, y, radius=0.5):
+        """Build a circular object centred on ``(x, y)``."""
+        return ObjectBase(shape={"name": "circle", "radius": radius}, state=[x, y, 0])
+
+    @pytest.mark.parametrize("distance", [0.8, 0.7, 0.6, 0.5, 0.4, 0.2])
+    def test_close_object_on_axis_stays_detected(self, distance):
+        """An object on the view axis stays detected as it closes in.
+
+        Below ``radius / sin(fov / 2)`` (~0.707 m here) its angular half
+        width exceeds ``fov / 2``, which must not push it back out of the
+        cone it is centred in.
+        """
+        viewer = self._viewer()
+        assert viewer.fov_detect_object(self._target(distance, 0.0))
+
+    def test_object_enclosing_view_point_is_detected(self):
+        """An object covering the view point spans every bearing."""
+        viewer = self._viewer()
+        assert viewer.fov_detect_object(self._target(0.0, 0.0, radius=1.0))
+
+    def test_object_wider_than_cone_is_detected(self):
+        """A narrow cone still sees an object that straddles its axis."""
+        viewer = self._viewer(fov=0.2)
+        assert viewer.fov_detect_object(self._target(2.0, 0.0))
+
+    @pytest.mark.parametrize(("x", "y"), [(-2.0, 0.0), (0.0, 3.0), (-1.0, 1.0)])
+    def test_object_outside_cone_is_not_detected(self, x, y):
+        """Objects off to the side or behind are still rejected."""
+        viewer = self._viewer()
+        assert not viewer.fov_detect_object(self._target(x, y))
+
+    def test_object_beyond_fov_radius_is_not_detected(self):
+        """The range limit still applies on the view axis."""
+        viewer = self._viewer()
+        assert not viewer.fov_detect_object(self._target(8.0, 0.0))
+
 
 def _loop_world(tmp_path, kinematics="diff", goal=None, behavior=None):
     """Write a minimal loop-behavior world YAML and return its path."""


### PR DESCRIPTION
`fov_detect_object` widens the angular test by the object's angular half width, then takes the absolute value of the result. Once that half width exceeds the bearing to the object, which is what happens when the object straddles the view axis, the difference flips sign and grows again, so an object centred in the cone is reported outside it.

The effect is that objects disappear as they get closer, which is the opposite of what a field of view test should do.

### Reproduction

On the settings shipped in `usage/15fov_world` (`fov: 1.57`, obstacle radius 0.5), with the object dead ahead:

```
 distance  gap to surface  detected(before)  detected(after)
     0.80            0.30      True              True
     0.71            0.21      True              True
     0.70            0.20     False              True
     0.50            0.00     False              True     <- touching
     0.20           -0.30     False              True     <- overlapping
```

The cut-off is exactly `radius / sin(fov / 2)` = 0.7071. Through the public API (`irsim.make` plus `get_fov_detected_objects`), an obstacle 0.10 m from the robot's surface is dropped while one 1.50 m away is returned.

### Checking it against an independent oracle

Comparing against a shapely intersection of the object disc with the exact sector `plot_fov` draws, over 20,000 random placements:

|                                                  | before | after |
| ------------------------------------------------ | ------ | ----- |
| false negatives (inside the drawn cone, reported out) | 57     | **0** |
| false positives (outside, reported in)            | 14     | 14    |

The 14 false positives are unchanged and pre-existing. They all sit at the wedge's two outer corners, at most 0.15 m outside, and are the inherent conservatism of a separable angle/range test rather than this bug. Since they are an over-detection rather than a miss, this PR leaves them alone instead of rewriting the test as an exact sector-disc intersection.

### The change

Compare the near-edge bearing directly (`fov_diff = rad_diff - rad_offset`), and treat an object which encloses the view point as spanning every bearing rather than the half plane the previous `distance == 0` branch gave it.

Adds six tests to `TestFOVDetection`, which previously asserted only `isinstance(detected, list)`. They fail 7 of 14 against the unfixed source. Suite goes from 875 to 887 passing, with no regressions. `ruff check` and `ruff format` are clean.

Two notes:

- Tested on Windows with Python 3.12. Four failures in `tests/test_world_map.py::TestImageGridGenerator` are present before and after this change and are unrelated to it; they are an open temp-file handle that only Windows rejects, which I have opened a separate PR for.
- #360 also touches `irsim/world/object_base.py`, but in `_init_sensors` rather than `fov_detect_object`, so the hunks do not overlap. I have not added a `changelog.md` entry since entries there carry a PR link, but happy to add one.
