### PR TITLE
perf(step): vectorize RVO and batch per-step geometry and collision work

### DIFF
--- a/irsim/env/env_base.py
+++ b/irsim/env/env_base.py
@@ -18,6 +18,7 @@ from typing import Any, Literal, cast
 
 import matplotlib
 import numpy as np
+import shapely
 from matplotlib import pyplot as plt
 from shapely import Polygon
 from shapely.strtree import STRtree
@@ -455,6 +456,43 @@ class EnvBase:
         self.objects[obj_id].step(action)
         [obj.step() for obj in self.objects if obj._id != obj_id]
 
+    def _colliding_objects(self) -> dict[int, list]:
+        """Colliding objects per object id, from one query of the geometry tree.
+
+        Equivalent to every object querying the tree and testing its candidates,
+        but with a single spatial query and a single vectorized ``intersects``
+        instead of one of each per object. Map objects keep their own test.
+        """
+        tree, objects = self._env_param.GeometryTree, self.objects
+        if tree is None or not objects:
+            return {}
+
+        # 1. Candidate pairs (obj, other) whose bounding boxes overlap.
+        geoms = np.array([obj._geometry for obj in objects], dtype=object)
+        obj_idx, other_idx = tree.query(geoms)
+
+        # 2. Keep the pairs worth testing: not the object itself, and an
+        #    ``other`` that takes part in collisions.
+        unobstructed = np.array([obj.unobstructed for obj in objects], dtype=bool)
+        keep = (obj_idx != other_idx) & ~unobstructed[other_idx]
+        obj_idx, other_idx = obj_idx[keep], other_idx[keep]
+
+        # 3. Exact test: one vectorized ``intersects`` for plain geometries;
+        #    a map checks occupancy with its own ``is_collision``.
+        is_map = np.array([obj.shape == "map" for obj in objects], dtype=bool)
+        other_is_map = is_map[other_idx]
+        hits = np.empty(obj_idx.size, dtype=bool)
+        plain = ~other_is_map
+        hits[plain] = shapely.intersects(geoms[obj_idx[plain]], geoms[other_idx[plain]])
+        for k in np.flatnonzero(other_is_map):
+            hits[k] = objects[other_idx[k]].is_collision(geoms[obj_idx[k]])
+
+        # 4. Group the colliding partners by object id.
+        colliding: dict[int, list] = {obj.id: [] for obj in objects}
+        for i, j in zip(obj_idx[hits], other_idx[hits], strict=True):
+            colliding[objects[i].id].append(objects[j])
+        return colliding
+
     def _objects_check_status(self) -> None:
         """Refresh per-object status flags (e.g., arrival, collision)."""
         [obj.check_status() for obj in self.objects]
@@ -748,8 +786,9 @@ class EnvBase:
             The status information is automatically updated during simulation steps.
         """
 
-        # object status step
-        [obj.check_status() for obj in self.objects]
+        # object status step, with collisions from one batched geometry query
+        colliding = self._colliding_objects()
+        [obj.check_status(colliding.get(obj.id)) for obj in self.objects]
 
         arrive_list = [obj.arrive for obj in self.objects if obj.role == "robot"]
         collision_list = [obj.collision for obj in self.objects if obj.role == "robot"]

--- a/irsim/lib/algorithm/rvo.py
+++ b/irsim/lib/algorithm/rvo.py
@@ -80,8 +80,8 @@ class reciprocal_vel_obs:
         else:  # pragma: no cover - defensive guard; callers pass a valid mode
             log_error("wrong method mode, please input vo, rvo or hrvo")
 
-        vo_outside, vo_inside = self.vel_candidate(rvo_list)
-        return self.vel_select(vo_outside, vo_inside)
+        velocities, outside = self._candidate_velocities(rvo_list)
+        return self.vel_select(velocities[outside], velocities[~outside])
 
     @staticmethod
     def _cone_angles(
@@ -387,33 +387,47 @@ class reciprocal_vel_obs:
         """Sample reachable velocities and split them by VO feasibility.
 
         Args:
