### PR TITLE
test(map): use tmp_path for the image grid generator tests

### DIFF
--- a/tests/test_world_map.py
+++ b/tests/test_world_map.py
@@ -496,57 +496,45 @@ class TestImageGridGenerator:
         assert grid is not None
         assert grid.shape[0] > 0
 
-    def test_load_rgb_image_uses_grayscale(self):
+    def test_load_rgb_image_uses_grayscale(self, tmp_path):
         """RGB image is converted to grayscale (covers _rgb2gray branch)."""
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
-            # 5x5 RGB image
-            rgb = np.random.randint(0, 255, (5, 5, 3), dtype=np.uint8)
-            plt.imsave(f.name, rgb)
-            try:
-                gen = ImageGridGenerator(path=f.name).generate()
-                assert gen.grid.shape == (5, 5)
-                assert gen.grid.dtype == np.float64
-            finally:
-                os.unlink(f.name)
+        path = tmp_path / "rgb.png"
+        # 5x5 RGB image
+        rgb = np.random.randint(0, 255, (5, 5, 3), dtype=np.uint8)
+        plt.imsave(path, rgb)
+        gen = ImageGridGenerator(path=str(path)).generate()
+        assert gen.grid.shape == (5, 5)
+        assert gen.grid.dtype == np.float64
 
-    def test_load_integer_image_normalized(self):
+    def test_load_integer_image_normalized(self, tmp_path):
         """Integer dtype image is normalized by iinfo max (covers integer branch)."""
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
-            arr = np.random.randint(0, 255, (4, 4), dtype=np.uint8)
-            plt.imsave(f.name, arr, cmap="gray", vmin=0, vmax=255)
-            try:
-                gen = ImageGridGenerator(path=f.name).generate()
-                assert gen.grid.dtype == np.float64
-                assert gen.grid.min() >= 0
-                assert gen.grid.max() <= 100
-            finally:
-                os.unlink(f.name)
+        path = tmp_path / "integer.png"
+        arr = np.random.randint(0, 255, (4, 4), dtype=np.uint8)
+        plt.imsave(path, arr, cmap="gray", vmin=0, vmax=255)
+        gen = ImageGridGenerator(path=str(path)).generate()
+        assert gen.grid.dtype == np.float64
+        assert gen.grid.min() >= 0
+        assert gen.grid.max() <= 100
 
-    def test_load_float_max_gt_one_normalized(self):
+    def test_load_float_max_gt_one_normalized(self, tmp_path):
         """Float image with max > 1 is normalized by max (covers max>1 branch)."""
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
-            arr = np.random.rand(4, 4).astype(np.float64) * 10
-            plt.imsave(f.name, arr, cmap="gray", vmin=0, vmax=10)
-            try:
-                gen = ImageGridGenerator(path=f.name).generate()
-                assert gen.grid.dtype == np.float64
-                assert gen.grid.min() >= 0
-                assert gen.grid.max() <= 100
-            finally:
-                os.unlink(f.name)
+        path = tmp_path / "float_gt_one.png"
+        arr = np.random.rand(4, 4).astype(np.float64) * 10
+        plt.imsave(path, arr, cmap="gray", vmin=0, vmax=10)
+        gen = ImageGridGenerator(path=str(path)).generate()
+        assert gen.grid.dtype == np.float64
+        assert gen.grid.min() >= 0
+        assert gen.grid.max() <= 100
 
-    def test_load_float_in_zero_one_passthrough(self):
+    def test_load_float_in_zero_one_passthrough(self, tmp_path):
         """Float image already in [0, 1] is cast to float64 (covers else branch)."""
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
-            arr = np.random.rand(4, 4).astype(np.float64)  # max <= 1
-            plt.imsave(f.name, arr, cmap="gray", vmin=0, vmax=1)
-            try:
-                gen = ImageGridGenerator(path=f.name).generate()
-                assert gen.grid.dtype == np.float64
-                assert gen.grid.min() >= 0
-                assert gen.grid.max() <= 100
-            finally:
-                os.unlink(f.name)
+        path = tmp_path / "float_zero_one.png"
+        arr = np.random.rand(4, 4).astype(np.float64)  # max <= 1
+        plt.imsave(path, arr, cmap="gray", vmin=0, vmax=1)
+        gen = ImageGridGenerator(path=str(path)).generate()
+        assert gen.grid.dtype == np.float64
+        assert gen.grid.min() >= 0
+        assert gen.grid.max() <= 100
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The four `ImageGridGenerator` loader tests write through an open `NamedTemporaryFile(delete=False)` handle and unlink the file inside the `with` block. Windows refuses to unlink a file that is still open, so each raises `PermissionError: [WinError 32]` after its assertions have already passed.

CI runs Ubuntu and macOS, where unlinking an open file succeeds, so the suite is green there and red on Windows.

### The change

Switch them to the `tmp_path` fixture the rest of this file already uses 20 times, which drops the manual cleanup along with the handle. Same assertions, same branches covered.

### Verification

```
tests/test_world_map.py   132 passed, 4 failed  ->  136 passed
full suite                875 passed, 4 failed  ->  879 passed, 0 failed
```

Behaviour is unchanged on Linux and macOS, though I was only able to run the suite on Windows with Python 3.12. `ruff check` and `ruff format` are clean.

This is the unrelated Windows failure I mentioned in #363; the two PRs touch different files and can be merged in either order.
