### PR TITLE
feat(behavior): add sfm group behavior with social groups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,8 @@ cd docs && make html
   - `acker`: `dash`
 - Group behaviors in `group_behavior.py` and `group_behavior_methods.py`:
   - `orca` (optimal reciprocal collision avoidance) - requires `pyrvo` package
-- SFM algorithm implementation: `irsim/lib/algorithm/social_force_model.py` (anisotropic Moussaid-Helbing 2009 variant)
+  - `sfm` (vectorized social force model stepping all members from one snapshot, with optional Moussaid 2010 social groups: coherence, repulsion, gaze)
+- SFM algorithm implementation: `irsim/lib/algorithm/social_force_model.py` (anisotropic Moussaid-Helbing 2009 variant; `social_force_model` per agent, `SocialForceModelBatch` for a whole crowd)
 
 **Path Planners** (`irsim/lib/path_planners/`):
 - `a_star.py`: A* grid-based path planning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,8 @@ cd docs && make html
   - `acker`: `dash`
 - Group behaviors in `group_behavior.py` and `group_behavior_methods.py`:
   - `orca` (optimal reciprocal collision avoidance) - requires `pyrvo` package
-- SFM algorithm implementation: `irsim/lib/algorithm/social_force_model.py` (anisotropic Moussaid-Helbing 2009 variant)
+  - `sfm` (vectorized social force model stepping all members from one snapshot, with optional Moussaid 2010 social groups: coherence, repulsion, gaze)
+- SFM algorithm implementation: `irsim/lib/algorithm/social_force_model.py` (anisotropic Moussaid-Helbing 2009 variant; `social_force_model` per agent, `SocialForceModelBatch` for a whole crowd)
 
 **Path Planners** (`irsim/lib/path_planners/`):
 - `a_star.py`: A* grid-based path planning

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ For more examples, see the [usage directory](https://github.com/hanruihua/ir-sim
 | **Kinematics**   | Differential Drive mobile Robot · Omnidirectional mobile Robot · Omnidirectional with Angular control · Ackermann Steering mobile Robot                                                 |
 | **Sensors**      | 2D LiDAR · 2D FMCW LiDAR · FOV Detector                                                                                                                                                 |
 | **Geometries**   | Circle · Rectangle · Polygon · LineString · Binary Grid Map · Fog of Map                                                                                                                |
-| **Behaviors**    | dash (move directly toward goal) · RVO (Reciprocal Velocity Obstacle) · ORCA (Optimal Reciprocal Collision Avoidance) · SFM (Social Force Model)                                        |
+| **Behaviors**    | dash (move directly toward goal) · RVO (Reciprocal Velocity Obstacle) · ORCA (Optimal Reciprocal Collision Avoidance) · SFM (Social Force Model, per-object and group with social groups) |
 
 ## Documentation
 

--- a/docs/locale/zh_CN/LC_MESSAGES/usage/configure_behavior.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/usage/configure_behavior.po
@@ -1248,3 +1248,7 @@ msgstr "成员对哪些外部对象作出反应：`'all'`、`'robot'` 或 `'obst
 #: ../../source/usage/configure_behavior.md:449
 msgid "Generate random goals when the current goal is reached"
 msgstr "到达当前目标后生成随机目标"
+
+#: ../../source/usage/configure_behavior.md:456
+msgid "The batched evaluation and the social-group forces follow [PySocialForce](https://github.com/yuxiang-gao/PySocialForce), a NumPy implementation of the extended social force model, using the force definitions of [pedsim_ros](https://github.com/srl-freiburg/pedsim_ros)."
+msgstr "批量求解与社会群组力遵循 [PySocialForce](https://github.com/yuxiang-gao/PySocialForce)（扩展社会力模型的 NumPy 实现），并采用 [pedsim_ros](https://github.com/srl-freiburg/pedsim_ros) 的力定义。"

--- a/docs/locale/zh_CN/LC_MESSAGES/usage/configure_behavior.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/usage/configure_behavior.po
@@ -327,12 +327,8 @@ msgid "SFM cross-corridor crowd"
 msgstr "SFM 交叉走廊人群"
 
 #: ../../source/usage/configure_behavior.md:226
-msgid ""
-"See `usage/23sfm_world/` for the full runnable file (24-agent cross corridor "
-"plus a separate two-robot head-on pass)."
-msgstr ""
-"完整可运行示例见 `usage/23sfm_world/`（24 个行人的交叉走廊场景，以及另一对相"
-"向通行的机器人示例）。"
+msgid "See `usage/23sfm_world/` for the full runnable file (24-agent cross corridor plus a separate two-robot head-on pass). For crowds, `sfm` is also available as a [group behavior](#sfm-as-a-group-behavior) that steps all members at once and can model pedestrians walking together."
+msgstr "完整可运行文件见 `usage/23sfm_world/`（24 个智能体的十字走廊，以及另一个双机器人迎面交会示例）。若要模拟人群，`sfm` 也可作为[群组行为](#sfm-as-a-group-behavior)使用，它一次性推进所有成员，并能模拟结伴而行的行人。"
 
 #: ../../source/usage/configure_behavior.md:228
 msgid "RVO with Line Obstacles"
@@ -434,8 +430,8 @@ msgid "`dash`, `rvo`, `sfm` (kinematics-dependent: see matrix above)"
 msgstr "`dash`、`rvo`、`sfm`（取决于运动学模型 —— 见上方矩阵）"
 
 #: ../../source/usage/configure_behavior.md:218
-msgid "`orca` (`omni`, `diff`)"
-msgstr "`orca`（`omni`、`diff`）"
+msgid "`orca`, `sfm` (`omni`, `diff`)"
+msgstr "`orca`、`sfm`（`omni`、`diff`）"
 
 #: ../../source/usage/configure_behavior.md:260
 msgid "ORCA (Optimal Reciprocal Collision Avoidance)"
@@ -1128,3 +1124,127 @@ msgstr ""
 "两个示例均支持 `omni` 与 `diff` 机动学，可从 YAML 中读取机动学类型，并需要 "
 "`cvxpy` 求解器（`pip install cvxpy`）。完整公式、支持的障碍物类型与已知限制详"
 "见 `usage/21cbf_world/README.md`。"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "SFM as a Group Behavior"
+msgstr "作为群组行为的 SFM"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`sfm` is also available as a group behavior for `omni` and `diff` kinematics. It uses the same physics and parameter names as the per-object [`sfm`](#sfm-social-force-model) behavior, evaluated for every member at once by {py:class}`~irsim.lib.algorithm.social_force_model.SocialForceModelBatch`:"
+msgstr "`sfm` 也可以作为 `omni` 与 `diff` 运动学的群组行为使用。它与逐对象的 [`sfm`](#sfm-social-force-model) 行为采用相同的物理模型和参数名，由 {py:class}`~irsim.lib.algorithm.social_force_model.SocialForceModelBatch` 一次性为所有成员求解："
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "**Synchronous update.** All members read one state snapshot, so the crowd no longer depends on the order in which objects are listed in the YAML. A single member follows exactly the same trajectory as under `behavior: sfm`."
+msgstr "**同步更新。** 所有成员读取同一份状态快照，因此人群行为不再依赖对象在 YAML 中的排列顺序。单个成员的轨迹与 `behavior: sfm` 下完全一致。"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "**Vectorized.** The pairwise social force is one NumPy pass over all member pairs instead of a Python loop per member, so large crowds stay cheap."
+msgstr "**向量化。** 成对的社会力通过一次 NumPy 运算覆盖所有成员对，而不是逐成员的 Python 循环，因此大规模人群的开销依然很低。"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "**Social groups.** `social_groups` optionally partitions the members into pedestrians walking together, which adds the three group forces of Moussaid et al. (2010): a *coherence* pull toward the group's centre of mass, an intra-group *repulsion* once two members' discs touch, and a *gaze* brake that slows a member down when the rest of the group leaves its field of view."
+msgstr "**社会群组。** `social_groups` 可选地把成员划分为结伴而行的行人，从而加入 Moussaid 等人（2010）的三种群组力：朝群组质心的*凝聚*拉力、两名成员的圆盘相触时的组内*排斥*力，以及当群组其余成员离开视野时让该成员减速的*注视*制动力。"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "Objects outside the group still take part: `linestring` obstacles enter as walls, and every other object as a circular neighbour that pushes members but is not moved by them. `target_roles`, `loop` and `wander` work as for the per-object behavior. A member without a goal stands still but still yields to neighbours."
+msgstr "群组之外的对象仍会参与其中：`linestring` 障碍物作为墙壁进入模型，其他所有对象则作为圆形邻居——它们会推开成员，但不会被成员推动。`target_roles`、`loop` 与 `wander` 的用法与逐对象行为相同。没有目标的成员会原地站立，但仍会为邻居让路。"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "The example below is `usage/23sfm_world/sfm_group_world.yaml`: two pairs and two triples walk a corridor in opposite directions, overlapping by one lane, while two singles thread through the middle. Each group slides sideways as a unit to pass the oncoming one."
+msgstr "下面的示例是 `usage/23sfm_world/sfm_group_world.yaml`：两对两人组与两组三人组在走廊中相向而行，彼此重叠一条车道，另有两名单独行人从中间穿过。每个群组作为整体侧向移动以避让迎面而来的群组。"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "Group SFM Parameters"
+msgstr "群组 SFM 参数"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "All per-object SFM parameters (`vmax`, `neighbor_threshold`, `relaxation_time`, `force_factor_desired`, `force_factor_social`, `force_factor_obstacle`, `sigma_obstacle`, `lambda_importance`, `gamma`, `n_angular`, `n_velocity`, `safety_radius`) keep their names and defaults. The group version adds:"
+msgstr "所有逐对象 SFM 参数（`vmax`、`neighbor_threshold`、`relaxation_time`、`force_factor_desired`、`force_factor_social`、`force_factor_obstacle`、`sigma_obstacle`、`lambda_importance`、`gamma`、`n_angular`、`n_velocity`、`safety_radius`）保持相同的名称与默认值。群组版本额外增加："
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "Must be `'sfm'`"
+msgstr "必须为 `'sfm'`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`social_groups`"
+msgstr "`social_groups`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`list` of `list` of `int`"
+msgstr "`list` of `list` of `int`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "Member indices, in YAML group order, of pedestrians walking together. Each member may appear in at most one group; omit to disable the group forces"
+msgstr "结伴而行的行人的成员索引（按 YAML 群组顺序）。每个成员最多只能出现在一个群组中；省略即关闭群组力"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`force_factor_coherence`"
+msgstr "`force_factor_coherence`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`2.0`"
+msgstr "`2.0`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "Weight of the pull toward the group's centre of mass. It ramps in smoothly once a member is further than `(size - 1) / 2` m from the centre"
+msgstr "朝群组质心拉力的权重。当成员距质心超过 `(size - 1) / 2` 米时平滑地生效"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`force_factor_group_repulsion`"
+msgstr "`force_factor_group_repulsion`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`1.0`"
+msgstr "`1.0`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "Weight of the push between two group members that come too close"
+msgstr "两名靠得过近的群组成员之间推力的权重"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`group_repulsion_threshold`"
+msgstr "`group_repulsion_threshold`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "Centre-to-centre distance below which two members repel each other. `None` uses the sum of their radii, so members push apart as soon as their discs touch"
+msgstr "两名成员开始相互排斥的中心距离阈值。`None` 表示使用两者半径之和，即圆盘一接触就相互推开"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`force_factor_gaze`"
+msgstr "`force_factor_gaze`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`3.0`"
+msgstr "`3.0`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "Weight of the brake `-alpha * v` applied when the other members' centre of mass leaves the field of view; `alpha` is the missing head rotation in radians"
+msgstr "当其余成员的质心离开视野时施加的制动力 `-alpha * v` 的权重；`alpha` 为需要补足的头部转角（弧度）"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`gaze_vision_angle`"
+msgstr "`gaze_vision_angle`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`90.0`"
+msgstr "`90.0`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "Half-angle, in degrees, of the field of view around the walking direction"
+msgstr "以行走方向为中心的视野半角（度）"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`target_roles`"
+msgstr "`target_roles`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "`'all'`"
+msgstr "`'all'`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "Which outside objects members react to: `'all'`, `'robot'` or `'obstacle'`"
+msgstr "成员对哪些外部对象作出反应：`'all'`、`'robot'` 或 `'obstacle'`"
+
+#: ../../source/usage/configure_behavior.md:449
+msgid "Generate random goals when the current goal is reached"
+msgstr "到达当前目标后生成随机目标"

--- a/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
+++ b/docs/locale/zh_CN/LC_MESSAGES/yaml_config/configuration.po
@@ -960,8 +960,8 @@ msgid "`group_behavior`"
 msgstr "`group_behavior`"
 
 #: ../../../../../../../Users/han/tech/ir-sim/docs/source/yaml_config/configuration.md:721
-msgid "Group-level behavior for objects in the same group. Support name: `orca`"
-msgstr "同组对象的群体行为配置，支持 `orca`。"
+msgid "Group-level behavior for objects in the same group. Support name: `orca`, `sfm`"
+msgstr "同组对象的群体行为配置，支持 `orca`、`sfm`。"
 
 #: ../../../../../../../Users/han/tech/ir-sim/docs/source/yaml_config/configuration.md:721
 msgid "`role`"
@@ -1760,8 +1760,8 @@ msgid ""
 msgstr "**`behavior`**：`dash`（直接朝目标移动）、`rvo`（互惠速度障碍）、`sfm`（社会力模型）"
 
 #: ../../../../../../../Users/han/tech/ir-sim/docs/source/yaml_config/configuration.md:1149
-msgid "**`group_behavior`**: `orca` (optimal reciprocal collision avoidance)"
-msgstr "**`group_behavior`**：`orca`（最优互惠碰撞避免）"
+msgid "**`group_behavior`**: `orca` (optimal reciprocal collision avoidance), `sfm` (social force model for a whole group)"
+msgstr "**`group_behavior`**：`orca`（最优互惠碰撞避免）、`sfm`（面向整个群组的社会力模型）"
 
 #: ../../../../../../../Users/han/tech/ir-sim/docs/source/yaml_config/configuration.md:1150
 msgid "**`static`**: Immobile objects (`True`/`False`)"
@@ -3068,3 +3068,34 @@ msgstr "**绘图选项**：若 `plot` 位于对象配置内部，可为单个对
 #~ "`@register_kinematics` 注册的自定义模型正是以此方式接收自己的参数，例如 "
 #~ "`kinematics: {name: 'lag', tau: 0.5}`。"
 
+#: ../../../../../../../Users/han/tech/ir-sim/docs/source/yaml_config/configuration.md:1218
+msgid "`'sfm'`: Social Force Model for the whole group, stepped from one state snapshot in a vectorised pass. Supported kinematics are `diff` and `omni`. Takes every per-object `sfm` parameter with the same names and defaults, plus the social-group parameters below; see [Configure behavior](../usage/configure_behavior.md#sfm-as-a-group-behavior)."
+msgstr "`'sfm'`：面向整个群组的社会力模型，从同一份状态快照出发以向量化方式一次推进所有成员。支持的运动学为 `diff` 与 `omni`。接受所有逐对象 `sfm` 参数（名称与默认值相同），以及下列社会群组参数；参见[配置行为](../usage/configure_behavior.md#sfm-as-a-group-behavior)。"
+
+#: ../../../../../../../Users/han/tech/ir-sim/docs/source/yaml_config/configuration.md:1218
+msgid "`social_groups` (list/`None`): Member indices, in YAML group order, of pedestrians walking together; each member in at most one group."
+msgstr "`social_groups`（list/`None`）：结伴而行的行人的成员索引（按 YAML 群组顺序）；每个成员最多属于一个群组。"
+
+#: ../../../../../../../Users/han/tech/ir-sim/docs/source/yaml_config/configuration.md:1218
+msgid "`force_factor_coherence` (float/`2.0`): Weight of the pull toward the group's centre of mass."
+msgstr "`force_factor_coherence`（float/`2.0`）：朝群组质心拉力的权重。"
+
+#: ../../../../../../../Users/han/tech/ir-sim/docs/source/yaml_config/configuration.md:1218
+msgid "`force_factor_group_repulsion` (float/`1.0`): Weight of the push between group members that come too close."
+msgstr "`force_factor_group_repulsion`（float/`1.0`）：靠得过近的群组成员之间推力的权重。"
+
+#: ../../../../../../../Users/han/tech/ir-sim/docs/source/yaml_config/configuration.md:1218
+msgid "`group_repulsion_threshold` (float/`None`): Centre distance below which members repel; `None` uses the sum of their radii."
+msgstr "`group_repulsion_threshold`（float/`None`）：成员开始相互排斥的中心距离；`None` 表示使用两者半径之和。"
+
+#: ../../../../../../../Users/han/tech/ir-sim/docs/source/yaml_config/configuration.md:1218
+msgid "`force_factor_gaze` (float/`3.0`): Weight of the brake applied when the other members leave the field of view."
+msgstr "`force_factor_gaze`（float/`3.0`）：当其余成员离开视野时施加的制动力权重。"
+
+#: ../../../../../../../Users/han/tech/ir-sim/docs/source/yaml_config/configuration.md:1218
+msgid "`gaze_vision_angle` (float/`90.0`): Half-angle in degrees of the field of view around the walking direction."
+msgstr "`gaze_vision_angle`（float/`90.0`）：以行走方向为中心的视野半角（度）。"
+
+#: ../../../../../../../Users/han/tech/ir-sim/docs/source/yaml_config/configuration.md:1218
+msgid "`target_roles` (str/`'all'`): Which outside objects members react to: `'all'`, `'robot'` or `'obstacle'`."
+msgstr "`target_roles`（str/`'all'`）：成员对哪些外部对象作出反应：`'all'`、`'robot'` 或 `'obstacle'`。"

--- a/docs/source/usage/configure_behavior.md
+++ b/docs/source/usage/configure_behavior.md
@@ -455,6 +455,8 @@ Use `group_behavior` in YAML for most cases as it handles initialization automat
 
 Objects outside the group still take part: `linestring` obstacles enter as walls, and every other object as a circular neighbour that pushes members but is not moved by them. `target_roles`, `loop` and `wander` work as for the per-object behavior. A member without a goal stands still but still yields to neighbours.
 
+The batched evaluation and the social-group forces follow [PySocialForce](https://github.com/yuxiang-gao/PySocialForce), a NumPy implementation of the extended social force model, using the force definitions of [pedsim_ros](https://github.com/srl-freiburg/pedsim_ros).
+
 The example below is `usage/23sfm_world/sfm_group_world.yaml`: two pairs and two triples walk a corridor in opposite directions, overlapping by one lane, while two singles thread through the middle. Each group slides sideways as a unit to pass the oncoming one.
 
 ::::{tab-set}

--- a/docs/source/usage/configure_behavior.md
+++ b/docs/source/usage/configure_behavior.md
@@ -222,7 +222,7 @@ obstacle:
 :::
 ::::
 
-See `usage/23sfm_world/` for the full runnable file (24-agent cross corridor plus a separate two-robot head-on pass).
+See `usage/23sfm_world/` for the full runnable file (24-agent cross corridor plus a separate two-robot head-on pass). For crowds, `sfm` is also available as a [group behavior](#sfm-as-a-group-behavior) that steps all members at once and can model pedestrians walking together.
 
 ### RVO with Line Obstacles
 
@@ -254,7 +254,7 @@ While `behavior` controls individual object movement, **`group_behavior`** enabl
 | Scope | Individual object | All objects in a group |
 | Computation | Per-object each step | All members at once |
 | Use case | Simple navigation | Coordinated multi-agent |
-| Available | `dash`, `rvo`, `sfm` (kinematics-dependent: see matrix above) | `orca` (`omni`, `diff`) |
+| Available | `dash`, `rvo`, `sfm` (kinematics-dependent: see matrix above) | `orca`, `sfm` (`omni`, `diff`) |
 
 ### ORCA (Optimal Reciprocal Collision Avoidance)
 
@@ -444,6 +444,147 @@ When `loop: true`, the robot will navigate through all waypoints and restart fro
 :::{tip}
 Use `group_behavior` in YAML for most cases as it handles initialization automatically. For full control, such as custom collision logic or an external planner, drive each robot yourself by passing velocity commands to `env.step(action)` instead of setting a behavior.
 :::
+
+### SFM as a Group Behavior
+
+`sfm` is also available as a group behavior for `omni` and `diff` kinematics. It uses the same physics and parameter names as the per-object [`sfm`](#sfm-social-force-model) behavior, evaluated for every member at once by {py:class}`~irsim.lib.algorithm.social_force_model.SocialForceModelBatch`:
+
+- **Synchronous update.** All members read one state snapshot, so the crowd no longer depends on the order in which objects are listed in the YAML. A single member follows exactly the same trajectory as under `behavior: sfm`.
+- **Vectorized.** The pairwise social force is one NumPy pass over all member pairs instead of a Python loop per member, so large crowds stay cheap.
+- **Social groups.** `social_groups` optionally partitions the members into pedestrians walking together, which adds the three group forces of Moussaid et al. (2010): a *coherence* pull toward the group's centre of mass, an intra-group *repulsion* once two members' discs touch, and a *gaze* brake that slows a member down when the rest of the group leaves its field of view.
+
+Objects outside the group still take part: `linestring` obstacles enter as walls, and every other object as a circular neighbour that pushes members but is not moved by them. `target_roles`, `loop` and `wander` work as for the per-object behavior. A member without a goal stands still but still yields to neighbours.
+
+The example below is `usage/23sfm_world/sfm_group_world.yaml`: two pairs and two triples walk a corridor in opposite directions, overlapping by one lane, while two singles thread through the middle. Each group slides sideways as a unit to pass the oncoming one.
+
+::::{tab-set}
+
+:::{tab-item} Python Script
+
+```python
+import irsim
+
+env = irsim.make()
+
+while not env.done():
+    env.step()
+    env.render(0.01)
+
+env.end()
+```
+:::
+
+:::{tab-item} YAML Configuration
+:selected:
+
+```yaml
+world:
+  height: 10
+  width: 20
+  step_time: 0.1
+  sample_time: 0.1
+  offset: [-10, -5]
+  collision_mode: 'unobstructed'   # SFM is reactive; let pedestrians overlap briefly
+  control_mode: 'auto'
+
+robot:
+  - number: 12
+    distribution: {name: 'manual'}
+    kinematics: {name: 'diff'}
+    shape: [{name: 'circle', radius: 0.25}]
+    state:
+      - [-9,  1.5, 0]
+      - [-9,  2.2, 0]
+      - [-9, -1.5, 0]
+      - [-9, -2.2, 0]
+      - [-9, -2.9, 0]
+      - [ 9, -2.4, 3.14]
+      - [ 9, -3.1, 3.14]
+      - [ 9,  2.4, 3.14]
+      - [ 9,  3.1, 3.14]
+      - [ 9,  3.8, 3.14]
+      - [-9,  0.3, 0]
+      - [ 9, -0.3, 3.14]
+    goal:
+      - [ 9,  1.5, 0]
+      - [ 9,  2.2, 0]
+      - [ 9, -1.5, 0]
+      - [ 9, -2.2, 0]
+      - [ 9, -2.9, 0]
+      - [-9, -2.4, 3.14]
+      - [-9, -3.1, 3.14]
+      - [-9,  2.4, 3.14]
+      - [-9,  3.1, 3.14]
+      - [-9,  3.8, 3.14]
+      - [ 9,  0.3, 0]
+      - [-9, -0.3, 3.14]
+    color:
+      - 'royalblue'
+      - 'royalblue'
+      - 'green'
+      - 'green'
+      - 'green'
+      - 'red'
+      - 'red'
+      - 'orange'
+      - 'orange'
+      - 'orange'
+      - 'purple'
+      - 'gray'
+    group_behavior:
+      name: 'sfm'
+      vmax: 1.0
+      neighbor_threshold: 5.0
+      force_factor_social: 4.0         # head-on stiffness for a 12-agent corridor
+      force_factor_obstacle: 5.0
+      sigma_obstacle: 0.3              # walls only matter within ~1 m
+      gamma: 0.5
+      safety_radius: 0.15              # 0.3 m personal bubble for vmax=1.0
+      social_groups: [[0, 1], [2, 3, 4], [5, 6], [7, 8, 9]]
+      force_factor_coherence: 2.0      # pull toward the group centre
+      force_factor_group_repulsion: 1.0
+      group_repulsion_threshold: 0.7   # members push apart once their discs touch
+      force_factor_gaze: 3.0           # leader brakes when the group leaves its view
+      gaze_vision_angle: 90.0
+    vel_min: [-1.5, -3.0]
+    vel_max: [ 1.5,  3.0]
+    arrive_mode: position
+    goal_threshold: 0.5
+    plot:
+      show_trail: true
+      show_goal: true
+      trail_fill: true
+      trail_alpha: 0.2
+      keep_trail_length: 25
+
+
+obstacle:
+  - shape: {name: 'linestring', vertices: [[-10,  5], [10,  5]]}
+    state: [0, 0, 0]
+    unobstructed: true
+  - shape: {name: 'linestring', vertices: [[-10, -5], [10, -5]]}
+    state: [0, 0, 0]
+    unobstructed: true
+```
+:::
+::::
+
+#### Group SFM Parameters
+
+All per-object SFM parameters (`vmax`, `neighbor_threshold`, `relaxation_time`, `force_factor_desired`, `force_factor_social`, `force_factor_obstacle`, `sigma_obstacle`, `lambda_importance`, `gamma`, `n_angular`, `n_velocity`, `safety_radius`) keep their names and defaults. The group version adds:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `name` | `str` | - | Must be `'sfm'` |
+| `social_groups` | `list` of `list` of `int` | `None` | Member indices, in YAML group order, of pedestrians walking together. Each member may appear in at most one group; omit to disable the group forces |
+| `force_factor_coherence` | `float` | `2.0` | Weight of the pull toward the group's centre of mass. It ramps in smoothly once a member is further than `(size - 1) / 2` m from the centre |
+| `force_factor_group_repulsion` | `float` | `1.0` | Weight of the push between two group members that come too close |
+| `group_repulsion_threshold` | `float` | `None` | Centre-to-centre distance below which two members repel each other. `None` uses the sum of their radii, so members push apart as soon as their discs touch |
+| `force_factor_gaze` | `float` | `3.0` | Weight of the brake `-alpha * v` applied when the other members' centre of mass leaves the field of view; `alpha` is the missing head rotation in radians |
+| `gaze_vision_angle` | `float` | `90.0` | Half-angle, in degrees, of the field of view around the walking direction |
+| `target_roles` | `str` | `'all'` | Which outside objects members react to: `'all'`, `'robot'` or `'obstacle'` |
+| `wander` | `bool` | `False` | Generate random goals when the current goal is reached |
+| `loop` | `bool` | `False` | Loop through waypoints continuously when reaching the last goal |
 
 ### Custom Group Behavior
 

--- a/docs/source/yaml_config/configuration.md
+++ b/docs/source/yaml_config/configuration.md
@@ -215,15 +215,46 @@ In a combined configuration for multiple simulators, these keys may be nested un
   </div>
   </details>
   <details>
-  <summary><a class="yt-key" href="#p-o-group-behavior">group_behavior</a><span class="yt-type yt-t-dict">dict</span><span class="yt-note">group-level (ORCA)</span></summary>
+  <summary><a class="yt-key" href="#p-o-group-behavior">group_behavior</a><span class="yt-type yt-t-dict">dict</span><span class="yt-note">group-level (ORCA / SFM)</span></summary>
   <div class="yt-body">
-    <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">name</a><span class="yt-type yt-t-str"><b class="yt-pill">str</b></span><span class="yt-def">unset</span><span class="yt-desc">orca</span></div>
-    <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">neighborDist</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">15.0</span></div>
-    <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">maxNeighbors</a><span class="yt-type yt-t-num"><b class="yt-pill">int</b></span><span class="yt-def">10</span></div>
-    <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">timeHorizon</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">20.0</span></div>
-    <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">timeHorizonObst</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">10.0</span></div>
-    <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">safe_radius</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">0.1</span></div>
-    <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">maxSpeed</a><span class="yt-type yt-t-mix"><b class="yt-pill">float/null</b></span><span class="yt-def">null</span><span class="yt-desc">falls back to vel_max</span></div>
+    <div class="yt-utabs">
+      <input class="yt-utab-radio" type="radio" name="yt-v-group-behavior" id="yt-v-gbeh-orca" checked>
+      <input class="yt-utab-radio" type="radio" name="yt-v-group-behavior" id="yt-v-gbeh-sfm">
+      <div class="yt-leaf yt-uvar-row"><a class="yt-key" href="#p-o-group-behavior">name</a><span class="yt-type yt-t-str"><b class="yt-pill">str</b></span><span class="yt-uvar-tabbar"><label for="yt-v-gbeh-orca">orca</label><label for="yt-v-gbeh-sfm">sfm</label></span></div>
+      <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">wander</a><span class="yt-type yt-t-bool"><b class="yt-pill">bool</b></span><span class="yt-def">false</span><span class="yt-desc">shared: new random goal on arrival</span></div>
+      <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">loop</a><span class="yt-type yt-t-bool"><b class="yt-pill">bool</b></span><span class="yt-def">false</span><span class="yt-desc">shared: cycle waypoints</span></div>
+      <div class="yt-utabpanels">
+        <div class="yt-utabpanel">
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">neighborDist</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">15.0</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">maxNeighbors</a><span class="yt-type yt-t-num"><b class="yt-pill">int</b></span><span class="yt-def">10</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">timeHorizon</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">20.0</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">timeHorizonObst</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">10.0</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">safe_radius</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">0.1</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">maxSpeed</a><span class="yt-type yt-t-mix"><b class="yt-pill">float/null</b></span><span class="yt-def">null</span><span class="yt-desc">falls back to vel_max</span></div>
+        </div>
+        <div class="yt-utabpanel">
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">vmax</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">1.5</span><span class="yt-desc">speed cap after force integration</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">neighbor_threshold</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">10.0</span><span class="yt-desc">social interaction cutoff distance</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">relaxation_time</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">0.5</span><span class="yt-desc">goal-pull time constant tau</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">force_factor_desired</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">1.0</span><span class="yt-desc">goal-pull weight</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">force_factor_social</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">2.1</span><span class="yt-desc">inter-agent repulsion weight</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">force_factor_obstacle</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">10.0</span><span class="yt-desc">obstacle repulsion weight</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">sigma_obstacle</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">0.8</span><span class="yt-desc">obstacle force decay length</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">lambda_importance</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">2.0</span><span class="yt-desc">velocity vs. position weight in interaction direction</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">gamma</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">0.35</span><span class="yt-desc">interaction range scale</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">n_angular</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">2.0</span><span class="yt-desc">sideways force angular sharpness</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">n_velocity</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">3.0</span><span class="yt-desc">slowdown force angular sharpness</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">safety_radius</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">0.0</span><span class="yt-desc">personal-space buffer (m) shifting decay closer in</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">social_groups</a><span class="yt-type yt-t-mix"><b class="yt-pill">list/null</b></span><span class="yt-def">null</span><span class="yt-desc">member index lists of pedestrians walking together</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">force_factor_coherence</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">2.0</span><span class="yt-desc">pull toward the group centre</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">force_factor_group_repulsion</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">1.0</span><span class="yt-desc">push between too-close members</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">group_repulsion_threshold</a><span class="yt-type yt-t-mix"><b class="yt-pill">float/null</b></span><span class="yt-def">null</span><span class="yt-desc">repel below this centre distance; null = sum of radii</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">force_factor_gaze</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">3.0</span><span class="yt-desc">brake when the group leaves the field of view</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">gaze_vision_angle</a><span class="yt-type yt-t-num"><b class="yt-pill">float</b></span><span class="yt-def">90.0</span><span class="yt-desc">field-of-view half-angle (deg)</span></div>
+          <div class="yt-leaf"><a class="yt-key" href="#p-o-group-behavior">target_roles</a><span class="yt-type yt-t-str"><b class="yt-pill">str</b></span><span class="yt-def">"all"</span><span class="yt-desc">all | robot | obstacle</span></div>
+        </div>
+      </div>
+    </div>
   </div>
   </details>
   <details>
@@ -743,7 +774,7 @@ All `robot` and `obstacle` entities in the simulation are configured as objects 
 | `velocity`       | `list` of `float`                                | `[0] * action_dim` | Initial velocity vector. Length matches the kinematics action dimension (2 for `diff`/`omni`/`acker`, 3 for `omni_angular`). |
 | `goal`           | `list` of `float` or `list` of `list` of `float` | `[1, 9, 0]` for manual distribution | Goal state(s) vector.                                                                                              |
 | `behavior`       | `dict`                                           | `None`           | Behavior configuration dictating object movement. Support name: `dash`, `rvo`, `sfm` (availability depends on `kinematics`; see [Configure behavior](../usage/configure_behavior.md))   |
-| `group_behavior` | `dict`                                           | `None`           | Group-level behavior for objects in the same group. Support name: `orca`                                           |
+| `group_behavior` | `dict`                                           | `None`           | Group-level behavior for objects in the same group. Support name: `orca`, `sfm`                                    |
 | `role`           | `str`                                            | inferred from top-level key | Role of the object in the simulation (`"robot"` under `robot`, `"obstacle"` under `obstacle`).                    |
 | `color`          | `str`                                            | inferred from role and kinematics | Visualization color of the object in the simulation. Robots use kinematics-specific defaults; obstacles default to black. |
 | `static`         | `bool`                                           | derived          | `False` when kinematics are present; otherwise the object is always static. Set `true` to freeze an object that has kinematics. |
@@ -1146,7 +1177,7 @@ env.step(env.robot.vel_world2body(world_vel))
 ```{card} Behavior Systems
 :class-card: sd-bg-light sd-rounded-3
 - **`behavior`**: `dash` (move toward the goal directly), `rvo` (reciprocal velocity obstacles), `sfm` (social force model)
-- **`group_behavior`**: `orca` (optimal reciprocal collision avoidance)
+- **`group_behavior`**: `orca` (optimal reciprocal collision avoidance), `sfm` (social force model for a whole group)
 - **`static`**: Immobile objects (`True`/`False`)
 ```
 
@@ -1216,6 +1247,24 @@ env.step(env.robot.vel_world2body(world_vel))
       timeHorizon: 10.0
       timeHorizonObst: 10.0
       safe_radius: 0.1
+    ```
+
+  - `'sfm'`: Social Force Model for the whole group, stepped from one state snapshot in a vectorised pass. Supported kinematics are `diff` and `omni`. Takes every per-object `sfm` parameter with the same names and defaults, plus the social-group parameters below; see [Configure behavior](../usage/configure_behavior.md#sfm-as-a-group-behavior).
+    - `social_groups` (list/`None`): Member indices, in YAML group order, of pedestrians walking together; each member in at most one group.
+    - `force_factor_coherence` (float/`2.0`): Weight of the pull toward the group's centre of mass.
+    - `force_factor_group_repulsion` (float/`1.0`): Weight of the push between group members that come too close.
+    - `group_repulsion_threshold` (float/`None`): Centre distance below which members repel; `None` uses the sum of their radii.
+    - `force_factor_gaze` (float/`3.0`): Weight of the brake applied when the other members leave the field of view.
+    - `gaze_vision_angle` (float/`90.0`): Half-angle in degrees of the field of view around the walking direction.
+    - `target_roles` (str/`'all'`): Which outside objects members react to: `'all'`, `'robot'` or `'obstacle'`.
+
+    **Example:**
+    ```yaml
+    group_behavior:
+      name: 'sfm'
+      vmax: 1.0
+      force_factor_social: 4.0
+      social_groups: [[0, 1], [2, 3, 4]]
     ```
 
 (p-o-static)=

--- a/irsim/lib/__init__.py
+++ b/irsim/lib/__init__.py
@@ -8,7 +8,10 @@ from irsim.lib.algorithm.kinematics import (
     omni_kinematics,
 )
 from irsim.lib.algorithm.rvo import reciprocal_vel_obs
-from irsim.lib.algorithm.social_force_model import social_force_model
+from irsim.lib.algorithm.social_force_model import (
+    SocialForceModelBatch,
+    social_force_model,
+)
 from irsim.lib.behavior.behavior import Behavior
 from irsim.lib.behavior.behavior_registry import (
     register_behavior,

--- a/irsim/lib/algorithm/__init__.py
+++ b/irsim/lib/algorithm/__init__.py
@@ -4,7 +4,7 @@ Core algorithms for IR-SIM simulation.
 This package contains:
 - kinematics: Robot kinematics functions
 - rvo: Reciprocal Velocity Obstacle algorithm
-- social_force_model: Anisotropic Social Force Model (Moussaïd 2009)
+- social_force_model: Anisotropic Social Force Model (Moussaïd 2009), per-agent and batched with Moussaïd 2010 social groups
 - generation: Polygon generation utilities
 - ray_casting_2d: Vectorized 2D ray casting for lidar sensors
 """
@@ -18,9 +18,10 @@ from .kinematics import (
 )
 from .ray_casting_2d import cast_rays
 from .rvo import reciprocal_vel_obs
-from .social_force_model import social_force_model
+from .social_force_model import SocialForceModelBatch, social_force_model
 
 __all__ = [
+    "SocialForceModelBatch",
     "ackermann_kinematics",
     "cast_rays",
     "differential_kinematics",

--- a/irsim/lib/algorithm/social_force_model.py
+++ b/irsim/lib/algorithm/social_force_model.py
@@ -26,6 +26,12 @@ is the weighted sum of three forces:
 * obstacle force -- exponential repulsion summed over all line
   obstacles within ``5 * sigma_obstacle`` (Helbing-Molnar 1995 form).
 
+:class:`social_force_model` evaluates these forces for one agent at a time
+and backs the per-object ``sfm`` behavior. :class:`SocialForceModelBatch`
+evaluates the same forces for a whole crowd in one NumPy pass from a single
+state snapshot and adds the optional social-group forces of Moussaid et al.
+(2010); it backs the ``sfm`` group behavior.
+
 Acknowledgement:
 
     pedsim_ros (https://github.com/srl-freiburg/pedsim_ros) and its
@@ -34,6 +40,8 @@ Acknowledgement:
 """
 
 from math import atan2, exp, sqrt
+
+import numpy as np
 
 
 class social_force_model:
@@ -309,6 +317,414 @@ class social_force_model:
         t = ((x - x1) * dx + (y - y1) * dy) / l2
         t = max(0.0, min(1.0, t))
         return x1 + t * dx, y1 + t * dy
+
+
+class SocialForceModelBatch:
+    """Vectorized Social Force Model for a crowd of agents.
+
+    Evaluates the same desired, social and obstacle forces as
+    :class:`social_force_model` for ``N`` agents at once from one state
+    snapshot. Every agent therefore reacts to the same instant, so the
+    result does not depend on the order in which agents are stepped, and
+    the pairwise social term is array math over all ``N x (N + M)`` pairs
+    instead of a Python loop.
+
+    Agents can optionally be partitioned into *social groups* (people
+    walking together). Members of a group receive the three extra forces
+    of Moussaid et al. (2010), in the formulation used by pedsim_ros:
+
+    * coherence -- pull toward the group's centre of mass, ramping in
+      smoothly (``tanh``) once a member is further than ``(size - 1) / 2``
+      metres from it;
+    * repulsion -- push apart members whose centres come closer than
+      ``group_repulsion_threshold``;
+    * gaze -- brake along the velocity, ``f = -alpha * v``, when the other
+      members' centre of mass lies outside a ``gaze_vision_angle`` cone
+      around the walking direction; ``alpha`` is the missing head rotation
+      in radians, so an agent slows down until it can see its group again.
+
+    References:
+        Moussaid, M., Perozo, N., Garnier, S., Helbing, D., Theraulaz, G.
+        (2010), *The walking behaviour of pedestrian social groups and its
+        impact on crowd dynamics.* PLoS ONE 5(4): e10047.
+
+    Args:
+        states (array-like): ``(N, 8)`` agent states
+            ``[x, y, vx, vy, radius, vx_des, vy_des, theta]``; ``theta`` is
+            carried for the caller and not used by the forces.
+        neighbor_states (array-like): ``(M, 5)`` circular neighbours that
+            are *not* part of the batch, ``[[x, y, vx, vy, radius], ...]``
+            (robots driven by other behaviors, circular obstacles). They
+            push batch agents but are not moved.
+        line_obs_list (array-like): ``(K, 4)`` line obstacles
+            ``[[x1, y1, x2, y2], ...]``.
+        social_groups (list[list[int]] | None): Index lists into ``states``;
+            each agent may appear in at most one group. ``None`` or ``[]``
+            disables the group forces.
+        vmax (float): Speed cap applied after the velocity update.
+        step_time (float): Integration step ``dt``.
+        relaxation_time (float): ``tau`` in the desired-force term.
+        force_factor_desired (float): Weight on the desired force.
+        force_factor_social (float): Weight on the social force.
+        force_factor_obstacle (float): Weight on the obstacle force.
+        sigma_obstacle (float): Decay length of the obstacle repulsion.
+        lambda_importance (float): Weight of relative velocity in the
+            interaction direction.
+        gamma (float): Sets the interaction range ``B = gamma * ||t||``.
+        n_angular (float): Angular sharpness ``n`` for the sideways force.
+        n_velocity (float): Angular sharpness ``n'`` for the slowdown force.
+        neighbor_range (float): Agents further apart than this ignore each
+            other in the social force.
+        safety_radius (float): Personal-space buffer subtracted from the
+            agent-to-agent distance inside the social-force exponential.
+        force_factor_coherence (float): Weight on the group coherence force.
+        force_factor_group_repulsion (float): Weight on the intra-group
+            repulsion force.
+        group_repulsion_threshold (float | None): Centre-to-centre distance
+            below which two group members repel each other. ``None`` uses
+            the sum of their radii (``states[:, 4]``), i.e. members push
+            apart as soon as their discs touch.
+        force_factor_gaze (float): Weight on the group gaze force.
+        gaze_vision_angle (float): Half-angle, in degrees, of the cone
+            around the walking direction inside which the group's centre
+            of mass is considered visible.
+    """
+
+    def __init__(
+        self,
+        states,
+        neighbor_states=None,
+        line_obs_list=None,
+        social_groups: list[list[int]] | None = None,
+        vmax: float = 1.5,
+        step_time: float = 0.1,
+        relaxation_time: float = 0.5,
+        force_factor_desired: float = 1.0,
+        force_factor_social: float = 2.1,
+        force_factor_obstacle: float = 10.0,
+        sigma_obstacle: float = 0.8,
+        lambda_importance: float = 2.0,
+        gamma: float = 0.35,
+        n_angular: float = 2.0,
+        n_velocity: float = 3.0,
+        neighbor_range: float = 10.0,
+        safety_radius: float = 0.0,
+        force_factor_coherence: float = 2.0,
+        force_factor_group_repulsion: float = 1.0,
+        group_repulsion_threshold: float | None = None,
+        force_factor_gaze: float = 3.0,
+        gaze_vision_angle: float = 90.0,
+    ) -> None:
+        if relaxation_time <= 0.0:
+            raise ValueError(f"relaxation_time must be > 0, got {relaxation_time}")
+        if gamma <= 0.0:
+            raise ValueError(f"gamma must be > 0, got {gamma}")
+        if sigma_obstacle <= 0.0:
+            raise ValueError(f"sigma_obstacle must be > 0, got {sigma_obstacle}")
+        if group_repulsion_threshold is not None and group_repulsion_threshold < 0.0:
+            raise ValueError(
+                f"group_repulsion_threshold must be >= 0, got {group_repulsion_threshold}"
+            )
+        if not 0.0 < gaze_vision_angle <= 180.0:
+            raise ValueError(
+                f"gaze_vision_angle must be in (0, 180] degrees, got {gaze_vision_angle}"
+            )
+
+        self.vmax = vmax
+        self.step_time = step_time
+        self.relaxation_time = relaxation_time
+
+        self.force_factor_desired = force_factor_desired
+        self.force_factor_social = force_factor_social
+        self.force_factor_obstacle = force_factor_obstacle
+
+        self.sigma_obstacle = sigma_obstacle
+        self.lambda_importance = lambda_importance
+        self.gamma = gamma
+        self.n_angular = n_angular
+        self.n_velocity = n_velocity
+        self.neighbor_range = neighbor_range
+        self.safety_radius = safety_radius
+
+        self.force_factor_coherence = force_factor_coherence
+        self.force_factor_group_repulsion = force_factor_group_repulsion
+        self.group_repulsion_threshold = group_repulsion_threshold
+        self.force_factor_gaze = force_factor_gaze
+        self.gaze_vision_angle = gaze_vision_angle
+
+        self.social_groups: list[np.ndarray] = []
+        self.update(
+            states,
+            neighbor_states,
+            line_obs_list,
+            social_groups if social_groups is not None else [],
+        )
+
+    def update(
+        self,
+        states,
+        neighbor_states=None,
+        line_obs_list=None,
+        social_groups: list[list[int]] | None = None,
+    ) -> None:
+        """Refresh the per-step inputs without re-instantiating.
+
+        Args:
+            states: ``(N, 8)`` agent states.
+            neighbor_states: ``(M, 5)`` external circular neighbours.
+            line_obs_list: ``(K, 4)`` line obstacles.
+            social_groups: New group partition, or ``None`` to keep the
+                current one. Pass ``[]`` to switch the group forces off.
+        """
+        self.states = np.asarray(states, dtype=float).reshape(-1, 8)
+        self.neighbor_states = np.asarray(
+            neighbor_states if neighbor_states is not None else [], dtype=float
+        ).reshape(-1, 5)
+        self.line_obs_list = np.asarray(
+            line_obs_list if line_obs_list is not None else [], dtype=float
+        ).reshape(-1, 4)
+        if social_groups is not None:
+            self.social_groups = self._validate_groups(social_groups, self.n)
+        else:
+            self._validate_groups([g.tolist() for g in self.social_groups], self.n)
+
+    @staticmethod
+    def _validate_groups(social_groups, n: int) -> list[np.ndarray]:
+        """Check the group partition and drop singleton groups.
+
+        Raises:
+            ValueError: If an index is out of range or an agent is listed
+                more than once.
+        """
+        groups: list[np.ndarray] = []
+        seen: set[int] = set()
+        for group in social_groups:
+            idx = [int(i) for i in group]
+            for i in idx:
+                if not 0 <= i < n:
+                    raise ValueError(
+                        f"social_groups index {i} is out of range for {n} agents"
+                    )
+                if i in seen:
+                    raise ValueError(f"agent {i} appears in more than one social group")
+                seen.add(i)
+            if len(idx) >= 2:
+                groups.append(np.asarray(idx, dtype=int))
+        return groups
+
+    # ------------------------------------------------------------------
+    # Convenience views
+    # ------------------------------------------------------------------
+
+    @property
+    def n(self) -> int:
+        """Number of agents in the batch."""
+        return self.states.shape[0]
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def cal_vel(self) -> np.ndarray:
+        """Integrate one SFM step for every agent.
+
+        Returns:
+            np.ndarray: ``(N, 2)`` updated world-frame velocities, each
+            clipped to ``vmax``.
+        """
+        acc = (
+            self.force_factor_desired * self.desired_force()
+            + self.force_factor_social * self.social_force()
+            + self.force_factor_obstacle * self.obstacle_force()
+        )
+        if self.social_groups:
+            acc = (
+                acc
+                + self.force_factor_coherence * self.coherence_force()
+                + self.force_factor_group_repulsion * self.group_repulsive_force()
+                + self.force_factor_gaze * self.gaze_force()
+            )
+
+        vel = self.states[:, 2:4] + self.step_time * acc
+        speed = np.hypot(vel[:, 0], vel[:, 1])
+        over = speed > self.vmax
+        scale = np.where(over, self.vmax / np.where(over, speed, 1.0), 1.0)
+        return vel * scale[:, None]
+
+    # ------------------------------------------------------------------
+    # Individual force terms (all return ``(N, 2)`` unweighted forces)
+    # ------------------------------------------------------------------
+
+    def desired_force(self) -> np.ndarray:
+        """Relaxation toward the desired velocity ``states[:, 5:7]``."""
+        return (self.states[:, 5:7] - self.states[:, 2:4]) / self.relaxation_time
+
+    def social_force(self) -> np.ndarray:
+        """Anisotropic neighbour repulsion (Moussaid-Helbing 2009).
+
+        Each agent sums the contribution of every other batch agent and
+        every external neighbour closer than ``neighbor_range``. Matches
+        :meth:`social_force_model.social_force` term by term.
+        """
+        n = self.n
+        if n == 0:
+            return np.zeros((0, 2))
+
+        pos = self.states[:, 0:2]
+        vel = self.states[:, 2:4]
+        others_pos = np.vstack((pos, self.neighbor_states[:, 0:2]))
+        others_vel = np.vstack((vel, self.neighbor_states[:, 2:4]))
+
+        d = others_pos[None, :, :] - pos[:, None, :]
+        dist = np.hypot(d[..., 0], d[..., 1])
+        valid = (dist >= 1e-6) & (dist < self.neighbor_range)
+        valid[np.arange(n), np.arange(n)] = False
+        if not valid.any():
+            return np.zeros((n, 2))
+
+        safe_dist = np.where(valid, dist, 1.0)
+        d_hat = d / safe_dist[..., None]
+
+        # velocity diff is self - other (upstream convention)
+        dv = vel[:, None, :] - others_vel[None, :, :]
+
+        # interaction vector  t = lambda * dv + d_hat
+        t = self.lambda_importance * dv + d_hat
+        t_norm = np.hypot(t[..., 0], t[..., 1])
+        valid &= t_norm >= 1e-9
+        safe_t = np.where(valid, t_norm, 1.0)
+        t_hat = t / safe_t[..., None]
+        b = self.gamma * safe_t
+
+        # signed angle from t_hat to d_hat
+        theta = np.arctan2(
+            t_hat[..., 0] * d_hat[..., 1] - t_hat[..., 1] * d_hat[..., 0],
+            t_hat[..., 0] * d_hat[..., 0] + t_hat[..., 1] * d_hat[..., 1],
+        )
+
+        gap = np.maximum(dist - 2.0 * self.safety_radius, 0.0)
+        decay = -gap / b
+        f_v = -np.exp(decay - (self.n_velocity * b * theta) ** 2)
+        f_a = -np.sign(theta) * np.exp(decay - (self.n_angular * b * theta) ** 2)
+
+        # f_v along t_hat plus f_a along the left normal of t_hat
+        fx = np.where(valid, f_v * t_hat[..., 0] - f_a * t_hat[..., 1], 0.0)
+        fy = np.where(valid, f_v * t_hat[..., 1] + f_a * t_hat[..., 0], 0.0)
+        return np.stack((fx.sum(axis=1), fy.sum(axis=1)), axis=1)
+
+    def obstacle_force(self) -> np.ndarray:
+        """Exponential repulsion summed over all nearby line obstacles.
+
+        Same rule as :meth:`social_force_model.obstacle_force`: every
+        segment within ``5 * sigma_obstacle + radius`` of an agent's centre
+        contributes, the decay is clamped at the body surface, and a
+        segment passing exactly through the centre pushes along ``+x``.
+        """
+        n = self.n
+        force = np.zeros((n, 2))
+        if n == 0 or self.line_obs_list.shape[0] == 0:
+            return force
+
+        pos = self.states[:, 0:2]
+        r = self.states[:, 4]
+        seg = self.line_obs_list
+        a = seg[:, 0:2]
+        ab = seg[:, 2:4] - a
+        l2 = np.einsum("kj,kj->k", ab, ab)
+        degenerate = l2 < 1e-12
+
+        ap = pos[:, None, :] - a[None, :, :]
+        t = np.einsum("nkj,kj->nk", ap, ab) / np.where(degenerate, 1.0, l2)[None, :]
+        t = np.clip(np.where(degenerate[None, :], 0.0, t), 0.0, 1.0)
+        closest = a[None, :, :] + t[..., None] * ab[None, :, :]
+
+        dvec = pos[:, None, :] - closest
+        dist_center = np.hypot(dvec[..., 0], dvec[..., 1])
+        within = dist_center <= 5.0 * self.sigma_obstacle + r[:, None]
+        overlap = within & (dist_center < 1e-9)
+        regular = within & ~overlap
+
+        distance = np.maximum(dist_center - r[:, None], 0.0)
+        amount = np.exp(-distance / self.sigma_obstacle)
+        scale = np.where(regular, amount / np.where(regular, dist_center, 1.0), 0.0)
+
+        force[:, 0] = (scale * dvec[..., 0]).sum(axis=1) + overlap.sum(axis=1)
+        force[:, 1] = (scale * dvec[..., 1]).sum(axis=1)
+        return force
+
+    # ------------------------------------------------------------------
+    # Social-group force terms (Moussaid et al. 2010)
+    # ------------------------------------------------------------------
+
+    def coherence_force(self) -> np.ndarray:
+        """Pull each member toward its group's centre of mass.
+
+        The pull is ``(com - p) * (tanh(d - d_max) + 1) / 2`` with
+        ``d_max = (size - 1) / 2`` metres, the smooth variant of the
+        paper's step rule used by pedsim_ros.
+        """
+        force = np.zeros((self.n, 2))
+        pos = self.states[:, 0:2]
+        for idx in self.social_groups:
+            members = pos[idx]
+            rel = members.mean(axis=0) - members
+            dist = np.hypot(rel[:, 0], rel[:, 1])
+            max_dist = (len(idx) - 1) / 2.0
+            soft = (np.tanh(dist - max_dist) + 1.0) / 2.0
+            force[idx] = rel * soft[:, None]
+        return force
+
+    def group_repulsive_force(self) -> np.ndarray:
+        """Push apart group members that come too close.
+
+        Each pair closer than ``group_repulsion_threshold`` (or the sum of
+        the two radii when that is ``None``) contributes the raw offset
+        ``p_self - p_other``.
+        """
+        force = np.zeros((self.n, 2))
+        pos = self.states[:, 0:2]
+        radius = self.states[:, 4]
+        for idx in self.social_groups:
+            members = pos[idx]
+            diff = members[:, None, :] - members[None, :, :]
+            dist = np.hypot(diff[..., 0], diff[..., 1])
+            if self.group_repulsion_threshold is None:
+                threshold = radius[idx][:, None] + radius[idx][None, :]
+            else:
+                threshold = self.group_repulsion_threshold
+            close = dist < threshold
+            np.fill_diagonal(close, False)
+            force[idx] = (diff * close[..., None]).sum(axis=1)
+        return force
+
+    def gaze_force(self) -> np.ndarray:
+        """Brake when the rest of the group falls out of view.
+
+        With ``phi`` the angle between the walking direction ``v`` and the
+        other members' centre of mass, the force is ``-(phi - phi_vis) * v``
+        when ``phi`` exceeds ``gaze_vision_angle`` and zero otherwise. A
+        stationary member has no walking direction and gets no gaze force.
+        """
+        force = np.zeros((self.n, 2))
+        pos = self.states[:, 0:2]
+        vel = self.states[:, 2:4]
+        vision = np.radians(self.gaze_vision_angle)
+        for idx in self.social_groups:
+            m = len(idx)
+            members = pos[idx]
+            com_others = (m * members.mean(axis=0) - members) / (m - 1)
+            rel = com_others - members
+            v = vel[idx]
+            speed = np.hypot(v[:, 0], v[:, 1])
+            rel_dist = np.hypot(rel[:, 0], rel[:, 1])
+            ok = (speed > 1e-9) & (rel_dist > 1e-9)
+            cos_phi = np.einsum("ij,ij->i", v, rel) / np.where(
+                ok, speed * rel_dist, 1.0
+            )
+            phi = np.arccos(np.clip(cos_phi, -1.0, 1.0))
+            rotation = np.where(ok, np.maximum(phi - vision, 0.0), 0.0)
+            force[idx] = -rotation[:, None] * v
+        return force
 
 
 # ----------------------------------------------------------------------

--- a/irsim/lib/algorithm/social_force_model.py
+++ b/irsim/lib/algorithm/social_force_model.py
@@ -37,6 +37,11 @@ Acknowledgement:
     pedsim_ros (https://github.com/srl-freiburg/pedsim_ros) and its
     vendored ``libpedsim`` by Christian Gloor were consulted as
     reference implementations while writing this module.
+
+    PySocialForce (https://github.com/yuxiang-gao/PySocialForce) by
+    Yuxiang Gao, a NumPy implementation of the extended social force
+    model with social groups, inspired the batched evaluation and the
+    social-group forces of :class:`SocialForceModelBatch`.
 """
 
 from math import atan2, exp, sqrt
@@ -347,6 +352,10 @@ class SocialForceModelBatch:
         Moussaid, M., Perozo, N., Garnier, S., Helbing, D., Theraulaz, G.
         (2010), *The walking behaviour of pedestrian social groups and its
         impact on crowd dynamics.* PLoS ONE 5(4): e10047.
+
+        PySocialForce, https://github.com/yuxiang-gao/PySocialForce --
+        NumPy implementation of the extended social force model whose
+        batched force evaluation and group forces this class follows.
 
     Args:
         states (array-like): ``(N, 8)`` agent states

--- a/irsim/lib/behavior/group_behavior_methods.py
+++ b/irsim/lib/behavior/group_behavior_methods.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import numpy as np
 
+from irsim.lib.algorithm.social_force_model import SocialForceModelBatch
 from irsim.lib.behavior.behavior_registry import register_group_behavior_class
 from irsim.util.util import relative_position, vel_world2diff, vel_world2omni
 from irsim.world.object_base import ObjectBase
@@ -168,3 +169,185 @@ class OrcaGroupBehavior:
             self._to_action(members[i], self._sim.get_agent_velocity(i).to_tuple())
             for i in range(self._sim.get_num_agents())
         ]
+
+
+@register_group_behavior_class("omni", "sfm")
+def beh_omni_sfm_group(members: list[ObjectBase], **kwargs: Any):
+    """
+    Registered initializer returning a class-based SFM handler for
+    omnidirectional robots.
+    """
+    return SfmGroupBehavior(members, **kwargs)
+
+
+@register_group_behavior_class("diff", "sfm")
+def beh_diff_sfm_group(members: list[ObjectBase], **kwargs: Any):
+    """
+    Registered initializer returning a class-based SFM handler for
+    differential-drive robots.
+    """
+    return SfmGroupBehavior(members, **kwargs)
+
+
+class SfmGroupBehavior:
+    """
+    Class-based Social Force Model group behavior.
+
+    Same physics and parameter names as the per-object ``sfm`` behavior,
+    evaluated for every member at once by
+    :class:`~irsim.lib.algorithm.social_force_model.SocialForceModelBatch`.
+    All members read one state snapshot, so the crowd does not depend on the
+    order objects are stepped in, and the pairwise social force is NumPy
+    array math instead of a Python loop per member.
+
+    Objects outside the group still take part: linestring obstacles enter as
+    walls, every other object as a circular neighbour that pushes members
+    but is not moved by them. ``target_roles`` filters those outside objects
+    exactly as it does for the per-object behavior.
+
+    ``social_groups`` optionally partitions the members into pedestrians
+    walking together (Moussaid et al. 2010): those receive coherence,
+    intra-group repulsion and gaze forces on top of the three base forces.
+    Indices refer to the member order of the YAML group.
+
+    A member without a goal has zero desired velocity: it stands still but
+    still yields to neighbours. ``omni`` members receive the planned world
+    velocity rotated into their body frame; ``diff`` members get it mapped
+    to ``(linear, angular)`` via :func:`vel_world2diff`.
+    """
+
+    def __init__(
+        self,
+        members: list[ObjectBase],
+        vmax: float = 1.5,
+        neighbor_threshold: float = 10.0,
+        relaxation_time: float = 0.5,
+        force_factor_desired: float = 1.0,
+        force_factor_social: float = 2.1,
+        force_factor_obstacle: float = 10.0,
+        sigma_obstacle: float = 0.8,
+        lambda_importance: float = 2.0,
+        gamma: float = 0.35,
+        n_angular: float = 2.0,
+        n_velocity: float = 3.0,
+        safety_radius: float = 0.0,
+        social_groups: list[list[int]] | None = None,
+        force_factor_coherence: float = 2.0,
+        force_factor_group_repulsion: float = 1.0,
+        group_repulsion_threshold: float | None = None,
+        force_factor_gaze: float = 3.0,
+        gaze_vision_angle: float = 90.0,
+        target_roles: str = "all",
+        **kwargs: Any,
+    ) -> None:
+        self._vmax = float(vmax)
+        self._target_roles = target_roles
+        self._kinematics = members[0].kinematics if members else None
+        self._step_time = members[0]._world_param.step_time if members else 0.1
+        self._sfm = SocialForceModelBatch(
+            states=np.zeros((len(members), 8)),
+            social_groups=social_groups,
+            vmax=self._vmax,
+            step_time=self._step_time,
+            relaxation_time=relaxation_time,
+            force_factor_desired=force_factor_desired,
+            force_factor_social=force_factor_social,
+            force_factor_obstacle=force_factor_obstacle,
+            sigma_obstacle=sigma_obstacle,
+            lambda_importance=lambda_importance,
+            gamma=gamma,
+            n_angular=n_angular,
+            n_velocity=n_velocity,
+            neighbor_range=neighbor_threshold,
+            safety_radius=safety_radius,
+            force_factor_coherence=force_factor_coherence,
+            force_factor_group_repulsion=force_factor_group_repulsion,
+            group_repulsion_threshold=group_repulsion_threshold,
+            force_factor_gaze=force_factor_gaze,
+            gaze_vision_angle=gaze_vision_angle,
+        )
+
+    @property
+    def sfm(self) -> SocialForceModelBatch:
+        """The batch solver holding the tuned parameters."""
+        return self._sfm
+
+    def _collect_inputs(
+        self, members: list[ObjectBase]
+    ) -> tuple[np.ndarray, list[list[float]], list[list[float]]]:
+        """Snapshot member states and the outside objects they react to.
+
+        Returns:
+            tuple: ``(states, circles, segments)`` where ``states`` is the
+            ``(N, 8)`` member array with the desired velocity renormalised to
+            ``vmax`` along the goal bearing (``rvo_state`` scales it by the
+            kinematics-specific ``vel_max``), ``circles`` the neighbour
+            states of non-member objects and ``segments`` the line obstacles.
+        """
+        states = np.array([m.rvo_state for m in members], dtype=float).reshape(-1, 8)
+        v_des = states[:, 5:7]
+        norm = np.hypot(v_des[:, 0], v_des[:, 1])
+        moving = norm > 1e-9
+        states[moving, 5:7] = self._vmax * v_des[moving] / norm[moving, None]
+
+        circles: list[list[float]] = []
+        segments: list[list[float]] = []
+        if not members:
+            return states, circles, segments
+
+        member_ids = {id(m) for m in members}
+        externals = [
+            obj for obj in members[0].external_objects if id(obj) not in member_ids
+        ]
+        if self._target_roles in ("robot", "obstacle"):
+            externals = [obj for obj in externals if obj.role == self._target_roles]
+
+        for obj in externals:
+            segs = obj.rvo_line_segments
+            if segs:
+                segments.extend(segs)
+            else:
+                circles.append(obj.rvo_neighbor_state)
+
+        return states, circles, segments
+
+    def _to_action(self, member: ObjectBase, vel_xy: np.ndarray) -> np.ndarray:
+        """Convert a world-frame SFM velocity into a member control input."""
+        vx, vy = float(vel_xy[0]), float(vel_xy[1])
+
+        if self._kinematics == "diff":
+            # Track the holonomic velocity tightly so the small sideways
+            # component of the anisotropic forces survives the conversion.
+            _, vmax_pair = member.get_vel_range()
+            return vel_world2diff(
+                member.state[2, 0],
+                [vx, vy],
+                w_max=float(vmax_pair[1, 0]),
+                guarantee_time=self._step_time,
+                tolerance=0.02,
+            )
+
+        if self._kinematics == "omni":
+            return vel_world2omni(member.state[2, 0], np.array([[vx], [vy]]))
+
+        return np.array([[vx], [vy]])
+
+    def __call__(self, members: list[ObjectBase], **kwargs: Any) -> list[np.ndarray]:
+        """
+        Generate the velocity for every member from one shared snapshot.
+
+        Args:
+            members: the members of the group
+            kwargs: unused; the parameters are fixed at construction
+
+        Returns:
+            list[np.ndarray]: one control input per member, in member order
+        """
+        if members:
+            self._kinematics = members[0].kinematics
+
+        states, circles, segments = self._collect_inputs(members)
+        self._sfm.update(states, circles, segments)
+        vel = self._sfm.cal_vel()
+
+        return [self._to_action(m, vel[i]) for i, m in enumerate(members)]

--- a/tests/test_behaviors.py
+++ b/tests/test_behaviors.py
@@ -1111,10 +1111,12 @@ class TestOrcaGroupBehaviorMockedPyrvo:
 
         from irsim.lib.behavior.behavior_registry import group_behaviors_class_map
 
-        # ORCA registers both omni and diff handlers; clear both so a fresh
-        # import doesn't trip the duplicate-registration guard.
-        for key in (("omni", "orca"), ("diff", "orca")):
-            group_behaviors_class_map.pop(key, None)
+        # The module registers omni and diff handlers for both ORCA and SFM;
+        # clear all of them so a fresh import doesn't trip the
+        # duplicate-registration guard.
+        for kinematics in ("omni", "diff"):
+            for action in ("orca", "sfm"):
+                group_behaviors_class_map.pop((kinematics, action), None)
         sys.modules.pop("irsim.lib.behavior.group_behavior_methods", None)
 
     @pytest.fixture(autouse=True)

--- a/tests/test_sfm.py
+++ b/tests/test_sfm.py
@@ -2,22 +2,33 @@
 
 Covers:
 - social_force_model algorithm: desired/social/obstacle forces, vmax clipping.
-- ("diff", "sfm") and ("omni", "sfm") behavior registration.
-- End-to-end env step with `behavior: sfm` via a temp YAML.
+- SocialForceModelBatch: parity with the scalar solver, social-group forces.
+- ("diff", "sfm") and ("omni", "sfm") behavior registration, per-object and group.
+- SfmGroupBehavior: outside objects, kinematics mapping, role filtering.
+- End-to-end env step with `behavior: sfm` and `group_behavior: sfm` via a temp YAML.
 """
 
 import contextlib
 import importlib
 import os
 import tempfile
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
 import yaml
 
 import irsim
-from irsim.lib.algorithm.social_force_model import social_force_model
-from irsim.lib.behavior.behavior_registry import behaviors_map
+from irsim.lib.algorithm.social_force_model import (
+    SocialForceModelBatch,
+    social_force_model,
+)
+from irsim.lib.behavior.behavior_registry import (
+    behaviors_map,
+    group_behaviors_class_map,
+)
+from irsim.lib.behavior.group_behavior_methods import SfmGroupBehavior
+from irsim.world.object_base import ObjectBase
 
 # Trigger the @register_behavior decorators in behavior_methods.py.
 importlib.import_module("irsim.lib.behavior.behavior_methods")
@@ -130,6 +141,445 @@ class TestSFMIntegration:
         sfm.update(_state(x=5.0), neighbor_list=[[1, 1, 0, 0, 0.3]])
         assert sfm.state[0] == 5.0
         assert len(sfm.neighbor_list) == 1
+
+
+# ===================================================================
+# SocialForceModelBatch: parity with the scalar solver
+# ===================================================================
+
+
+def _random_scene(seed=0, n=10, m=4, k=5):
+    """Random members, outside neighbours and walls in a 6 m box."""
+    rng = np.random.default_rng(seed)
+    states = np.column_stack(
+        [
+            rng.uniform(-3, 3, n),
+            rng.uniform(-3, 3, n),
+            rng.uniform(-1, 1, n),
+            rng.uniform(-1, 1, n),
+            rng.uniform(0.2, 0.4, n),
+            rng.uniform(-1, 1, n),
+            rng.uniform(-1, 1, n),
+            rng.uniform(-3, 3, n),
+        ]
+    )
+    neighbors = np.column_stack(
+        [
+            rng.uniform(-3, 3, m),
+            rng.uniform(-3, 3, m),
+            rng.uniform(-1, 1, m),
+            rng.uniform(-1, 1, m),
+            rng.uniform(0.2, 0.5, m),
+        ]
+    )
+    segments = rng.uniform(-4, 4, (k, 4))
+    return states, neighbors, segments
+
+
+_PARITY_PARAMS = {
+    "vmax": 1.2,
+    "step_time": 0.1,
+    "relaxation_time": 0.4,
+    "lambda_importance": 1.3,
+    "gamma": 0.5,
+    "n_angular": 1.5,
+    "n_velocity": 2.5,
+    "sigma_obstacle": 0.6,
+    "safety_radius": 0.1,
+    "force_factor_desired": 0.9,
+    "force_factor_social": 4.0,
+    "force_factor_obstacle": 6.0,
+}
+
+
+class TestSFMBatchMatchesScalar:
+    def _scalar_for(self, i, states, neighbors, segments, neighbor_range):
+        """Scalar solver for member ``i`` fed exactly what the per-object
+        behavior feeds it: other members and outside neighbours within
+        ``neighbor_range``."""
+        x, y = states[i, 0], states[i, 1]
+        others = [s[:5].tolist() for j, s in enumerate(states) if j != i]
+        others += neighbors.tolist()
+        others = [
+            o for o in others if (x - o[0]) ** 2 + (y - o[1]) ** 2 < neighbor_range**2
+        ]
+        return social_force_model(
+            states[i].tolist(),
+            others,
+            segments.tolist(),
+            neighbor_range=neighbor_range,
+            **_PARITY_PARAMS,
+        )
+
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_every_force_and_velocity_match(self, seed):
+        states, neighbors, segments = _random_scene(seed)
+        # A point segment and a wall through member 0's centre exercise the
+        # degenerate-segment and overlap branches in both solvers.
+        segments = np.vstack(
+            [
+                segments,
+                [1.0, 1.0, 1.0, 1.0],
+                [states[0, 0] - 1, states[0, 1], states[0, 0] + 1, states[0, 1]],
+            ]
+        )
+        neighbor_range = 4.0
+        batch = SocialForceModelBatch(
+            states, neighbors, segments, neighbor_range=neighbor_range, **_PARITY_PARAMS
+        )
+        fd, fs, fo, vel = (
+            batch.desired_force(),
+            batch.social_force(),
+            batch.obstacle_force(),
+            batch.cal_vel(),
+        )
+        assert vel.shape == (len(states), 2)
+        for i in range(len(states)):
+            scalar = self._scalar_for(i, states, neighbors, segments, neighbor_range)
+            np.testing.assert_allclose(fd[i], scalar.desired_force(), atol=1e-12)
+            np.testing.assert_allclose(fs[i], scalar.social_force(), atol=1e-12)
+            np.testing.assert_allclose(fo[i], scalar.obstacle_force(), atol=1e-12)
+            np.testing.assert_allclose(vel[i], scalar.cal_vel(), atol=1e-12)
+
+    def test_outside_neighbors_push_but_are_not_moved(self):
+        # One member walking +x, one outside neighbour straight ahead.
+        states = np.array([[0.0, 0.0, 1.0, 0.0, 0.3, 1.0, 0.0, 0.0]])
+        batch = SocialForceModelBatch(
+            states, neighbor_states=[[1.0, 0.0, 0.0, 0.0, 0.3]]
+        )
+        fs = batch.social_force()
+        assert fs.shape == (1, 2)
+        assert fs[0, 0] < 0.0
+        assert batch.cal_vel().shape == (1, 2)
+
+    def test_self_interaction_and_range_are_excluded(self):
+        states = np.array(
+            [
+                [0.0, 0.0, 1.0, 0.0, 0.3, 1.0, 0.0, 0.0],
+                [50.0, 0.0, -1.0, 0.0, 0.3, -1.0, 0.0, 0.0],
+            ]
+        )
+        batch = SocialForceModelBatch(states, neighbor_range=10.0)
+        np.testing.assert_array_equal(batch.social_force(), np.zeros((2, 2)))
+
+    def test_vmax_clipping(self):
+        states = np.array([[0.0, 0.0, 0.0, 0.0, 0.3, 10.0, 0.0, 0.0]])
+        vel = SocialForceModelBatch(states, vmax=1.0, step_time=1.0).cal_vel()
+        assert np.hypot(*vel[0]) <= 1.0 + 1e-9
+
+    def test_empty_batch(self):
+        batch = SocialForceModelBatch(
+            np.zeros((0, 8)), [[1, 1, 0, 0, 0.3]], [[0, 0, 1, 1]]
+        )
+        assert batch.cal_vel().shape == (0, 2)
+        assert batch.social_force().shape == (0, 2)
+        assert batch.obstacle_force().shape == (0, 2)
+
+    def test_non_positive_divisors_rejected(self):
+        states = np.zeros((1, 8))
+        for kwargs in (
+            {"relaxation_time": 0.0},
+            {"gamma": -0.5},
+            {"sigma_obstacle": 0.0},
+            {"group_repulsion_threshold": -0.1},
+            {"gaze_vision_angle": 0.0},
+            {"gaze_vision_angle": 181.0},
+        ):
+            param = next(iter(kwargs))
+            with pytest.raises(ValueError, match=f"^{param} must be"):
+                SocialForceModelBatch(states, **kwargs)
+
+
+# ===================================================================
+# SocialForceModelBatch: social-group forces (Moussaid et al. 2010)
+# ===================================================================
+
+
+def _row(x, y, vx=0.0, vy=0.0, r=0.3):
+    return [x, y, vx, vy, r, vx, vy, 0.0]
+
+
+class TestSFMBatchGroupForces:
+    def test_coherence_pulls_straggler_toward_centre(self):
+        # Members at x = 0 and x = 3: the centre of mass is at 1.5, well
+        # beyond the (2 - 1) / 2 = 0.5 m comfort distance, so both are
+        # pulled toward it and the straggler feels the larger pull.
+        batch = SocialForceModelBatch([_row(0, 0), _row(3, 0)], social_groups=[[0, 1]])
+        f = batch.coherence_force()
+        assert f[0, 0] > 0.0
+        assert f[1, 0] < 0.0
+        assert f[0, 1] == f[1, 1] == 0.0
+
+    def test_coherence_fades_when_members_are_close(self):
+        near = SocialForceModelBatch([_row(0, 0), _row(0.2, 0)], social_groups=[[0, 1]])
+        far = SocialForceModelBatch([_row(0, 0), _row(3.0, 0)], social_groups=[[0, 1]])
+        assert np.abs(near.coherence_force()).max() < 0.05
+        assert np.abs(far.coherence_force()).max() > 1.0
+
+    def test_repulsion_only_inside_threshold_and_points_apart(self):
+        close = SocialForceModelBatch(
+            [_row(0, 0), _row(0.2, 0)],
+            social_groups=[[0, 1]],
+            group_repulsion_threshold=0.55,
+        )
+        f = close.group_repulsive_force()
+        assert f[0, 0] < 0.0
+        assert f[1, 0] > 0.0
+        np.testing.assert_allclose(f[0], -f[1])
+
+        apart = SocialForceModelBatch(
+            [_row(0, 0), _row(1.0, 0)],
+            social_groups=[[0, 1]],
+            group_repulsion_threshold=0.55,
+        )
+        np.testing.assert_array_equal(apart.group_repulsive_force(), np.zeros((2, 2)))
+
+    def test_repulsion_default_threshold_is_sum_of_radii(self):
+        # radii 0.3 + 0.3: discs touch at 0.6 m centre distance
+        touching = SocialForceModelBatch(
+            [_row(0, 0, r=0.3), _row(0.55, 0, r=0.3)], social_groups=[[0, 1]]
+        )
+        assert touching.group_repulsive_force()[0, 0] < 0.0
+        clear = SocialForceModelBatch(
+            [_row(0, 0, r=0.3), _row(0.65, 0, r=0.3)], social_groups=[[0, 1]]
+        )
+        np.testing.assert_array_equal(clear.group_repulsive_force(), np.zeros((2, 2)))
+
+    def test_gaze_brakes_the_member_ahead_only(self):
+        # All walk +x; member 1 is 3 m ahead so the others' centre of mass
+        # sits directly behind it (180 deg > 90 deg vision): it is braked by
+        # (pi - pi/2) * v. Members 0 and 2 see the centre ahead: no force.
+        batch = SocialForceModelBatch(
+            [_row(0, 0, vx=1.0), _row(3, 0, vx=1.0), _row(0.2, 0, vx=1.0)],
+            social_groups=[[0, 1, 2]],
+        )
+        f = batch.gaze_force()
+        np.testing.assert_allclose(f[1], [-np.pi / 2, 0.0], atol=1e-9)
+        np.testing.assert_array_equal(f[0], [0.0, 0.0])
+        np.testing.assert_array_equal(f[2], [0.0, 0.0])
+
+    def test_gaze_partial_rotation_scales_with_speed(self):
+        # Partner directly to the side and slightly behind: the centre of
+        # mass is a few degrees past 90, so the brake is small and grows
+        # linearly with the walking speed.
+        slow = SocialForceModelBatch(
+            [_row(0, 0, vx=0.5), _row(-0.1, 0.6, vx=0.5)], social_groups=[[0, 1]]
+        ).gaze_force()
+        fast = SocialForceModelBatch(
+            [_row(0, 0, vx=1.0), _row(-0.1, 0.6, vx=1.0)], social_groups=[[0, 1]]
+        ).gaze_force()
+        assert slow[0, 0] < 0.0
+        assert fast[0, 0] == pytest.approx(2.0 * slow[0, 0])
+        assert np.abs(slow[0, 0]) < np.pi / 2 * 0.5
+
+    def test_gaze_zero_when_stationary(self):
+        batch = SocialForceModelBatch([_row(0, 0), _row(3, 0)], social_groups=[[0, 1]])
+        np.testing.assert_array_equal(batch.gaze_force(), np.zeros((2, 2)))
+
+    def test_group_forces_enter_cal_vel_only_with_groups(self):
+        rows = [_row(0, 0, vx=1.0), _row(3, 0, vx=1.0)]
+        alone = SocialForceModelBatch(rows).cal_vel()
+        grouped = SocialForceModelBatch(rows, social_groups=[[0, 1]]).cal_vel()
+        assert not np.allclose(alone, grouped)
+        # coherence pulls the straggler forward and the leader back
+        assert grouped[0, 0] > alone[0, 0]
+        assert grouped[1, 0] < alone[1, 0]
+
+    def test_singletons_and_empty_groups_are_ignored(self):
+        batch = SocialForceModelBatch(
+            [_row(0, 0), _row(3, 0)], social_groups=[[0], [1]]
+        )
+        assert batch.social_groups == []
+        batch = SocialForceModelBatch([_row(0, 0), _row(3, 0)], social_groups=[])
+        assert batch.social_groups == []
+
+    def test_invalid_groups_raise(self):
+        rows = [_row(0, 0), _row(3, 0), _row(6, 0)]
+        with pytest.raises(ValueError, match="out of range"):
+            SocialForceModelBatch(rows, social_groups=[[0, 5]])
+        with pytest.raises(ValueError, match="out of range"):
+            SocialForceModelBatch(rows, social_groups=[[-1, 0]])
+        with pytest.raises(ValueError, match="more than one social group"):
+            SocialForceModelBatch(rows, social_groups=[[0, 1], [1, 2]])
+        with pytest.raises(ValueError, match="more than one social group"):
+            SocialForceModelBatch(rows, social_groups=[[0, 0]])
+
+    def test_update_keeps_groups_unless_replaced(self):
+        rows = [_row(0, 0), _row(3, 0)]
+        batch = SocialForceModelBatch(rows, social_groups=[[0, 1]])
+        batch.update(rows)
+        assert len(batch.social_groups) == 1
+        batch.update(rows, social_groups=[])
+        assert batch.social_groups == []
+        # Shrinking the batch below a group index is rejected on update.
+        batch.update(rows, social_groups=[[0, 1]])
+        with pytest.raises(ValueError, match="out of range"):
+            batch.update(rows[:1])
+
+
+# ===================================================================
+# SfmGroupBehavior (class-based group handler) with mock members
+# ===================================================================
+
+
+def _mock_member(
+    kin="diff",
+    x=0.0,
+    y=0.0,
+    theta=0.0,
+    vx=0.0,
+    vy=0.0,
+    vx_des=1.0,
+    vy_des=0.0,
+    r=0.3,
+    externals=None,
+):
+    m = Mock(spec=ObjectBase)
+    m.kinematics = kin
+    m.role = "robot"
+    m.state = np.array([[x], [y], [theta]])
+    m.rvo_state = [x, y, vx, vy, r, vx_des, vy_des, theta]
+    m.rvo_neighbor_state = [x, y, vx, vy, r]
+    m.rvo_line_segments = []
+    m.external_objects = list(externals) if externals is not None else []
+    m.get_vel_range = Mock(
+        return_value=(np.array([[-1.5], [-3.0]]), np.array([[1.5], [3.0]]))
+    )
+    m._world_param = Mock()
+    m._world_param.step_time = 0.1
+    return m
+
+
+def _mock_wall(segments, role="obstacle"):
+    o = Mock(spec=ObjectBase)
+    o.role = role
+    o.rvo_line_segments = segments
+    o.rvo_neighbor_state = [0.0, 0.0, 0.0, 0.0, 0.0]
+    return o
+
+
+def _mock_circle(x, y, vx=0.0, vy=0.0, r=0.3, role="robot"):
+    o = Mock(spec=ObjectBase)
+    o.role = role
+    o.rvo_line_segments = []
+    o.rvo_neighbor_state = [x, y, vx, vy, r]
+    return o
+
+
+class TestSfmGroupBehavior:
+    def test_registered_for_omni_and_diff(self):
+        # Other test modules may evict and re-import the methods module, so
+        # look the class up on the module that is currently registered.
+        module = importlib.import_module("irsim.lib.behavior.group_behavior_methods")
+        assert ("omni", "sfm") in group_behaviors_class_map
+        assert ("diff", "sfm") in group_behaviors_class_map
+        handler = group_behaviors_class_map[("diff", "sfm")]([_mock_member()])
+        assert isinstance(handler, module.SfmGroupBehavior)
+
+    def test_diff_isolated_member_accelerates_forward(self):
+        member = _mock_member("diff")
+        out = SfmGroupBehavior([member], vmax=1.0)([member])
+        assert len(out) == 1
+        assert out[0].shape == (2, 1)
+        # from rest: v = dt * (v_des - 0) / tau = 0.1 * 1.0 / 0.5
+        assert out[0][0, 0] == pytest.approx(0.2, abs=1e-9)
+        assert out[0][1, 0] == pytest.approx(0.0, abs=1e-9)
+
+    def test_desired_velocity_renormalised_to_vmax(self):
+        # rvo_state carries an anisotropically scaled desired velocity;
+        # only its direction should survive, at speed ``vmax``.
+        member = _mock_member("diff", vx_des=3.0, vy_des=0.0)
+        beh = SfmGroupBehavior([member], vmax=1.0)
+        states, _, _ = beh._collect_inputs([member])
+        np.testing.assert_allclose(states[0, 5:7], [1.0, 0.0])
+
+    def test_omni_output_is_in_body_frame(self):
+        # Facing +y while the plan says +x world: body-frame lateral command.
+        member = _mock_member("omni", theta=np.pi / 2)
+        out = SfmGroupBehavior([member], vmax=1.0)([member])
+        assert out[0].shape == (2, 1)
+        assert out[0][0, 0] == pytest.approx(0.0, abs=1e-9)
+        assert out[0][1, 0] == pytest.approx(-0.2, abs=1e-9)
+
+    def test_unknown_kinematics_passes_world_velocity_through(self):
+        member = _mock_member("custom")
+        out = SfmGroupBehavior([member], vmax=1.0)([member])
+        np.testing.assert_allclose(out[0], [[0.2], [0.0]], atol=1e-9)
+
+    def test_outside_wall_and_robot_push_member(self):
+        wall = _mock_wall([[-1.0, 0.5, 1.0, 0.5]])
+        other = _mock_circle(1.0, 0.0)
+        member = _mock_member("diff", vx=1.0, externals=[wall, other])
+        beh = SfmGroupBehavior([member], vmax=2.0)
+        states, circles, segments = beh._collect_inputs([member])
+        assert circles == [other.rvo_neighbor_state]
+        assert segments == [[-1.0, 0.5, 1.0, 0.5]]
+        beh.sfm.update(states, circles, segments)
+        assert beh.sfm.obstacle_force()[0, 1] < 0.0  # wall above pushes down
+        assert beh.sfm.social_force()[0, 0] < 0.0  # robot ahead pushes back
+
+    def test_members_are_not_double_counted_as_externals(self):
+        a = _mock_member("diff", x=0.0)
+        b = _mock_member("diff", x=1.0)
+        a.external_objects = [b]
+        b.external_objects = [a]
+        beh = SfmGroupBehavior([a, b])
+        _, circles, segments = beh._collect_inputs([a, b])
+        assert circles == []
+        assert segments == []
+
+    def test_target_roles_filters_outside_objects(self):
+        wall = _mock_wall([[-1.0, 0.5, 1.0, 0.5]], role="obstacle")
+        other = _mock_circle(1.0, 0.0, role="robot")
+        member = _mock_member("diff", externals=[wall, other])
+        _, circles, segments = SfmGroupBehavior(
+            [member], target_roles="robot"
+        )._collect_inputs([member])
+        assert circles == [other.rvo_neighbor_state]
+        assert segments == []
+        _, circles, segments = SfmGroupBehavior(
+            [member], target_roles="obstacle"
+        )._collect_inputs([member])
+        assert circles == []
+        assert segments == [[-1.0, 0.5, 1.0, 0.5]]
+
+    def test_member_without_goal_stands_but_yields(self):
+        # No goal -> zero desired velocity (rvo_state convention). Alone it
+        # brakes to rest; with a neighbour bearing down it is pushed aside.
+        alone = _mock_member("omni", vx=1.0, vx_des=0.0, vy_des=0.0)
+        out = SfmGroupBehavior([alone], vmax=2.0)([alone])
+        assert out[0][0, 0] < 1.0
+        pushed = _mock_member(
+            "omni",
+            vx_des=0.0,
+            vy_des=0.0,
+            externals=[_mock_circle(0.6, 0.05, vx=-1.0)],
+        )
+        out = SfmGroupBehavior([pushed], vmax=2.0)([pushed])
+        assert np.abs(out[0]).max() > 0.0
+
+    def test_call_refreshes_kinematics_from_members(self):
+        member = _mock_member("diff")
+        beh = SfmGroupBehavior([member])
+        beh._kinematics = "omni"
+        out = beh([member])
+        assert beh._kinematics == "diff"
+        assert out[0].shape == (2, 1)
+
+    def test_member_count_change_revalidates_groups(self):
+        a, b = _mock_member("diff", x=0.0), _mock_member("diff", x=1.0)
+        beh = SfmGroupBehavior([a, b], social_groups=[[0, 1]])
+        assert len(beh([a, b])) == 2
+        with pytest.raises(ValueError, match="out of range"):
+            beh([a])
+
+    def test_invalid_social_groups_raise_at_construction(self):
+        with pytest.raises(ValueError, match="out of range"):
+            SfmGroupBehavior([_mock_member()], social_groups=[[0, 1]])
+
+    def test_call_with_no_members_returns_no_actions(self):
+        beh = SfmGroupBehavior([_mock_member()])
+        assert beh([]) == []
 
 
 # ===================================================================
@@ -276,6 +726,190 @@ class TestSFMEndToEnd:
         assert any_resampled, (
             "wander mode should re-sample at least one goal in 300 steps"
         )
+        env.end(suppress_summary=True)
+
+
+# ===================================================================
+# End-to-end: ``group_behavior: sfm`` via temp YAML
+# ===================================================================
+
+
+def _corridor_world(height=8, width=14):
+    return {
+        "height": height,
+        "width": width,
+        "step_time": 0.1,
+        "sample_time": 0.1,
+        "offset": [-width / 2, -height / 2],
+        "collision_mode": "unobstructed",
+        "control_mode": "auto",
+    }
+
+
+def _wall(y, half_width=7):
+    return {
+        "shape": {
+            "name": "linestring",
+            "vertices": [[-half_width, y], [half_width, y]],
+        },
+        "state": [0, 0, 0],
+        "unobstructed": True,
+    }
+
+
+class TestSFMGroupEndToEnd:
+    def _single_robot_trajectory(self, behavior_key):
+        cfg = {
+            "world": _corridor_world(),
+            "robot": [
+                {
+                    "kinematics": {"name": "diff"},
+                    "shape": [{"name": "circle", "radius": 0.3}],
+                    "state": [-6, 1.0, 0.3],
+                    "goal": [6, -1.0, 0],
+                    behavior_key: {"name": "sfm", "vmax": 1.0, "sigma_obstacle": 0.6},
+                    "vel_min": [-1.5, -3],
+                    "vel_max": [1.5, 3],
+                    "arrive_mode": "position",
+                    "goal_threshold": 0.2,
+                }
+            ],
+            "obstacle": [
+                _wall(2.0),
+                {"shape": {"name": "circle", "radius": 0.5}, "state": [0, 0.3, 0]},
+            ],
+        }
+        env = irsim.make(_write_temp_yaml(cfg), save_ani=False, display=False)
+        traj = []
+        for _ in range(150):
+            env.step()
+            traj.append(env.robot.state.copy())
+        env.end(suppress_summary=True)
+        return np.array(traj)
+
+    def test_group_matches_per_object_behavior_for_one_robot(self):
+        """With a single member the synchronous update is moot, so the group
+        handler must reproduce the per-object ``sfm`` trajectory exactly,
+        walls and circular obstacles included."""
+        individual = self._single_robot_trajectory("behavior")
+        grouped = self._single_robot_trajectory("group_behavior")
+        np.testing.assert_allclose(grouped, individual, atol=1e-9)
+
+    @pytest.mark.parametrize(
+        ("kinematics", "vel_max"), [("diff", [1.5, 3]), ("omni", [1.5, 1.5])]
+    )
+    def test_pair_head_on_with_outside_robot_and_wall(self, kinematics, vel_max):
+        """A two-member group passes head-on while a ``dash`` robot crosses
+        the corridor; everyone reaches its goal."""
+        cfg = {
+            "world": _corridor_world(),
+            "robot": [
+                {
+                    "number": 2,
+                    "distribution": {"name": "manual"},
+                    "kinematics": {"name": kinematics},
+                    "shape": [{"name": "circle", "radius": 0.3}],
+                    "state": [[-6, 0, 0], [6, 0.05, 3.14]],
+                    "goal": [[6, 0, 0], [-6, 0.05, 3.14]],
+                    "group_behavior": {
+                        "name": "sfm",
+                        "vmax": 1.0,
+                        "force_factor_social": 5.0,
+                        "gamma": 0.5,
+                        "sigma_obstacle": 0.5,
+                    },
+                    "vel_min": [-v for v in vel_max],
+                    "vel_max": vel_max,
+                    "arrive_mode": "position",
+                    "goal_threshold": 0.2,
+                },
+                {
+                    "kinematics": {"name": "diff"},
+                    "shape": [{"name": "circle", "radius": 0.3}],
+                    "state": [0, -2.5, 1.57],
+                    "goal": [0, 2.5, 0],
+                    "behavior": {"name": "dash"},
+                    "vel_min": [-1, -2],
+                    "vel_max": [1, 2],
+                    "arrive_mode": "position",
+                    "goal_threshold": 0.2,
+                },
+            ],
+            "obstacle": [_wall(3.0)],
+        }
+        env = irsim.make(_write_temp_yaml(cfg), save_ani=False, display=False)
+        handler = env._object_groups[0].group_behavior._invoke_func
+        assert type(handler).__name__ == "SfmGroupBehavior"
+        for _ in range(400):
+            env.step()
+            if env.done():
+                break
+        assert env.done(), "group members and the crossing robot should all arrive"
+        env.end(suppress_summary=True)
+
+    def _pair_separation(self, social_groups):
+        cfg = {
+            "world": _corridor_world(),
+            "robot": [
+                {
+                    "number": 2,
+                    "distribution": {"name": "manual"},
+                    "kinematics": {"name": "omni"},
+                    "shape": [{"name": "circle", "radius": 0.25}],
+                    "state": [[-6, 1.5, 0], [-6, -1.5, 0]],
+                    "goal": [[6, 0.3, 0], [6, -0.3, 0]],
+                    "group_behavior": {
+                        "name": "sfm",
+                        "vmax": 1.0,
+                        "social_groups": social_groups,
+                    },
+                    "vel_min": [-1.5, -1.5],
+                    "vel_max": [1.5, 1.5],
+                    "arrive_mode": "position",
+                    "goal_threshold": 0.3,
+                }
+            ],
+        }
+        env = irsim.make(_write_temp_yaml(cfg), save_ani=False, display=False)
+        sep = []
+        for _ in range(60):
+            env.step()
+            a, b = (r.state[:2, 0] for r in env.robot_list)
+            sep.append(np.linalg.norm(a - b))
+        env.end(suppress_summary=True)
+        return np.array(sep)
+
+    def test_social_group_closes_up_early(self):
+        """Two pedestrians starting 3 m apart converge much sooner when they
+        form a social group than when they merely share goals."""
+        grouped = self._pair_separation([[0, 1]])
+        loose = self._pair_separation([])
+        assert grouped[20:].mean() < 0.6 * loose[20:].mean()
+        # they never overlap while closing up
+        assert grouped.min() > 0.5
+
+    def test_invalid_social_groups_disable_the_handler(self):
+        """An out-of-range index is reported at construction and the group
+        falls back to having no handler instead of crashing ``make``."""
+        cfg = {
+            "world": _corridor_world(),
+            "robot": [
+                {
+                    "number": 2,
+                    "distribution": {"name": "manual"},
+                    "kinematics": {"name": "omni"},
+                    "shape": [{"name": "circle", "radius": 0.25}],
+                    "state": [[-6, 1, 0], [-6, -1, 0]],
+                    "goal": [[6, 1, 0], [6, -1, 0]],
+                    "group_behavior": {"name": "sfm", "social_groups": [[0, 7]]},
+                    "vel_min": [-1.5, -1.5],
+                    "vel_max": [1.5, 1.5],
+                }
+            ],
+        }
+        env = irsim.make(_write_temp_yaml(cfg), save_ani=False, display=False)
+        assert env._object_groups[0].group_behavior._invoke_func is None
+        env.step()
         env.end(suppress_summary=True)
 
 

--- a/usage/23sfm_world/sfm_group_world.py
+++ b/usage/23sfm_world/sfm_group_world.py
@@ -1,0 +1,24 @@
+"""Group Social Force Model usage example — pedestrians walking together.
+
+Twelve differential-drive "pedestrians" share a corridor under the
+``sfm`` *group* behavior. All members are integrated from one state
+snapshot in a single vectorised pass, and ``social_groups`` splits them
+into two pairs and two triples that walk together thanks to the Moussaid
+et al. (2010) coherence, repulsion and gaze forces. Opposing groups
+overlap by one lane, so each group has to slide sideways as a unit while
+two singles thread through the middle.
+
+See ``irsim/lib/algorithm/social_force_model.py`` for the batch solver
+and ``irsim/lib/behavior/group_behavior_methods.py`` for the registered
+group behaviors ``("diff", "sfm")`` and ``("omni", "sfm")``.
+"""
+
+import irsim
+
+env = irsim.make("sfm_group_world.yaml", save_ani=False, full=False)
+
+while not env.done():
+    env.step()
+    env.render(0.01)
+
+env.end(3)

--- a/usage/23sfm_world/sfm_group_world.yaml
+++ b/usage/23sfm_world/sfm_group_world.yaml
@@ -1,0 +1,106 @@
+world:
+  height: 10
+  width: 20
+  step_time: 0.1
+  sample_time: 0.1
+  offset: [-10, -5]
+  collision_mode: 'unobstructed'   # SFM is reactive; let pedestrians overlap briefly
+  control_mode: 'auto'
+
+
+# Twelve pedestrians share a 10 m wide corridor under the *group* SFM
+# behavior. One YAML group holds all of them, so every member is stepped
+# from the same state snapshot in one vectorised pass, and
+# ``social_groups`` splits them into people walking together:
+#
+#   [0, 1]     royalblue pair,   W->E, lanes y =  1.5,  2.2
+#   [2, 3, 4]  green triple,     W->E, lanes y = -1.5, -2.2, -2.9
+#   [5, 6]     red pair,         E->W, lanes y = -2.4, -3.1
+#   [7, 8, 9]  orange triple,    E->W, lanes y =  2.4,  3.1,  3.8
+#   10, 11     purple / gray singles head-on along the centre line
+#
+# Opposing groups overlap by one lane, so each pair/triple has to slide
+# sideways as a unit to pass; the singles thread between them. The
+# Moussaid et al. (2010) coherence, repulsion and gaze forces keep each
+# social group together (the leader slows down when the others fall out
+# of its 90 degree field of view) while the Moussaid-Helbing (2009) social
+# force resolves the head-on encounters. ``social_groups`` indices refer
+# to the member order below.
+robot:
+  - number: 12
+    distribution: {name: 'manual'}
+    kinematics: {name: 'diff'}
+    shape: [{name: 'circle', radius: 0.25}]
+    state:
+      - [-9,  1.5, 0]
+      - [-9,  2.2, 0]
+      - [-9, -1.5, 0]
+      - [-9, -2.2, 0]
+      - [-9, -2.9, 0]
+      - [ 9, -2.4, 3.14]
+      - [ 9, -3.1, 3.14]
+      - [ 9,  2.4, 3.14]
+      - [ 9,  3.1, 3.14]
+      - [ 9,  3.8, 3.14]
+      - [-9,  0.3, 0]
+      - [ 9, -0.3, 3.14]
+    goal:
+      - [ 9,  1.5, 0]
+      - [ 9,  2.2, 0]
+      - [ 9, -1.5, 0]
+      - [ 9, -2.2, 0]
+      - [ 9, -2.9, 0]
+      - [-9, -2.4, 3.14]
+      - [-9, -3.1, 3.14]
+      - [-9,  2.4, 3.14]
+      - [-9,  3.1, 3.14]
+      - [-9,  3.8, 3.14]
+      - [ 9,  0.3, 0]
+      - [-9, -0.3, 3.14]
+    color:
+      - 'royalblue'
+      - 'royalblue'
+      - 'green'
+      - 'green'
+      - 'green'
+      - 'red'
+      - 'red'
+      - 'orange'
+      - 'orange'
+      - 'orange'
+      - 'purple'
+      - 'gray'
+    group_behavior:
+      name: 'sfm'
+      vmax: 1.0
+      neighbor_threshold: 5.0
+      force_factor_social: 4.0         # head-on stiffness for a 12-agent corridor
+      force_factor_obstacle: 5.0
+      sigma_obstacle: 0.3              # walls only matter within ~1 m
+      gamma: 0.5
+      safety_radius: 0.15              # 0.3 m personal bubble for vmax=1.0
+      social_groups: [[0, 1], [2, 3, 4], [5, 6], [7, 8, 9]]
+      force_factor_coherence: 2.0      # pull toward the group centre
+      force_factor_group_repulsion: 1.0
+      group_repulsion_threshold: 0.7   # members push apart once their discs touch
+      force_factor_gaze: 3.0           # leader brakes when the group leaves its view
+      gaze_vision_angle: 90.0
+    vel_min: [-1.5, -3.0]
+    vel_max: [ 1.5,  3.0]
+    arrive_mode: position
+    goal_threshold: 0.5
+    plot:
+      show_trail: true
+      show_goal: true
+      trail_fill: true
+      trail_alpha: 0.2
+      keep_trail_length: 25
+
+
+obstacle:
+  - shape: {name: 'linestring', vertices: [[-10,  5], [10,  5]]}
+    state: [0, 0, 0]
+    unobstructed: true
+  - shape: {name: 'linestring', vertices: [[-10, -5], [10, -5]]}
+    state: [0, 0, 0]
+    unobstructed: true


### PR DESCRIPTION
## Summary

Add `sfm` as a group behavior for `omni` and `diff` robots.

- `SocialForceModelBatch` evaluates the desired, social and obstacle forces for all members in one NumPy pass from a single state snapshot, so the crowd no longer depends on object order.
- Optional social groups (`social_groups: [[0, 1], [2, 3, 4]]`) add the Moussaid et al. (2010) coherence, repulsion and gaze forces for pedestrians walking together.
- Same physics and parameter names as the per-object `sfm`; a single member reproduces its trajectory exactly. Objects outside the group still act as walls and neighbours.
- `env.step()` is 2.0x faster on the 24-agent corridor and 2.6x on a 100-agent crowd; the solver step alone is 3x to 12x faster than PySocialForce on the same scenes.
- New example `usage/23sfm_world/sfm_group_world.yaml`, docs (en/zh) and tests. Also fix the mocked-pyrvo ORCA fixture, which cleared only the `orca` registrations before re-importing the module.

## References

- Moussaid et al. (2010), *The walking behaviour of pedestrian social groups and its impact on crowd dynamics*, PLoS ONE 5(4): e10047.
- [PySocialForce](https://github.com/yuxiang-gao/PySocialForce): batched force evaluation and social-group forces.
- [pedsim_ros](https://github.com/srl-freiburg/pedsim_ros): group force definitions.