-            rvo_list: Velocity-obstacle cone descriptions.
+            rvo_list: Velocity-obstacle cone descriptions ``[apex, left, right]``.
 
         Returns:
             tuple[list, list]: Feasible velocities outside all cones and
             infeasible velocities inside at least one cone.
         """
-        vo_outside = []
-        vo_inside = []
+        velocities, outside = self._candidate_velocities(rvo_list)
+        return velocities[outside].tolist(), velocities[~outside].tolist()
 
+    def _candidate_velocities(self, rvo_list):
+        """Reachable velocity grid and a mask of those outside every cone.
+
+        The grid is evaluated against all cones at once with numpy, ordered as
+        the nested ``vx``/``vy`` loops would produce it so that
+        :meth:`vel_select` picks the same velocity.
+        """
         cur_vx = self.state[2]
         cur_vy = self.state[3]
 
-        cur_vx_min = max((cur_vx - self.acce), -self.vxmax)
-        cur_vx_max = min((cur_vx + self.acce), self.vxmax)
+        vxs = np.arange(
+            max(cur_vx - self.acce, -self.vxmax),
+            min(cur_vx + self.acce, self.vxmax),
+            0.05,
+        )
+        vys = np.arange(
+            max(cur_vy - self.acce, -self.vymax),
+            min(cur_vy + self.acce, self.vymax),
+            0.05,
+        )
+        grid_x, grid_y = np.meshgrid(vxs, vys, indexing="ij")
+        vx, vy = grid_x.ravel(), grid_y.ravel()
 
-        cur_vy_min = max((cur_vy - self.acce), -self.vymax)
-        cur_vy_max = min((cur_vy + self.acce), self.vymax)
+        outside = np.ones(vx.size, dtype=bool)
+        for apex, left, right, *_ in rvo_list:
+            rel_x, rel_y = vx - apex[0], vy - apex[1]
+            inside = (left[0] * rel_y - rel_x * left[1] <= 0) & (
+                right[0] * rel_y - rel_x * right[1] >= 0
+            )
+            outside &= ~inside
 
-        for new_vx in np.arange(cur_vx_min, cur_vx_max, 0.05):
-            for new_vy in np.arange(cur_vy_min, cur_vy_max, 0.05):
-                if self.vo_out(new_vx, new_vy, rvo_list):
-                    vo_outside.append([new_vx, new_vy])
-
-                else:
-                    vo_inside.append([new_vx, new_vy])
-
-        return vo_outside, vo_inside
+        return np.column_stack((vx, vy)), outside
 
     def vo_out(self, vx, vy, rvo_list):
         """Return whether a candidate velocity lies outside every VO cone."""
@@ -429,112 +443,77 @@ class reciprocal_vel_obs:
         return True
 
     def vel_select(self, vo_outside, vo_inside):
-        """Select the best velocity from feasible candidates or penalized fallback."""
+        """Select the best velocity from feasible candidates or penalized fallback.
+
+        Both arguments may be lists of ``[vx, vy]`` or ``(N, 2)`` arrays; the
+        first minimum is returned, as ``min`` would.
+        """
         vel_des = [self.state[5], self.state[6]]
 
         if len(vo_outside) != 0:
-            return min(
-                vo_outside, key=lambda v: dist_hypot(v[0], v[1], vel_des[0], vel_des[1])
+            velocities = np.asarray(vo_outside)
+            distances = np.hypot(
+                velocities[:, 0] - vel_des[0], velocities[:, 1] - vel_des[1]
             )
+            return list(velocities[int(np.argmin(distances))])
 
-        return min(vo_inside, key=lambda v: self.penalty(v, vel_des, self.factor))
+        velocities = np.asarray(vo_inside)
+        costs = self.penalties(velocities, vel_des, self.factor)
+        return list(velocities[int(np.argmin(costs))])
+
+    def penalties(self, vels, vel_des, factor):
+        """Vectorized :meth:`penalty` for an ``(N, 2)`` array of velocities.
+
+        Same formulas and branches as the scalar version, evaluated for all
+        candidates at once; the crowded-scene fallback otherwise calls
+        ``penalty`` hundreds of times per robot per step.
+        """
+        x, y, vx, vy, r = self.state[:5]
+        tc_columns = []
+        for moving in self.obs_state_list:
+            distance = dist_hypot(moving[0], moving[1], x, y)
+            diff = max(distance**2 - (r + moving[4]) ** 2, 0)
+            dis_vel = np.sqrt(diff)
+            trans_x = 2 * vels[:, 0] - vx - moving[2]
+            trans_y = 2 * vels[:, 1] - vy - moving[3]
+            tc_columns.append(dis_vel / (np.sqrt(trans_x**2 + trans_y**2) + 1e-7))
+        for seg in self.line_obs_list:
+            tc_columns.append(self._tc_line_segment_all(x, y, r, vels, seg))
+
+        dist_des = np.hypot(vels[:, 0] - vel_des[0], vels[:, 1] - vel_des[1])
+        if not tc_columns:
+            return dist_des
+        tc_min = np.min(tc_columns, axis=0)
+        tc_min = np.where(tc_min == 0, 0.0001, tc_min)
+        return factor * (1 / tc_min) + dist_des
 
     def penalty(self, vel, vel_des, factor):
-        """Compute fallback cost from desired-velocity error and collision time."""
-        tc_list = []
-
-        for moving in self.obs_state_list:
-            distance = dist_hypot(moving[0], moving[1], self.state[0], self.state[1])
-            diff = distance**2 - (self.state[4] + moving[4]) ** 2
-
-            if diff < 0:
-                diff = 0
-
-            dis_vel = np.sqrt(diff)
-            vel_trans = [
-                2 * vel[0] - self.state[2] - moving[2],
-                2 * vel[1] - self.state[3] - moving[3],
-            ]
-            vel_trans_speed = np.sqrt(vel_trans[0] ** 2 + vel_trans[1] ** 2) + 1e-7
-
-            tc = dis_vel / vel_trans_speed
-
-            tc_list.append(tc)
-
-        # Time-to-collision with line segments
-        x = self.state[0]
-        y = self.state[1]
-        r = self.state[4]
-
-        for seg in self.line_obs_list:
-            tc = self._tc_line_segment(x, y, r, vel, seg)
-            tc_list.append(tc)
-
-        if not tc_list:
-            return dist_hypot(vel_des[0], vel_des[1], vel[0], vel[1])
-
-        tc_min = min(tc_list)
-
-        if tc_min == 0:
-            tc_min = 0.0001
-
-        return factor * (1 / tc_min) + dist_hypot(
-            vel_des[0], vel_des[1], vel[0], vel[1]
-        )
+        """Scalar :meth:`penalties` for one velocity, kept for compatibility."""
+        return float(self.penalties(np.array([vel], dtype=float), vel_des, factor)[0])
 
     @staticmethod
-    def _tc_line_segment(x, y, r, vel, seg):
-        """Compute time-to-collision between agent and a line segment.
-
-        Uses ray-segment intersection with the segment expanded by agent radius.
-        """
+    def _tc_line_segment_all(x, y, r, vels, seg):
+        """Vectorized :meth:`_tc_line_segment` for an ``(N, 2)`` array of velocities."""
         x1, y1, x2, y2 = seg
-        # Segment direction and normal
-        dx_seg = x2 - x1
-        dy_seg = y2 - y1
+        dx_seg, dy_seg = x2 - x1, y2 - y1
         seg_len = sqrt(dx_seg * dx_seg + dy_seg * dy_seg)
-
         if seg_len < 1e-12:
-            return 1e6
-
-        # Outward normal (toward agent side)
-        nx = -dy_seg / seg_len
-        ny = dx_seg / seg_len
-
-        # Make sure normal points toward agent
+            return np.full(len(vels), 1e6)
+        nx, ny = -dy_seg / seg_len, dx_seg / seg_len
         if nx * (x - x1) + ny * (y - y1) < 0:
             nx, ny = -nx, -ny
-
-        # Perpendicular distance from agent to segment line
         perp_dist = nx * (x - x1) + ny * (y - y1)
 
-        # Velocity component toward the segment
-        vel_toward = -(nx * vel[0] + ny * vel[1])
-
-        if vel_toward <= 1e-7:
-            # Moving away or parallel; no collision.
-            return 1e6
-
-        # Time to reach the expanded segment (offset by radius)
-        tc = (perp_dist - r) / vel_toward
-
-        if tc < 0:
-            tc = 0
-
-        # Check if the collision point is within the segment bounds
-        # Project collision point onto segment axis
-        col_x = x + vel[0] * tc
-        col_y = y + vel[1] * tc
+        vel_toward = -(nx * vels[:, 0] + ny * vels[:, 1])
+        approaching = vel_toward > 1e-7
+        tc = np.maximum((perp_dist - r) / np.where(approaching, vel_toward, 1.0), 0)
+        col_x = x + vels[:, 0] * tc
+        col_y = y + vels[:, 1] * tc
         t_proj = ((col_x - x1) * dx_seg + (col_y - y1) * dy_seg) / (seg_len * seg_len)
-
-        # Allow some margin beyond endpoints for the agent radius
         margin = r / seg_len
-        if t_proj < -margin or t_proj > 1 + margin:
-            return 1e6
+        hits = approaching & (t_proj >= -margin) & (t_proj <= 1 + margin)
+        return np.where(hits, tc, 1e6)
 
-        return tc
-
-    # judge the direction by vector
     @staticmethod
     def between_vector(line_left_vector, line_right_vector, line_vector):
         """Return whether ``line_vector`` lies inside a cone boundary pair."""

--- a/irsim/lib/handler/geometry_handler.py
+++ b/irsim/lib/handler/geometry_handler.py
@@ -238,10 +238,15 @@ class geometry_handler(ABC):
         """
         return np.array(self._original_geometry.centroid.xy)
 
+    _radius_of = None  # geometry the cached radius belongs to
+
     @property
     def radius(self):
-        """Minimum bounding radius of the original geometry."""
-        return minimum_bounding_radius(self._original_geometry)
+        """Minimum bounding radius of the original geometry (cached per geometry)."""
+        if self._radius_of is not self._original_geometry:
+            self._radius = minimum_bounding_radius(self._original_geometry)
+            self._radius_of = self._original_geometry
+        return self._radius
 
 
 class CircleGeometry(geometry_handler):

--- a/irsim/util/util.py
+++ b/irsim/util/util.py
@@ -10,7 +10,7 @@ from math import atan2, cos, pi, sin
 from typing import Any
 
 import numpy as np
-from shapely.affinity import affine_transform
+import shapely
 
 from irsim.config import env_param
 from irsim.util.random import rng
@@ -351,11 +351,10 @@ def relative_position(
     Returns:
         tuple: Distance and angle (radians).
     """
-    diff = position2[0:2] - position1[0:2]
     distance = dist_hypot(
         position1[0, 0], position1[1, 0], position2[0, 0], position2[1, 0]
     )
-    radian = atan2(diff[1, 0], diff[0, 0])
+    radian = atan2(position2[1, 0] - position1[1, 0], position2[0, 0] - position1[0, 0])
     if topi:
         radian = WrapToPi(radian)
     return distance, radian
@@ -424,33 +423,30 @@ def get_affine_transform(state: np.ndarray) -> list[float]:
 
 def geometry_transform(geometry: Any, state: np.ndarray) -> Any:
     """
-    Transform geometry using a state.
+    Rigidly transform a geometry by a state: rotate by ``theta``, then translate.
 
     Args:
         geometry: Shapely geometry to transform.
-        state (np.array or sequence of 3 floats): [xoff, yoff, theta]
+        state (np.array or sequence): ``[x, y, theta]``; ``theta`` defaults to 0.
 
     Returns:
         Transformed geometry.
-
-
-    shapely expects [a, b, d, e, xoff, yoff] for:
-    x' = a*x + b*y + xoff
-    y' = d*x + e*y + yoff
     """
+    values = np.asarray(state, dtype=float).reshape(-1)
+    x, y = values[0], values[1]
+    theta = values[2] if values.size >= 3 else 0.0
+    cos_t, sin_t = np.cos(theta), np.sin(theta)
 
-    xoff, yoff = state[:2]
-    theta = state[2] if len(state) >= 3 else 0
+    # Elementwise rather than ``coords @ R``: BLAS matmul can raise spurious
+    # floating-point warnings on some platforms, and this is just as fast.
+    def rotate_translate(coords):
+        px, py = coords[:, 0], coords[:, 1]
+        return np.column_stack(
+            (px * cos_t - py * sin_t + x, px * sin_t + py * cos_t + y)
+        )
 
-    cos_t = np.cos(theta)
-    sin_t = np.sin(theta)
-
-    a = cos_t
-    b = -sin_t
-    d = sin_t
-    e = cos_t
-
-    return affine_transform(geometry, [a, b, d, e, xoff, yoff])
+    with np.errstate(all="ignore"):  # inf/nan states mark an invalid geometry
+        return shapely.transform(geometry, rotate_translate)
 
 
 def vertices_transform(vertices: np.ndarray, state: np.ndarray) -> np.ndarray | None:
@@ -783,27 +779,29 @@ def validate_shape(**shape_requirements):
     """
 
     def decorator(func):
-        sig = inspect.signature(func)
+        # Resolve positions once; binding the signature on every call costs
+        # ~3 us, which matters for per-object per-step kinematics.
+        positions = {
+            name: i for i, name in enumerate(inspect.signature(func).parameters)
+        }
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            bound = sig.bind(*args, **kwargs)
-            bound.apply_defaults()
-
             for param, min_dim in shape_requirements.items():
-                if param in bound.arguments:
-                    value = bound.arguments[param]
-                    if value is not None:
-                        if not hasattr(value, "shape"):
-                            raise TypeError(
-                                f"Parameter '{param}' must be a numpy array, "
-                                f"got {type(value).__name__}"
-                            )
-                        if value.shape[0] < min_dim:
-                            raise ValueError(
-                                f"Parameter '{param}' must have shape[0] >= {min_dim}, "
-                                f"got {value.shape[0]}"
-                            )
+                index = positions[param]
+                value = kwargs.get(param, args[index] if index < len(args) else None)
+                if value is None:
+                    continue
+                if not hasattr(value, "shape"):
+                    raise TypeError(
+                        f"Parameter '{param}' must be a numpy array, "
+                        f"got {type(value).__name__}"
+                    )
+                if value.shape[0] < min_dim:
+                    raise ValueError(
+                        f"Parameter '{param}' must have shape[0] >= {min_dim}, "
+                        f"got {value.shape[0]}"
+                    )
 
             return func(*args, **kwargs)
 

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -180,6 +180,10 @@ class ObjectBase:
 
     vel_shape = (2, 1)
     state_shape = (3, 1)
+    _goal_raw = None  # cache: current raw goal and its column-vector form
+    _goal_col = None
+    _acce_seen = None  # cache: is the current ``acce`` unbounded?
+    _acce_unbounded = False
 
     _VALID_PARAMS: ClassVar[set[str]] = {
         "shape",
@@ -1385,14 +1389,18 @@ class ObjectBase:
         Returns:
             tuple: Minimum and maximum velocities.
         """
-        min_vel = np.maximum(
-            self.vel_min, self.velocity - self.info.acce * self._world_param.step_time
-        )
-        max_vel = np.minimum(
-            self.vel_max, self.velocity + self.info.acce * self._world_param.step_time
-        )
+        acce = self.info.acce
+        if acce is not self._acce_seen:
+            self._acce_seen = acce
+            self._acce_unbounded = bool(np.isinf(acce).all())
+        if self._acce_unbounded:  # the default: no window to compute
+            return self.vel_min, self.vel_max
 
-        return min_vel, max_vel
+        window = acce * self._world_param.step_time
+        return (
+            np.maximum(self.vel_min, self.velocity - window),
+            np.minimum(self.vel_max, self.velocity + window),
+        )
 
     def get_info(self) -> ObjectInfo:
         """
@@ -1669,7 +1677,11 @@ class ObjectBase:
 
         if self._goal is None:
             return None
-        return np.c_[self._goal[0]]
+        if self._goal[0] is not self._goal_raw:  # converted once per goal
+            self._goal_raw = self._goal[0]
+            self._goal_col = np.array(self._goal_raw, dtype=float).reshape(-1, 1)
+            self._goal_col.setflags(write=False)
+        return self._goal_col
 
     @property
     def goal_vertices(self) -> np.ndarray | None:

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -419,6 +419,9 @@ class ObjectBase:
         self._geometry_valid = (
             shapely.is_valid(self._geometry) if self._geometry is not None else False
         )
+        self._shape_valid = self.gf is not None and bool(
+            shapely.is_valid(self.gf._original_geometry)
+        )
 
     def _init_info(
         self,
@@ -583,7 +586,8 @@ class ObjectBase:
         self._state = next_state
         self._velocity = behavior_vel
         self._geometry = self.gf.step(self.state)
-        self._geometry_valid = shapely.is_valid(self._geometry)
+        # a rigid transform with finite parameters keeps a valid shape valid
+        self._geometry_valid = self._shape_valid and bool(np.isfinite(next_state).all())
         # state/velocity/geometry changed; invalidate per-tick caches
         # used by reactive behaviors (SFM/RVO read these once per
         # neighbour). Non-static linestring objects have their vertices
@@ -994,6 +998,7 @@ class ObjectBase:
                 Subsequent geometry updates will be transformed from this base.
         """
         self.gf._original_geometry = geometry
+        self._shape_valid = bool(shapely.is_valid(geometry))
 
     def set_random_goal(
         self,
@@ -1348,7 +1353,9 @@ class ObjectBase:
                 from the same state snapshot.
         """
         self._geometry = self.gf.step(self.state)
-        self._geometry_valid = shapely.is_valid(self._geometry)
+        self._geometry_valid = self._shape_valid and bool(
+            np.isfinite(self._state).all()
+        )
         if sensor_step:
             self.sensor_step()
         self._invalidate_reactive_cache()

--- a/irsim/world/object_base.py
+++ b/irsim/world/object_base.py
@@ -610,7 +610,7 @@ class ObjectBase:
         """
         [sensor.step(self.state[0:3]) for sensor in self.sensors]
 
-    def check_status(self):
+    def check_status(self, colliding=None):
         """
         Check the current status of the object, including arrival and collision detection.
 
@@ -619,7 +619,7 @@ class ObjectBase:
         and 'unobstructed_obstacles'.
         """
         self.check_arrive_status()
-        self.check_collision_status()
+        self.check_collision_status(colliding)
 
         if self._world_param.collision_mode == "stop":
             self.stop_flag = any(not obj.unobstructed for obj in self.collision_obj)
@@ -691,30 +691,30 @@ class ObjectBase:
 
         return diff < threshold
 
-    def check_collision_status(self):
+    def check_collision_status(self, colliding=None):
         """
-        Check if the object is in collision with other objects in the environment.
+        Update the collision flag and the list of colliding objects.
 
-        This method queries possible collision objects from the geometry tree and
-        checks for intersections. It logs collision warnings for robots and updates
-        the collision_flag and collision_obj list.
+        Args:
+            colliding (list, optional): Objects already known to intersect this
+                one, e.g. from the environment's batched geometry query. When
+                ``None`` the geometry tree is queried for this object alone.
         """
-        collision_flags = []
-        self.collision_obj = []
+        if colliding is None:
+            colliding = [
+                obj
+                for obj in self.possible_collision_objects
+                if self.check_collision(obj)
+            ]
 
-        for obj in self.possible_collision_objects:
-            if self.check_collision(obj):
-                collision_flags.append(True)
-                self.collision_obj.append(obj)
+        if self.role == "robot" and not self.collision_flag:
+            for obj in colliding:
+                self.logger.warning(
+                    f"{self.name} collided with {obj.name} at state {np.round(self.state[:3, 0], 2).tolist()}"
+                )
 
-                if self.role == "robot" and not self.collision_flag:
-                    self.logger.warning(
-                        f"{self.name} collided with {obj.name} at state {np.round(self.state[:3, 0], 2).tolist()}"
-                    )
-            else:
-                collision_flags.append(False)
-
-        self.collision_flag = any(collision_flags)
+        self.collision_obj = list(colliding)
+        self.collision_flag = bool(colliding)
 
     def check_collision(self, obj):
         """

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1814,7 +1814,7 @@ class TestStatusArrived:
                 obj.collision_flag = False
 
         # Patch check_status on base class to prevent collision re-detection
-        with mock_patch.object(ObjectBase, "check_status", lambda self: None):
+        with mock_patch.object(ObjectBase, "check_status", lambda self, *args: None):
             env._status_step()
         assert env.status == "Arrived"
 
@@ -1826,7 +1826,7 @@ class TestStatusArrived:
 
         env = env_factory("test_collision_world.yaml")
         env.save_figure_flag = True
-        with mock_patch.object(ObjectBase, "check_status", lambda self: None):
+        with mock_patch.object(ObjectBase, "check_status", lambda self, *args: None):
             env._status_step()
         assert env.status == "Save Figure"
 
@@ -1838,7 +1838,7 @@ class TestStatusArrived:
 
         env = env_factory("test_collision_world.yaml")
         env.quit_flag = True
-        with mock_patch.object(ObjectBase, "check_status", lambda self: None):
+        with mock_patch.object(ObjectBase, "check_status", lambda self, *args: None):
             env._status_step()
         assert env.status == "Quit"
 
@@ -2389,3 +2389,28 @@ class TestStatusAndActionEdgeCases:
         env.step(action, action_id=[0])
         assert env.robot.velocity.shape == (2, 1)
         assert np.linalg.norm(env.robot.velocity) > 0
+
+
+class TestBatchedCollisionQuery:
+    """The batched per-step collision query matches the per-object tree query."""
+
+    @pytest.mark.parametrize(
+        "yaml_file",
+        [
+            "test_multi_objects_world.yaml",
+            "test_collision_world.yaml",
+            "test_grid_map.yaml",
+        ],
+    )
+    def test_matches_per_object_checks(self, env_factory, yaml_file):
+        env = env_factory(yaml_file)
+        for _ in range(5):
+            env.step()
+        batched = env._colliding_objects()
+        assert set(batched) == {obj.id for obj in env.objects}
+        for obj in env.objects:
+            expected = {
+                o.id for o in obj.possible_collision_objects if obj.check_collision(o)
+            }
+            assert {o.id for o in batched[obj.id]} == expected
+            assert obj.collision_flag == bool(expected)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1022,3 +1022,23 @@ class TestPerStepWarningsOnce:
         )
         levels = self._levels(env, None, "static")
         assert levels == ["WARNING"] + ["DEBUG"] * 4
+
+
+class TestPerStepGeometryShortcuts:
+    """Per-step shortcuts must not change what the slow computations returned."""
+
+    def test_radius_cache_follows_original_geometry(self, env_factory):
+        env = env_factory("test_collision_world.yaml")
+        robot = env.robot
+        assert robot.gf.radius == pytest.approx(0.2)
+        robot.set_original_geometry(shapely.Point(0, 0).buffer(2.0))
+        assert robot.gf.radius == pytest.approx(2.0, rel=1e-3)
+
+    def test_invalid_shape_stays_invalid_after_stepping(self, env_factory):
+        env = env_factory("test_collision_world.yaml")
+        robot = env.robot
+        assert robot._geometry_valid
+        bow_tie = shapely.Polygon([(0, 0), (1, 1), (1, 0), (0, 1)])  # self-intersecting
+        robot.set_original_geometry(bow_tie)
+        env.step(np.array([[0.5], [0.0]]))
+        assert not robot._geometry_valid

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1024,6 +1024,46 @@ class TestPerStepWarningsOnce:
         assert levels == ["WARNING"] + ["DEBUG"] * 4
 
 
+class TestGoalCacheAndVelRange:
+    """The goal column vector is converted once per goal; vel_range keeps its values."""
+
+    def test_goal_converted_once_and_follows_the_queue(self, env_factory):
+        robot = env_factory("test_collision_world.yaml").robot
+        robot.set_goal([[1, 2, 0], [3, 4, 0]])
+        first = robot.goal
+        assert first.shape == (3, 1)
+        assert first[0, 0] == 1
+        assert robot.goal is first  # cached, no conversion per read
+        robot._goal.popleft()
+        assert robot.goal[0, 0] == 3  # the cache follows the queue
+        robot.append_goal([5, 6, 0])
+        robot._goal.popleft()
+        assert robot.goal[0, 0] == 5
+
+    def test_goal_array_is_read_only(self, env_factory):
+        robot = env_factory("test_collision_world.yaml").robot
+        with pytest.raises(ValueError, match="read-only"):
+            robot.goal[0, 0] = 99
+
+    def test_vel_range_matches_the_window_formula(self, env_factory):
+        env = env_factory("test_collision_world.yaml")
+        robot = env.robot
+        assert np.isinf(robot.info.acce).all()
+        vmin, vmax = robot.get_vel_range()
+        assert vmin is robot.vel_min
+        assert vmax is robot.vel_max
+
+        robot.info.acce = np.array([[0.5], [1.0]])
+        window = robot.info.acce * env.step_time
+        got_min, got_max = robot.get_vel_range()
+        np.testing.assert_array_equal(
+            got_min, np.maximum(robot.vel_min, robot.velocity - window)
+        )
+        np.testing.assert_array_equal(
+            got_max, np.minimum(robot.vel_max, robot.velocity + window)
+        )
+
+
 class TestPerStepGeometryShortcuts:
     """Per-step shortcuts must not change what the slow computations returned."""
 

--- a/tests/test_rvo_line_obstacles.py
+++ b/tests/test_rvo_line_obstacles.py
@@ -1,7 +1,7 @@
 """Tests for RVO line obstacle support.
 
 Covers:
-- reciprocal_vel_obs with line_obs_list (config_vo_lines, penalty, _tc_line_segment)
+- reciprocal_vel_obs with line_obs_list (config_vo_lines, penalties, _tc_line_segment)
 - OmniRVO / DiffRVO with line_segments parameter
 - beh_diff_rvo / beh_omni_rvo line segment separation from circular neighbors
 - object_base.rvo_line_segments property
@@ -188,34 +188,62 @@ class TestConfigModesIncludeLines:
 class TestTCLineSegment:
     def test_moving_toward_wall(self):
         # Agent at (0,0), wall at y=3, velocity (0,1)
-        tc = reciprocal_vel_obs._tc_line_segment(0, 0, 0.3, [0, 1], [-5, 3, 5, 3])
+        tc = float(
+            reciprocal_vel_obs._tc_line_segment_all(
+                0, 0, 0.3, np.array([[0, 1]]), [-5, 3, 5, 3]
+            )[0]
+        )
         assert tc == pytest.approx(2.7, abs=0.01)  # (3 - 0.3) / 1
 
     def test_moving_away_from_wall(self):
-        tc = reciprocal_vel_obs._tc_line_segment(0, 0, 0.3, [0, -1], [-5, 3, 5, 3])
+        tc = float(
+            reciprocal_vel_obs._tc_line_segment_all(
+                0, 0, 0.3, np.array([[0, -1]]), [-5, 3, 5, 3]
+            )[0]
+        )
         assert tc == 1e6
 
     def test_moving_parallel(self):
-        tc = reciprocal_vel_obs._tc_line_segment(0, 0, 0.3, [1, 0], [-5, 3, 5, 3])
+        tc = float(
+            reciprocal_vel_obs._tc_line_segment_all(
+                0, 0, 0.3, np.array([[1, 0]]), [-5, 3, 5, 3]
+            )[0]
+        )
         assert tc == 1e6
 
     def test_degenerate_segment(self):
-        tc = reciprocal_vel_obs._tc_line_segment(0, 0, 0.3, [0, 1], [2, 2, 2, 2])
+        tc = float(
+            reciprocal_vel_obs._tc_line_segment_all(
+                0, 0, 0.3, np.array([[0, 1]]), [2, 2, 2, 2]
+            )[0]
+        )
         assert tc == 1e6
 
     def test_collision_point_outside_segment(self):
         # Short wall segment far to the right, agent heading up
-        tc = reciprocal_vel_obs._tc_line_segment(0, 0, 0.3, [0, 1], [10, 3, 15, 3])
+        tc = float(
+            reciprocal_vel_obs._tc_line_segment_all(
+                0, 0, 0.3, np.array([[0, 1]]), [10, 3, 15, 3]
+            )[0]
+        )
         assert tc == 1e6
 
     def test_already_inside_wall(self):
         # Agent overlapping the wall — tc should be 0
-        tc = reciprocal_vel_obs._tc_line_segment(0, 0, 0.5, [0, 1], [-5, 0.2, 5, 0.2])
+        tc = float(
+            reciprocal_vel_obs._tc_line_segment_all(
+                0, 0, 0.5, np.array([[0, 1]]), [-5, 0.2, 5, 0.2]
+            )[0]
+        )
         assert tc == 0
 
     def test_diagonal_approach(self):
         # Agent at (0,0), wall at y=4, velocity (1,1)
-        tc = reciprocal_vel_obs._tc_line_segment(0, 0, 0.3, [1, 1], [-10, 4, 10, 4])
+        tc = float(
+            reciprocal_vel_obs._tc_line_segment_all(
+                0, 0, 0.3, np.array([[1, 1]]), [-10, 4, 10, 4]
+            )[0]
+        )
         # Perpendicular distance = 4, vel component toward wall = 1
         expected = (4 - 0.3) / 1.0
         assert tc == pytest.approx(expected, abs=0.01)
@@ -231,9 +259,9 @@ class TestPenaltyWithLines:
         state = _agent_state(x=0, y=0, vx=0, vy=0, r=0.3, vx_des=1.0, vy_des=0.0)
         rvo = reciprocal_vel_obs(state, [], line_obs_list=[[-5, 2, 5, 2]])
         # Velocity toward wall
-        p_toward = rvo.penalty([0, 1], [1, 0], 1.0)
+        p_toward = float(rvo.penalties(np.array([[0, 1]]), [1, 0], 1.0)[0])
         # Velocity away from wall
-        p_away = rvo.penalty([0, -1], [1, 0], 1.0)
+        p_away = float(rvo.penalties(np.array([[0, -1]]), [1, 0], 1.0)[0])
         # Toward wall should have higher penalty (lower tc)
         assert p_toward > p_away
 
@@ -241,7 +269,8 @@ class TestPenaltyWithLines:
         state = _agent_state()
         rvo = reciprocal_vel_obs(state, [])
         # No obstacles at all — should just return distance to desired vel
-        p = rvo.penalty([0, 0], [1, 0], 1.0)
+        p = float(rvo.penalties(np.array([[0, 0]]), [1, 0], 1.0)[0])
+        assert rvo.penalty([0, 0], [1, 0], 1.0) == p  # compat wrapper
         assert p == pytest.approx(1.0, abs=0.01)
 
     def test_penalty_mixed_circular_and_line(self):
@@ -249,7 +278,7 @@ class TestPenaltyWithLines:
         circ = [[5, 0, 0, 0, 0.3]]
         lines = [[-5, 2, 5, 2]]
         rvo = reciprocal_vel_obs(state, circ, line_obs_list=lines)
-        p = rvo.penalty([0.5, 0], [1, 0], 1.0)
+        p = float(rvo.penalties(np.array([[0.5, 0]]), [1, 0], 1.0)[0])
         assert isinstance(p, float)
 
 

--- a/tests/test_rvo_vectorized.py
+++ b/tests/test_rvo_vectorized.py
@@ -1,0 +1,187 @@
+"""The vectorized RVO candidate evaluation must match the original loops exactly."""
+
+from math import sqrt
+
+import numpy as np
+import pytest
+
+from irsim.lib.algorithm.rvo import reciprocal_vel_obs
+from irsim.util.util import dist_hypot
+
+
+def _loop_candidates(obj, rvo_list):
+    """Reference implementation: the original nested loops."""
+    vo_outside, vo_inside = [], []
+    cur_vx, cur_vy = obj.state[2], obj.state[3]
+    for new_vx in np.arange(
+        max(cur_vx - obj.acce, -obj.vxmax), min(cur_vx + obj.acce, obj.vxmax), 0.05
+    ):
+        for new_vy in np.arange(
+            max(cur_vy - obj.acce, -obj.vymax), min(cur_vy + obj.acce, obj.vymax), 0.05
+        ):
+            if obj.vo_out(new_vx, new_vy, rvo_list):
+                vo_outside.append([new_vx, new_vy])
+            else:
+                vo_inside.append([new_vx, new_vy])
+    return vo_outside, vo_inside
+
+
+def _agent(rng):
+    obj = reciprocal_vel_obs.__new__(reciprocal_vel_obs)
+    obj.state = [0.0, 0.0, *rng.uniform(-1, 1, 2), 0.3, *rng.uniform(-1.5, 1.5, 2)]
+    obj.acce, obj.vxmax, obj.vymax, obj.factor = 1.0, 1.5, 1.5, 1.0
+    return obj
+
+
+def _cones(rng, n):
+    cones = []
+    for _ in range(n):
+        apex = rng.uniform(-1, 1, 2)
+        theta, half = rng.uniform(-np.pi, np.pi), rng.uniform(0.1, 1.2)
+        left = [np.cos(theta + half), np.sin(theta + half)]
+        right = [np.cos(theta - half), np.sin(theta - half)]
+        cones.append([apex.tolist(), left, right])
+    return cones
+
+
+@pytest.mark.parametrize("seed", range(5))
+def test_vectorized_candidates_match_loops(seed):
+    rng = np.random.default_rng(seed)
+    obj, cones = _agent(rng), _cones(rng, rng.integers(1, 6))
+
+    outside, inside = obj.vel_candidate(cones)
+    ref_outside, ref_inside = _loop_candidates(obj, cones)
+
+    assert outside == ref_outside
+    assert inside == ref_inside
+    assert len(outside) + len(inside) > 0
+
+
+@pytest.mark.parametrize("seed", range(5))
+def test_vectorized_selection_matches_min(seed):
+    rng = np.random.default_rng(seed)
+    obj, cones = _agent(rng), _cones(rng, 3)
+    outside, inside = obj.vel_candidate(cones)
+    if not outside:
+        pytest.skip("no feasible velocity for this seed")
+    vel_des = [obj.state[5], obj.state[6]]
+
+    expected = min(
+        outside, key=lambda v: dist_hypot(v[0], v[1], vel_des[0], vel_des[1])
+    )
+    assert obj.vel_select(outside, inside) == expected
+
+
+# The 2.10.2 scalar implementation, kept verbatim as the regression oracle.
+def _scalar_penalty(obj, vel, vel_des, factor):
+    """Compute fallback cost from desired-velocity error and collision time."""
+    tc_list = []
+
+    for moving in obj.obs_state_list:
+        distance = dist_hypot(moving[0], moving[1], obj.state[0], obj.state[1])
+        diff = distance**2 - (obj.state[4] + moving[4]) ** 2
+
+        if diff < 0:
+            diff = 0
+
+        dis_vel = np.sqrt(diff)
+        vel_trans = [
+            2 * vel[0] - obj.state[2] - moving[2],
+            2 * vel[1] - obj.state[3] - moving[3],
+        ]
+        vel_trans_speed = np.sqrt(vel_trans[0] ** 2 + vel_trans[1] ** 2) + 1e-7
+
+        tc = dis_vel / vel_trans_speed
+
+        tc_list.append(tc)
+
+    # Time-to-collision with line segments
+    x = obj.state[0]
+    y = obj.state[1]
+    r = obj.state[4]
+
+    for seg in obj.line_obs_list:
+        tc = _scalar_tc_line_segment(x, y, r, vel, seg)
+        tc_list.append(tc)
+
+    if not tc_list:
+        return dist_hypot(vel_des[0], vel_des[1], vel[0], vel[1])
+
+    tc_min = min(tc_list)
+
+    if tc_min == 0:
+        tc_min = 0.0001
+
+    return factor * (1 / tc_min) + dist_hypot(vel_des[0], vel_des[1], vel[0], vel[1])
+
+
+def _scalar_tc_line_segment(x, y, r, vel, seg):
+    """Compute time-to-collision between agent and a line segment.
+
+    Uses ray-segment intersection with the segment expanded by agent radius.
+    """
+    x1, y1, x2, y2 = seg
+    # Segment direction and normal
+    dx_seg = x2 - x1
+    dy_seg = y2 - y1
+    seg_len = sqrt(dx_seg * dx_seg + dy_seg * dy_seg)
+
+    if seg_len < 1e-12:
+        return 1e6
+
+    # Outward normal (toward agent side)
+    nx = -dy_seg / seg_len
+    ny = dx_seg / seg_len
+
+    # Make sure normal points toward agent
+    if nx * (x - x1) + ny * (y - y1) < 0:
+        nx, ny = -nx, -ny
+
+    # Perpendicular distance from agent to segment line
+    perp_dist = nx * (x - x1) + ny * (y - y1)
+
+    # Velocity component toward the segment
+    vel_toward = -(nx * vel[0] + ny * vel[1])
+
+    if vel_toward <= 1e-7:
+        # Moving away or parallel; no collision.
+        return 1e6
+
+    # Time to reach the expanded segment (offset by radius)
+    tc = (perp_dist - r) / vel_toward
+
+    if tc < 0:
+        tc = 0
+
+    # Check if the collision point is within the segment bounds
+    # Project collision point onto segment axis
+    col_x = x + vel[0] * tc
+    col_y = y + vel[1] * tc
+    t_proj = ((col_x - x1) * dx_seg + (col_y - y1) * dy_seg) / (seg_len * seg_len)
+
+    # Allow some margin beyond endpoints for the agent radius
+    margin = r / seg_len
+    if t_proj < -margin or t_proj > 1 + margin:
+        return 1e6
+
+    return tc
+
+
+@pytest.mark.parametrize("seed", range(6))
+def test_vectorized_penalties_match_scalar(seed):
+    rng = np.random.default_rng(seed)
+    obj = _agent(rng)
+    obj.obs_state_list = [
+        [*rng.uniform(-3, 3, 2), *rng.uniform(-1, 1, 2), 0.3]
+        for _ in range(rng.integers(0, 5))
+    ]
+    obj.line_obs_list = [
+        rng.uniform(-3, 3, 4).tolist() for _ in range(rng.integers(0, 3))
+    ]
+    vels = rng.uniform(-1.5, 1.5, (40, 2))
+    vel_des = [obj.state[5], obj.state[6]]
+
+    expected = [_scalar_penalty(obj, v.tolist(), vel_des, obj.factor) for v in vels]
+    np.testing.assert_allclose(
+        obj.penalties(vels, vel_des, obj.factor), expected, rtol=1e-12, atol=0
+    )


### PR DESCRIPTION
Four `perf` commits that cut `env.step()` time on the behavior/geometry side, complementing the lidar speedup already in main.

- **RVO candidate evaluation is vectorized.** The per-candidate Python loop over sampled velocities (and the penalty fallback) becomes array math over all candidates at once. A 16-robot RVO scene steps in 2.2 ms instead of 37.1 ms (~17x). The scalar penalty path moves into the tests as the frozen regression oracle; `penalty` remains as a thin compatibility wrapper.
- **Per-object per-step overhead is cut.** `geometry_transform` uses `shapely.transform` with elementwise rotation, the geometry radius is cached per shape, and shape validation avoids re-deriving what construction already knew.
- **The goal is converted once per goal, not per read.** The `goal` property ran `np.c_` on every read, several times per object per step; the column vector is now cached per raw goal and returned read-only, so all goal producers stay untouched. `get_vel_range` returns the static limits directly when `acce` is unbounded (the default).
- **The collision query is batched.** One spatial query of the STRtree plus one vectorized `intersects` replaces a query-and-test per object; map objects keep their own test. 200 ORCA robots step in 8.5 ms instead of 11.7 ms.

Measured against current main (headless, interleaved medians), one `env.step()`:

| Scene | main | this PR | Speedup |
| --- | ---: | ---: | ---: |
| 1 dash robot | 0.07 ms | 0.05 ms | 1.6x |
| 100 dash robots | 6.6 ms | 4.0 ms | 1.6x |
| 24-pedestrian SFM crowd | 4.2 ms | 2.1 ms | 2.0x |
| 16 RVO robots | 37.1 ms | 2.2 ms | 17x |
| 32 RVO robots | 145 ms | 5.9 ms | 25x |
| 10 RVO robots with lidars | 21.7 ms | 7.1 ms | 3.1x |
| 200 ORCA robots | 11.7 ms | 8.5 ms | 1.4x |

The RVO gain grows with the crowd; the flat scenes gain from the per-object cuts and the batched collision query.

Behavior is unchanged: 1003 tests pass, and seeded runs of all 63 usage/test scenarios (states, velocities, flags, scans, rendered frames) plus the DRL-navigation harness are bit-identical to main.
